### PR TITLE
Add Svelte attachments: `draggable`, `sortable`, `tooltip`, `highlight_matches`, `click_outside`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
       "types": "./dist/index.d.ts",
       "svelte": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./attachments": {
+      "types": "./dist/attachments.d.ts",
+      "default": "./dist/attachments.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "svelte": "^5.35.6"
   },
   "devDependencies": {
-    "@playwright/test": "^1.54.0",
+    "@playwright/test": "^1.54.1",
     "@stylistic/eslint-plugin": "^5.1.0",
     "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/kit": "^2.22.5",
@@ -21,7 +21,7 @@
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
     "@types/node": "^24.0.13",
     "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^9.30.1",
+    "eslint": "^9.31.0",
     "eslint-plugin-svelte": "^3.10.1",
     "hastscript": "^9.0.1",
     "jsdom": "^26.1.0",
@@ -32,7 +32,7 @@
     "svelte": "^5.35.6",
     "svelte-check": "^4.2.2",
     "svelte-preprocess": "^6.0.3",
-    "svelte-toc": "^0.6.1",
+    "svelte-toc": "^0.6.2",
     "svelte2tsx": "^0.7.40",
     "typescript": "5.8.3",
     "typescript-eslint": "^8.36.0",

--- a/src/app.css
+++ b/src/app.css
@@ -138,20 +138,6 @@ div.multiselect.invalid {
   border: 1px solid red !important;
 }
 
-/* svelte-toc styles */
-aside.toc.desktop {
-  position: fixed;
-  top: 3em;
-  left: calc(50vw + var(--main-max-width) / 2);
-  max-width: 16em;
-}
-
-/* TODO remove this tmp style */
-nav:has(+ div.code-example) > a,
-section > aside > a.btn {
-  margin: 0;
-}
-
 /* target reusable icons like <svg><use href="#icon-info"></use></svg> */
 svg:has(use:only-child) {
   width: 1em;

--- a/src/lib/CopyButton.svelte
+++ b/src/lib/CopyButton.svelte
@@ -10,7 +10,7 @@
     content?: string
     state?: State
     global_selector?: string | null
-    global?: boolean
+    global?: boolean | string
     skip_selector?: string | null
     as?: string
     labels?: Record<State, { icon: IconName; text: string }>
@@ -34,21 +34,27 @@
   }: Props = $props()
 
   $effect(() => {
-    if (global || global_selector) {
-      for (const node of document.querySelectorAll(global_selector ?? `pre > code`)) {
-        // skip if <pre> already contains a button (presumably for copy)
-        const pre = node.parentElement
-        if (!pre || (skip_selector && pre.querySelector(skip_selector))) continue
+    if (!global && !global_selector) return
 
-        mount(CopyButton, {
-          target: pre,
-          props: {
-            content: node.textContent ?? ``,
-            style: `position: absolute; top: 9pt; right: 9pt;`,
-          },
-        })
+    const apply_copy_buttons = () => {
+      const button_style = typeof global === `string`
+        ? global
+        : `position: absolute; top: 9pt; right: 9pt;`
+      for (const code of document.querySelectorAll(global_selector ?? `pre > code`)) {
+        const pre = code.parentElement
+        if (pre && !(skip_selector && pre.querySelector(skip_selector))) {
+          mount(CopyButton, {
+            target: pre,
+            props: { content: code.textContent ?? ``, style: button_style },
+          })
+        }
       }
     }
+
+    apply_copy_buttons()
+    const observer = new MutationObserver(apply_copy_buttons)
+    observer.observe(document.body, { childList: true, subtree: true })
+    return () => observer.disconnect()
   })
 
   async function copy() {

--- a/src/lib/FileDetails.svelte
+++ b/src/lib/FileDetails.svelte
@@ -44,7 +44,7 @@
 
 <svelte:element this={as} {style}>
   {#each files as file, idx (file.title)}
-    {@const { title, content, _language = default_lang } = file ?? {}}
+    {@const { title, content, language = default_lang } = file ?? {}}
     <li>
       <!-- https://github.com/sveltejs/svelte/issues/12721#issuecomment-2269544690 -->
       <details bind:this={file.node}>
@@ -53,12 +53,12 @@
             {#if title_snippet}
               {@render title_snippet({ idx, ...file })}
             {:else}
-              <code>{title.split(`/`).at(-1)}</code>
+              {@html title}
             {/if}
           </summary>
         {/if}
 
-        <pre><code>{@html content}</code></pre>
+        <pre class="language-{language}"><code>{content}</code></pre>
         <!-- <pre><code>{@html hljs.highlight(content, { language }).value}</code></pre> -->
       </details>
     </li>

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1,0 +1,426 @@
+import { type Attachment } from 'svelte/attachments'
+
+// Type definitions for CSS highlight API (experimental)
+declare global {
+  interface CSS {
+    highlights: Map<string, Highlight>
+  }
+}
+
+export interface DraggableOptions {
+  handle_selector?: string
+  on_drag_start?: (event: MouseEvent) => void
+  on_drag?: (event: MouseEvent) => void
+  on_drag_end?: (event: MouseEvent) => void
+}
+
+// Svelte 5 attachment factory to make an element draggable
+// @param options - Configuration options for dragging behavior
+// @returns Attachment function that sets up dragging on an element
+export const draggable =
+  (options: DraggableOptions = {}): Attachment => (element: Element) => {
+    const node = element as HTMLElement
+
+    // Use simple variables for maximum performance
+    let dragging = false
+    let start = { x: 0, y: 0 }
+    const initial = { left: 0, top: 0, width: 0 }
+
+    const handle = options.handle_selector
+      ? node.querySelector<HTMLElement>(options.handle_selector)
+      : node
+
+    if (!handle) {
+      console.warn(
+        `Draggable: handle not found with selector "${options.handle_selector}"`,
+      )
+      return
+    }
+
+    function handle_mousedown(event: MouseEvent) {
+      // Only drag if mousedown is on the handle or its children
+      if (!handle?.contains?.(event.target as Node)) return
+
+      dragging = true
+
+      // For position: fixed elements, use getBoundingClientRect for viewport-relative position
+      const computed_style = getComputedStyle(node)
+      if (computed_style.position === `fixed`) {
+        const rect = node.getBoundingClientRect()
+        initial.left = rect.left
+        initial.top = rect.top
+        initial.width = rect.width
+      } else {
+        // For other positioning, use offset values
+        initial.left = node.offsetLeft
+        initial.top = node.offsetTop
+        initial.width = node.offsetWidth
+      }
+
+      node.style.left = `${initial.left}px`
+      node.style.top = `${initial.top}px`
+      node.style.width = `${initial.width}px`
+      node.style.right = `auto` // Prevent conflict with left
+      start = { x: event.clientX, y: event.clientY }
+      document.body.style.userSelect = `none` // Prevent text selection during drag
+      if (handle) handle.style.cursor = `grabbing`
+
+      globalThis.addEventListener(`mousemove`, handle_mousemove)
+      globalThis.addEventListener(`mouseup`, handle_mouseup)
+
+      options.on_drag_start?.(event) // Call optional callback
+    }
+
+    function handle_mousemove(event: MouseEvent) {
+      if (!dragging) return
+
+      // Use the exact same calculation as the fast old implementation
+      const dx = event.clientX - start.x
+      const dy = event.clientY - start.y
+      node.style.left = `${initial.left + dx}px`
+      node.style.top = `${initial.top + dy}px`
+
+      // Only call callback if it exists (minimize overhead)
+      if (options.on_drag) options.on_drag(event)
+    }
+
+    function handle_mouseup(event: MouseEvent) {
+      if (!dragging) return
+
+      dragging = false
+      event.stopPropagation()
+      document.body.style.userSelect = ``
+      if (handle) handle.style.cursor = `grab`
+
+      globalThis.removeEventListener(`mousemove`, handle_mousemove)
+      globalThis.removeEventListener(`mouseup`, handle_mouseup)
+
+      options.on_drag_end?.(event) // Call optional callback
+    }
+
+    if (handle) {
+      handle.addEventListener(`mousedown`, handle_mousedown)
+      handle.style.cursor = `grab`
+    }
+
+    // Return cleanup function (this is the attachment pattern)
+    return () => {
+      globalThis.removeEventListener(`mousemove`, handle_mousemove)
+      globalThis.removeEventListener(`mouseup`, handle_mouseup)
+      if (handle) {
+        handle.removeEventListener(`mousedown`, handle_mousedown)
+        handle.style.cursor = `` // Reset cursor
+      }
+    }
+  }
+
+export function get_html_sort_value(element: HTMLElement): string {
+  if (element.dataset.sortValue !== undefined) {
+    return element.dataset.sortValue
+  }
+  for (const child of Array.from(element.children)) {
+    const child_val = get_html_sort_value(child as HTMLElement)
+    if (child_val !== ``) return child_val
+  }
+  return element.textContent ?? ``
+}
+
+export const sortable = (
+  {
+    header_selector = `thead th`,
+    asc_class = `table-sort-asc`,
+    desc_class = `table-sort-desc`,
+    sorted_style = { backgroundColor: `rgba(255, 255, 255, 0.1)` },
+  } = {},
+) =>
+(node: HTMLElement) => {
+  // this action can be applied to bob-standard HTML tables to make them sortable by
+  // clicking on column headers (and clicking again to toggle sorting direction)
+  const headers = Array.from(node.querySelectorAll<HTMLTableCellElement>(header_selector))
+  let sort_col_idx: number
+  let sort_dir = 1 // 1 = asc, -1 = desc
+
+  for (const [idx, header] of headers.entries()) {
+    header.style.cursor = `pointer` // add cursor pointer to headers
+
+    const init_styles = header.getAttribute(`style`) ?? ``
+    header.addEventListener(`click`, () => {
+      // reset all headers to initial state
+      for (const header of headers) {
+        header.textContent = header.textContent?.replace(/ ↑| ↓/, ``) ?? ``
+        header.classList.remove(asc_class, desc_class)
+        header.setAttribute(`style`, init_styles)
+      }
+      if (idx === sort_col_idx) {
+        sort_dir *= -1 // reverse sort direction
+      } else {
+        sort_col_idx = idx // set new sort column index
+        sort_dir = 1 // reset sort direction
+      }
+      header.classList.add(sort_dir > 0 ? asc_class : desc_class)
+      Object.assign(header.style, sorted_style)
+      header.textContent = `${header.textContent?.replace(/ ↑| ↓/, ``)} ${
+        sort_dir > 0 ? `↑` : `↓`
+      }`
+
+      const table_body = node.querySelector(`tbody`)
+      if (!table_body) return
+
+      // re-sort table
+      const rows = Array.from(table_body.querySelectorAll(`tr`))
+      rows.sort((row_1, row_2) => {
+        const cell_1 = row_1.cells[sort_col_idx]
+        const cell_2 = row_2.cells[sort_col_idx]
+        const val_1 = get_html_sort_value(cell_1)
+        const val_2 = get_html_sort_value(cell_2)
+
+        if (val_1 === val_2) return 0
+        if (val_1 === ``) return 1 // treat empty string as lower than any value
+        if (val_2 === ``) return -1 // any value is considered higher than empty string
+
+        const num_1 = Number(val_1)
+        const num_2 = Number(val_2)
+
+        if (isNaN(num_1) && isNaN(num_2)) {
+          return (
+            sort_dir * val_1.localeCompare(val_2, undefined, { numeric: true })
+          )
+        }
+        return sort_dir * (num_1 - num_2)
+      })
+
+      for (const row of rows) table_body.appendChild(row)
+    })
+  }
+}
+
+type HighlightOptions = {
+  query?: string
+  disabled?: boolean
+  node_filter?: (node: Node) => number
+  css_class?: string
+}
+
+export const highlight_matches = (ops: HighlightOptions) => (node: HTMLElement) => {
+  const {
+    query = ``,
+    disabled = false,
+    node_filter = () => NodeFilter.FILTER_ACCEPT,
+    css_class = `highlight-match`,
+  } = ops
+
+  // clear previous ranges from HighlightRegistry
+  CSS.highlights.clear()
+
+  if (!query || disabled || typeof CSS === `undefined` || !CSS.highlights) return // abort if CSS highlight API not supported
+
+  const tree_walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, {
+    acceptNode: node_filter,
+  })
+  const text_nodes: Node[] = []
+  let current_node = tree_walker.nextNode()
+
+  while (current_node) {
+    text_nodes.push(current_node)
+    current_node = tree_walker.nextNode()
+  }
+
+  // iterate over all text nodes and find matches
+  const ranges = text_nodes.map((el) => {
+    const text = el.textContent?.toLowerCase()
+    const indices = []
+    let start_pos = 0
+    while (text && start_pos < text.length) {
+      const index = text.indexOf(query, start_pos)
+      if (index === -1) break
+      indices.push(index)
+      start_pos = index + query.length
+    }
+
+    // create range object for each str found in the text node
+    return indices.map((index) => {
+      const range = new Range()
+      range.setStart(el, index)
+      range.setEnd(el, index + query?.length)
+      return range
+    })
+  })
+
+  // create Highlight object from ranges and add to registry
+  CSS.highlights.set(css_class, new Highlight(...ranges.flat()))
+}
+
+// Global tooltip state to ensure only one tooltip is shown at a time
+let current_tooltip: HTMLElement | null = null
+let show_timeout: ReturnType<typeof setTimeout> | undefined
+let hide_timeout: ReturnType<typeof setTimeout> | undefined
+
+function clear_tooltip() {
+  if (show_timeout) clearTimeout(show_timeout)
+  if (hide_timeout) clearTimeout(hide_timeout)
+  if (current_tooltip) {
+    current_tooltip.remove()
+    current_tooltip = null
+  }
+}
+
+export const tooltip = (options: {
+  content?: string
+  placement?: `top` | `bottom` | `left` | `right`
+  delay?: number
+} = {}) =>
+(node: HTMLElement) => {
+  // Handle null/undefined elements
+  if (!node) return
+
+  // Handle null/undefined options
+  const safe_options = options || {}
+  const cleanup_functions: (() => void)[] = []
+
+  function setup_tooltip(element: HTMLElement) {
+    if (!element) return
+
+    const content = safe_options.content || element.title ||
+      element.getAttribute(`aria-label`) || element.getAttribute(`data-title`)
+    if (!content) return
+
+    // Store original title and remove it to prevent default tooltip
+    // Only store title if we're not using custom content
+    if (element.title && !safe_options.content) {
+      element.setAttribute(`data-original-title`, element.title)
+      element.removeAttribute(`title`)
+    }
+
+    function show_tooltip() {
+      clear_tooltip()
+
+      show_timeout = setTimeout(() => {
+        const tooltip = document.createElement(`div`)
+        tooltip.className = `custom-tooltip`
+        tooltip.style.cssText = `
+          position: absolute; z-index: 9999; opacity: 0;
+          background: var(--tooltip-bg); color: var(--text-color); border: var(--tooltip-border);
+          padding: 6px 10px; border-radius: 6px; font-size: 13px; line-height: 1.4;
+          max-width: 280px; word-wrap: break-word; pointer-events: none;
+          filter: drop-shadow(0 2px 8px rgba(0,0,0,0.25)); transition: opacity 0.15s ease-out;
+        `
+
+        tooltip.innerHTML = content?.replace(/\r/g, `<br/>`) ?? ``
+        document.body.appendChild(tooltip)
+
+        // Position tooltip
+        const rect = element.getBoundingClientRect()
+        const tooltip_rect = tooltip.getBoundingClientRect()
+        const placement = safe_options.placement || `bottom`
+        const margin = 12
+
+        let top = 0, left = 0
+        if (placement === `top`) {
+          top = rect.top - tooltip_rect.height - margin
+          left = rect.left + rect.width / 2 - tooltip_rect.width / 2
+        } else if (placement === `left`) {
+          top = rect.top + rect.height / 2 - tooltip_rect.height / 2
+          left = rect.left - tooltip_rect.width - margin
+        } else if (placement === `right`) {
+          top = rect.top + rect.height / 2 - tooltip_rect.height / 2
+          left = rect.right + margin
+        } else { // bottom
+          top = rect.bottom + margin
+          left = rect.left + rect.width / 2 - tooltip_rect.width / 2
+        }
+
+        // Keep in viewport
+        left = Math.max(8, Math.min(left, globalThis.innerWidth - tooltip_rect.width - 8))
+        top = Math.max(8, Math.min(top, globalThis.innerHeight - tooltip_rect.height - 8))
+
+        tooltip.style.left = `${left + globalThis.scrollX}px`
+        tooltip.style.top = `${top + globalThis.scrollY}px`
+        tooltip.style.opacity = `1`
+
+        current_tooltip = tooltip
+      }, safe_options.delay || 100)
+    }
+
+    function hide_tooltip() {
+      clear_tooltip()
+
+      hide_timeout = setTimeout(() => {
+        if (current_tooltip) {
+          current_tooltip.style.opacity = `0`
+          setTimeout(() => {
+            if (current_tooltip) {
+              current_tooltip.remove()
+              current_tooltip = null
+            }
+          }, 150)
+        }
+      }, 50)
+    }
+
+    const events = [`mouseenter`, `mouseleave`, `focus`, `blur`]
+    const handlers = [show_tooltip, hide_tooltip, show_tooltip, hide_tooltip]
+
+    events.forEach((event, idx) => element.addEventListener(event, handlers[idx]))
+
+    return () => {
+      events.forEach((event, idx) => element.removeEventListener(event, handlers[idx]))
+
+      const original_title = element.getAttribute(`data-original-title`)
+      if (original_title) {
+        element.setAttribute(`title`, original_title)
+        element.removeAttribute(`data-original-title`)
+      }
+    }
+  }
+
+  // Setup tooltip for main node and children
+  const main_cleanup = setup_tooltip(node)
+  if (main_cleanup) cleanup_functions.push(main_cleanup)
+
+  node.querySelectorAll(`[title], [aria-label], [data-title]`).forEach((element) => {
+    const child_cleanup = setup_tooltip(element as HTMLElement)
+    if (child_cleanup) cleanup_functions.push(child_cleanup)
+  })
+
+  // Return undefined if no cleanup functions were added
+  if (cleanup_functions.length === 0) return
+
+  return () => {
+    cleanup_functions.forEach((cleanup) => cleanup())
+    clear_tooltip()
+  }
+}
+
+type ClickOutsideConfig<T extends HTMLElement> = {
+  enabled?: boolean
+  exclude?: string[]
+  callback?: (node: T, config: ClickOutsideConfig<T>) => void
+}
+
+export const click_outside =
+  <T extends HTMLElement>(config: ClickOutsideConfig<T> = {}) => (node: T) => {
+    const { callback, enabled = true, exclude = [] } = config
+
+    function handle_click(event: MouseEvent) {
+      if (!enabled) return
+
+      const target = event.target as HTMLElement
+      const path = event.composedPath()
+
+      // Check if click target is the node or inside it
+      if (path.includes(node)) return
+
+      // Check excluded selectors
+      if (exclude.some((selector) => target.closest(selector))) return
+
+      // Execute callback if provided, passing node and full config
+      callback?.(node, { callback, enabled, exclude })
+
+      // Dispatch custom event if click was outside
+      node.dispatchEvent(new CustomEvent(`outside-click`))
+    }
+
+    document.addEventListener(`click`, handle_click, true)
+
+    return () => document.removeEventListener(`click`, handle_click, true)
+  }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './attachments'
 export { default as CircleSpinner } from './CircleSpinner.svelte'
 export { default as CmdPalette } from './CmdPalette.svelte'
 export { default as CodeExample } from './CodeExample.svelte'

--- a/src/routes/(demos)/cmd-palette/+page.md
+++ b/src/routes/(demos)/cmd-palette/+page.md
@@ -1,7 +1,6 @@
 <script>
-  // import hljs from 'highlight.js/lib/common'
-  // import 'highlight.js/styles/vs2015.css'
   import cmd_palette_src from '$lib/CmdPalette.svelte?raw'
+  import { FileDetails } from '$lib'
 </script>
 
 ## Nav Palette
@@ -23,7 +22,4 @@ You can use `<MultiSelect />` to build a navigation palette in just 70 lines of 
 <CmdPalette {actions} />
 ```
 
-Here's `<CmdPalette />` component
-
-<pre><code>{@html cmd_palette_src}</code></pre>
-<!-- <pre><code>{@html hljs.highlight(cmd_palette_src, { language: 'typescript' }).value}</code></pre> -->
+<FileDetails files={[{ title: `<code>CmdPalette.svelte</code> source code`, content: cmd_palette_src }]} />

--- a/src/routes/(demos)/snippets/+page.md
+++ b/src/routes/(demos)/snippets/+page.md
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { FileDetails } from '$lib'
+  import language_snippet_src from '$site/LanguageSnippet.svelte?raw'
+  import minus_icon_src from '$site/MinusIcon.svelte?raw'
 </script>
 
 ## Snippets
@@ -31,7 +33,10 @@
 </MultiSelect>
 ```
 
-<FileDetails paths={[`./LanguageSnippet.svelte`, `./MinusIcon.svelte`]} />
+<FileDetails files={[
+{ title: `<code>LanguageSnippet.svelte</code>`, content: language_snippet_src },
+{ title: `<code>MinusIcon.svelte</code>`, content: minus_icon_src },
+]} />
 
 ### Simple HTML tag as `"removeIcon"` snippet
 

--- a/src/routes/(demos)/sort-selected/+page.md
+++ b/src/routes/(demos)/sort-selected/+page.md
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { FileDetails } from '$lib'
+  import options_src from '$site/options.ts?raw'
 </script>
 
 ## Sorting Selected Items
@@ -46,7 +47,7 @@ selected = {selected.map((itm, idx) => `${idx + 1}. ${itm.label}`).join(`, `) ||
 />
 ```
 
-<FileDetails paths={[`./options.ts`]} />
+<FileDetails files={[{ title: `<code>options.ts</code>`, content: options_src }]} />
 
 <br />
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,9 +3,9 @@
   import { page } from '$app/state'
   import { CmdPalette, CopyButton, GitHubCorner } from '$lib'
   import { repository } from '$root/package.json'
-  // import { Toc } from 'svelte-toc'
   import { Footer } from '$site'
   import { type Snippet } from 'svelte'
+  import { Toc } from 'svelte-toc'
   import '../app.css'
   import { routes } from './(demos)'
 
@@ -32,7 +32,7 @@
 
 {@render children?.()}
 
-<!-- {#if page.url.pathname === `/`}
+{#if page.url.pathname === `/`}
   <Toc
     headingSelector="main > :where(h2, h3)"
     breakpoint={1250}
@@ -44,7 +44,7 @@
     title_element_style="font-size: 16pt; padding: 0 0 0.5em 0.5em;"
     ol_style="font-size: 8pt"
   />
-{/if} -->
+{/if}
 
 <Footer />
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -35,14 +35,9 @@
 {#if page.url.pathname === `/`}
   <Toc
     headingSelector="main > :where(h2, h3)"
-    breakpoint={1250}
-    --toc-mobile-bg="#1c0e3e"
-    --toc-li-padding="3pt 1ex"
-    --toc-mobile-btn-color="white"
-    --toc-desktop-nav-margin="0 0 0 14em"
-    aside_style="max-width: 24em;"
-    title_element_style="font-size: 16pt; padding: 0 0 0.5em 0.5em;"
-    ol_style="font-size: 8pt"
+    breakpoint={1500}
+    open_button_style="transform: scale(1.4); display: flex; aspect-ratio: 1;"
+    --toc-mobile-bg="rgb(30, 40, 50)"
   />
 {/if}
 
@@ -61,5 +56,10 @@
   }
   a[href='.']:hover {
     background-color: rgba(255, 255, 255, 0.2);
+  }
+  :global(aside.toc.desktop) {
+    position: fixed;
+    font-size: 9pt;
+    left: calc(50vw + var(--main-max-width) / 2 + 200px);
   }
 </style>

--- a/tests/vitest/CodeExample.test.ts
+++ b/tests/vitest/CodeExample.test.ts
@@ -1,4 +1,4 @@
-import { CodeExample } from '$lib'
+import { CodeExample, CopyButton } from '$lib'
 import { mount, tick } from 'svelte'
 import { expect, test } from 'vitest'
 import { doc_query } from './index'
@@ -58,4 +58,24 @@ test(`renders GitHub link when github and repo are provided`, () => {
   const github_link = document.querySelector(`nav a[href*="github.com"]`)
   expect(github_link).toBeInstanceOf(HTMLAnchorElement)
   expect(github_link?.getAttribute(`target`)).toBe(`_blank`)
+})
+
+test(`dynamically added pre > code elements get copy buttons applied`, async () => {
+  // Mount a CopyButton with global enabled to activate MutationObserver
+  mount(CopyButton, { target: document.body, props: { global: true } })
+
+  // Create a new pre > code element dynamically
+  const new_pre = document.createElement(`pre`)
+  const new_code = document.createElement(`code`)
+  new_code.textContent = `dynamically added code`
+  new_pre.appendChild(new_code)
+
+  // Add it to the DOM
+  document.body.appendChild(new_pre)
+  await tick()
+
+  // Verify that a copy button was added to the new pre element
+  const copy_button = new_pre.querySelector(`button`)
+  expect(copy_button).toBeInstanceOf(HTMLButtonElement)
+  expect(copy_button?.style.position).toBe(`absolute`)
 })

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -541,7 +541,6 @@ describe(`tooltip`, () => {
     it(`should handle elements without getBoundingClientRect`, () => {
       const element = create_element()
       element.title = `No getBoundingClientRect tooltip`
-      delete element.getBoundingClientRect
 
       setup_tooltip(element)
       expect(() => element.dispatchEvent(new Event(`mouseenter`))).not.toThrow()

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -1,0 +1,709 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { click_outside, get_html_sort_value, tooltip } from '../../src/lib/attachments'
+
+describe(`get_html_sort_value`, () => {
+  const create_element = (tag = `div`) => document.createElement(tag)
+  const add_data_sort = (element: HTMLElement, value: string) =>
+    element.setAttribute(`data-sort-value`, value)
+  const add_text = (element: HTMLElement, text: string) => element.textContent = text
+
+  it.each([
+    [
+      `returns data-sort-value when present`,
+      `custom-value`,
+      `Different text`,
+      `custom-value`,
+    ],
+    [`returns empty string for data-sort-value=""`, ``, `Some text`, ``],
+    [
+      `returns textContent when no data-sort-value`,
+      null,
+      `Element text content`,
+      `Element text content`,
+    ],
+    [`returns empty string for empty elements`, null, null, ``],
+    [`returns whitespace textContent`, null, `   \n\t   `, `   \n\t   `],
+  ])(`%s`, (_desc, data_sort_value, text_content, expected) => {
+    const element = create_element()
+    if (data_sort_value !== null) add_data_sort(element, data_sort_value)
+    if (text_content !== null) add_text(element, text_content)
+    expect(get_html_sort_value(element)).toBe(expected)
+  })
+
+  it(`should return child data-sort-value recursively`, () => {
+    const [parent, child, grandchild] = [
+      create_element(),
+      create_element(`span`),
+      create_element(`em`),
+    ]
+    add_text(parent, `Parent text`)
+    add_text(child, `Child text`)
+    add_data_sort(grandchild, `grandchild-value`)
+    add_text(grandchild, `Grandchild text`)
+    child.appendChild(grandchild)
+    parent.appendChild(child)
+    expect(get_html_sort_value(parent)).toBe(`grandchild-value`)
+  })
+
+  it(`should return first child data-sort-value when multiple exist`, () => {
+    const parent = create_element()
+    const [child1, child2] = [create_element(`span`), create_element(`span`)]
+    add_data_sort(child1, `first-value`)
+    add_data_sort(child2, `second-value`)
+    parent.append(child1, child2)
+    expect(get_html_sort_value(parent)).toBe(`first-value`)
+  })
+
+  it(`should handle deeply nested structures`, () => {
+    let current = create_element()
+    const root = current
+    for (let idx = 0; idx < 10; idx++) {
+      const child = create_element()
+      add_text(child, `Level ${idx}`)
+      current.appendChild(child)
+      current = child
+    }
+    add_data_sort(current, `deep-value`)
+    expect(get_html_sort_value(root)).toBe(`deep-value`)
+  })
+
+  it(`should return empty string for null textContent`, () => {
+    const element = create_element()
+    Object.defineProperty(element, `textContent`, { value: null })
+    expect(get_html_sort_value(element)).toBe(``)
+  })
+})
+
+describe(`tooltip`, () => {
+  let cleanup_functions: (() => void)[]
+
+  const setup_env = () => {
+    cleanup_functions = []
+    document.body.innerHTML = ``
+    document.documentElement.style.setProperty(`--tooltip-bg`, `#333`)
+    document.documentElement.style.setProperty(`--text-color`, `#fff`)
+    document.documentElement.style.setProperty(`--tooltip-border`, `1px solid #555`)
+    Object.assign(globalThis, {
+      innerWidth: 1024,
+      innerHeight: 768,
+      scrollX: 0,
+      scrollY: 0,
+    })
+  }
+
+  const cleanup_env = () => {
+    cleanup_functions.forEach((cleanup) => {
+      cleanup()
+    })
+    cleanup_functions = []
+    document.querySelectorAll(`.custom-tooltip`).forEach((tooltip) => tooltip.remove())
+    vi.clearAllTimers()
+  }
+
+  const create_element = (tag = `div`) => {
+    const element = document.createElement(tag)
+    document.body.appendChild(element)
+    return element
+  }
+
+  const setup_tooltip = (element: HTMLElement, options = {}) => {
+    const cleanup = tooltip(options)(element)
+    if (cleanup) cleanup_functions.push(cleanup)
+    return cleanup
+  }
+
+  const mock_bounds = (
+    element: HTMLElement,
+    bounds = { left: 100, top: 100, width: 50, height: 50 },
+  ) => {
+    element.getBoundingClientRect = vi.fn(() => ({
+      ...bounds,
+      right: bounds.left + bounds.width,
+      bottom: bounds.top + bounds.height,
+      x: bounds.left,
+      y: bounds.top,
+      toJSON: () => ({}),
+    }))
+  }
+
+  beforeEach(setup_env)
+  afterEach(cleanup_env)
+
+  describe(`Content Sources`, () => {
+    it.each([
+      [`title`, `title`, `Title tooltip`, true],
+      [`custom content`, `content`, `Custom content`, false],
+      [`aria-label`, `aria-label`, `Aria label tooltip`, false],
+      [`data-title`, `data-title`, `Data title tooltip`, false],
+    ])(`should create tooltip from %s`, (_desc, attr, content, stores_title) => {
+      const element = create_element()
+      const options = attr === `content` ? { content } : {}
+      if (attr !== `content`) element.setAttribute(attr, content)
+
+      setup_tooltip(element, options)
+
+      expect(element.hasAttribute(`data-original-title`)).toBe(stores_title)
+      if (stores_title) expect(element.getAttribute(`data-original-title`)).toBe(content)
+      if (attr !== `content`) {
+        expect(element.getAttribute(attr)).toBe(stores_title ? null : content)
+      }
+    })
+
+    it(`should prioritize custom content over title`, () => {
+      const element = create_element()
+      element.title = `Title content`
+      setup_tooltip(element, { content: `Custom content` })
+      expect(element.hasAttribute(`data-original-title`)).toBe(false)
+    })
+
+    it(`should prioritize title over aria-label`, () => {
+      const element = create_element()
+      element.title = `Title content`
+      element.setAttribute(`aria-label`, `Aria content`)
+      setup_tooltip(element)
+      expect(element.getAttribute(`data-original-title`)).toBe(`Title content`)
+    })
+
+    it.each([
+      [`empty content strings`, ``, undefined],
+      [`null and undefined content`, undefined, undefined],
+    ])(`should handle %s`, (_desc, content, expected) => {
+      const element = create_element()
+      if (content !== undefined) element.title = content
+      const cleanup = tooltip({ content })(element)
+      expect(cleanup).toBe(expected)
+    })
+
+    it.each([
+      [`line breaks`, `Line 1\rLine 2\rLine 3`, `Line 1<br/>Line 2<br/>Line 3`],
+      [
+        `special HTML characters`,
+        `<script>alert('xss')</script>`,
+        `<script>alert('xss')</script>`,
+      ],
+      [`very long content`, `A`.repeat(1000), `A`.repeat(1000)],
+      [
+        `unicode content`,
+        `🚀 Unicode: ñáéíóú 中文 العربية`,
+        `🚀 Unicode: ñáéíóú 中文 العربية`,
+      ],
+    ])(`should handle %s`, (_desc, content, expected) => {
+      const element = create_element()
+      element.title = content
+      setup_tooltip(element)
+      expect(element.getAttribute(`data-original-title`)).toBe(
+        expected.replace(/<br\/>/g, `\r`),
+      )
+    })
+  })
+
+  describe(`Configuration Options`, () => {
+    it.each([
+      [`custom delay`, { delay: 500 }, `Delayed tooltip`],
+      [`zero delay`, { delay: 0 }, `No delay tooltip`],
+      [`negative delay`, { delay: -100 }, `Negative delay tooltip`],
+      [`extremely large delay`, { delay: 999999 }, `Large delay tooltip`],
+      [`empty options object`, {}, `Empty options tooltip`],
+    ])(`should handle %s`, (_desc, options, expected) => {
+      const element = create_element()
+      element.title = expected
+      setup_tooltip(element, options)
+      expect(element.getAttribute(`data-original-title`)).toBe(expected)
+    })
+
+    it(`should handle all placement options`, () => {
+      ;[`top`, `bottom`, `left`, `right`].forEach((placement) => {
+        const element = create_element()
+        element.title = `${placement} tooltip`
+        setup_tooltip(element, { placement })
+        expect(element.getAttribute(`data-original-title`)).toBe(`${placement} tooltip`)
+      })
+    })
+
+    it.each([
+      [`invalid placement`, { placement: `invalid` }, `Invalid placement tooltip`],
+      [`null options`, null, `Null options tooltip`],
+    ])(`should handle %s gracefully`, (_desc, options, expected) => {
+      const element = create_element()
+      element.title = expected
+      const cleanup = tooltip(options)(element)
+      if (cleanup) cleanup_functions.push(cleanup)
+      expect(element.getAttribute(`data-original-title`)).toBe(expected)
+    })
+  })
+
+  describe(`Child Element Handling`, () => {
+    it.each([
+      [`title`, `title`, `Child tooltip`],
+      [`aria-label`, `aria-label`, `Child aria tooltip`],
+      [`data-title`, `data-title`, `Child data tooltip`],
+    ])(`should setup tooltips for child elements with %s`, (_desc, attr, content) => {
+      const parent = create_element()
+      const child = document.createElement(`span`)
+      child.setAttribute(attr, content)
+      parent.appendChild(child)
+
+      setup_tooltip(parent)
+
+      if (attr === `title`) {
+        expect(child.hasAttribute(`title`)).toBe(false)
+        expect(child.getAttribute(`data-original-title`)).toBe(content)
+      } else {
+        expect(child.getAttribute(attr)).toBe(content)
+      }
+    })
+
+    it(`should handle deeply nested child elements`, () => {
+      const parent = create_element()
+      let current = parent
+      for (let idx = 0; idx < 5; idx++) {
+        const child = document.createElement(`div`)
+        child.title = `Level ${idx} tooltip`
+        current.appendChild(child)
+        current = child
+      }
+
+      setup_tooltip(parent)
+
+      parent.querySelectorAll(`[data-original-title]`).forEach((element, idx) => {
+        expect(element.getAttribute(`data-original-title`)).toBe(`Level ${idx} tooltip`)
+      })
+    })
+
+    it(`should handle multiple child elements with tooltips`, () => {
+      const parent = create_element()
+      for (let idx = 0; idx < 10; idx++) {
+        const child = document.createElement(`div`)
+        child.title = `Child ${idx} tooltip`
+        parent.appendChild(child)
+      }
+
+      setup_tooltip(parent)
+
+      const children_with_tooltips = parent.querySelectorAll(`[data-original-title]`)
+      expect(children_with_tooltips.length).toBe(10)
+      children_with_tooltips.forEach((child, idx) => {
+        expect(child.getAttribute(`data-original-title`)).toBe(`Child ${idx} tooltip`)
+      })
+    })
+
+    it(`should handle child elements with mixed tooltip attributes`, () => {
+      const parent = create_element()
+      const test_cases = [
+        [`title`, `Title tooltip`],
+        [`aria-label`, `Aria tooltip`],
+        [`data-title`, `Data tooltip`],
+        [null, null],
+      ]
+
+      test_cases.forEach(([attr, content]) => {
+        const child = document.createElement(`div`)
+        if (attr && content) child.setAttribute(attr, content)
+        parent.appendChild(child)
+      })
+
+      setup_tooltip(parent)
+
+      if (parent.children[0].hasAttribute(`data-original-title`)) {
+        expect(parent.children[0].getAttribute(`data-original-title`)).toBe(
+          `Title tooltip`,
+        )
+      }
+      if (parent.children[1].hasAttribute(`aria-label`)) {
+        expect(parent.children[1].getAttribute(`aria-label`)).toBe(`Aria tooltip`)
+      }
+      if (parent.children[2].hasAttribute(`data-title`)) {
+        expect(parent.children[2].getAttribute(`data-title`)).toBe(`Data tooltip`)
+      }
+      expect(parent.children[3].hasAttribute(`data-original-title`)).toBe(false)
+    })
+
+    it.each([
+      [`child elements added after initialization`, true],
+      [`empty child elements`, false],
+    ])(`should handle %s`, (_desc, should_add_after) => {
+      const parent = create_element()
+      const child = document.createElement(`div`)
+      if (should_add_after) {
+        setup_tooltip(parent)
+        child.title = `Dynamic child tooltip`
+        parent.appendChild(child)
+        expect(child.hasAttribute(`title`)).toBe(true)
+      } else {
+        parent.appendChild(child)
+        setup_tooltip(parent)
+      }
+      expect(child.hasAttribute(`data-original-title`)).toBe(false)
+    })
+  })
+
+  describe(`DOM Manipulation and Positioning`, () => {
+    it.each([
+      [`correct CSS classes`, { left: 100, top: 100, width: 50, height: 50 }],
+      [`correct base styles`, { left: 100, top: 100, width: 50, height: 50 }],
+      [`viewport edge constraints`, { left: 1020, top: 5, width: 4, height: 20 }],
+      [`different placements`, { left: 400, top: 300, width: 50, height: 50 }],
+      [`very small elements`, { left: 500, top: 300, width: 1, height: 1 }],
+      [`elements with transforms`, { left: 200, top: 150, width: 50, height: 50 }],
+    ])(`should handle %s`, (test_desc, bounds) => {
+      const element = create_element()
+      element.title = `Test tooltip`
+      if (test_desc.includes(`transforms`)) {
+        element.style.transform = `rotate(45deg) scale(0.5)`
+      }
+      mock_bounds(element, bounds)
+
+      setup_tooltip(element)
+
+      const event = new Event(`mouseenter`)
+      expect(() => element.dispatchEvent(event)).not.toThrow()
+    })
+
+    it(`should handle scroll offset correctly`, () => {
+      Object.assign(globalThis, { scrollX: 100, scrollY: 50 })
+      const element = create_element()
+      element.title = `Scrolled tooltip`
+      mock_bounds(element, { left: 200, top: 150, width: 50, height: 50 })
+
+      setup_tooltip(element)
+
+      const event = new Event(`mouseenter`)
+      expect(() => element.dispatchEvent(event)).not.toThrow()
+    })
+  })
+
+  describe(`Event Handling`, () => {
+    it.each([
+      [`mouseenter`, `div`],
+      [`mouseleave`, `div`],
+      [`focus`, `button`],
+      [`blur`, `button`],
+    ])(`should handle %s event`, (event_type, tag) => {
+      const element = create_element(tag)
+      element.title = `${event_type} tooltip`
+      setup_tooltip(element)
+
+      const event = new Event(event_type)
+      expect(() => element.dispatchEvent(event)).not.toThrow()
+    })
+
+    it(`should handle rapid event sequences`, () => {
+      const element = create_element()
+      element.title = `Rapid events tooltip`
+      setup_tooltip(element)
+
+      for (let idx = 0; idx < 10; idx++) {
+        ;[new Event(`mouseenter`), new Event(`mouseleave`)].forEach((event) => {
+          element.dispatchEvent(event)
+        })
+      }
+      expect(() => element.dispatchEvent(new Event(`mouseenter`))).not.toThrow()
+    })
+
+    it.each([
+      [`disabled elements`, true, `button`],
+      [`detached elements`, false, `div`],
+      [`synthetic events`, false, `div`],
+      [`events with custom properties`, false, `div`],
+    ])(`should handle %s`, (description, is_disabled, tag) => {
+      const element = document.createElement(tag)
+      if (!description.includes(`detached`)) document.body.appendChild(element)
+      element.title = `${description} tooltip`
+      if (is_disabled && `disabled` in element) element.disabled = true
+
+      setup_tooltip(element)
+
+      const event = description.includes(`synthetic`)
+        ? new CustomEvent(`mouseenter`, { bubbles: true, cancelable: true })
+        : new Event(`mouseenter`)
+      if (description.includes(`custom`)) event.customProp = `custom value`
+
+      expect(() => element.dispatchEvent(event)).not.toThrow()
+    })
+  })
+
+  describe(`Global State Management`, () => {
+    it(`should clear previous tooltips when showing new ones`, () => {
+      const [element1, element2] = [create_element(), create_element()]
+      element1.title = `First tooltip`
+      element2.title = `Second tooltip`
+
+      setup_tooltip(element1)
+      setup_tooltip(element2)
+
+      element1.dispatchEvent(new Event(`mouseenter`))
+      element2.dispatchEvent(new Event(`mouseenter`))
+
+      setTimeout(() => {
+        expect(document.querySelectorAll(`.custom-tooltip`).length).toBeLessThanOrEqual(1)
+      }, 150)
+    })
+
+    it(`should handle multiple tooltip instances`, () => {
+      const elements = Array.from({ length: 5 }, (_, idx) => {
+        const element = create_element()
+        element.title = `Tooltip ${idx}`
+        setup_tooltip(element)
+        return element
+      })
+
+      elements.forEach((element) => element.dispatchEvent(new Event(`mouseenter`)))
+      expect(elements.length).toBe(5)
+    })
+
+    it.each([
+      [`tooltip cleanup on element removal`, true],
+      [`concurrent tooltip operations`, false],
+    ])(`should handle %s`, (description, should_remove) => {
+      const element = create_element()
+      element.title = `${description} tooltip`
+      setup_tooltip(element)
+
+      const event = new Event(`mouseenter`)
+      element.dispatchEvent(event)
+
+      if (should_remove) {
+        element.remove()
+        expect(() => element.dispatchEvent(new Event(`mouseleave`))).not.toThrow()
+      } else {
+        ;[new Event(`mouseenter`), new Event(`mouseleave`)].forEach((e) => {
+          element.dispatchEvent(e)
+          element.dispatchEvent(e)
+        })
+        expect(() => element.dispatchEvent(new Event(`mouseenter`))).not.toThrow()
+      }
+    })
+  })
+
+  describe(`Memory Management and Cleanup`, () => {
+    it(`should clean up event listeners on cleanup`, () => {
+      const element = create_element()
+      element.title = `Cleanup test tooltip`
+      const cleanup = setup_tooltip(element)
+      expect(cleanup).toBeDefined()
+      expect(() => cleanup?.()).not.toThrow()
+    })
+
+    it(`should restore original title on cleanup`, () => {
+      const element = create_element()
+      element.title = `Original title`
+      const cleanup = setup_tooltip(element)
+
+      expect(element.hasAttribute(`title`)).toBe(false)
+      expect(element.getAttribute(`data-original-title`)).toBe(`Original title`)
+
+      cleanup?.()
+      expect(element.getAttribute(`title`)).toBe(`Original title`)
+      expect(element.hasAttribute(`data-original-title`)).toBe(false)
+    })
+
+    it.each([
+      [`multiple cleanup calls`, 3],
+      [`child element listeners`, 1],
+      [`global tooltips on cleanup`, 1],
+      [`cleanup with active timers`, 1],
+      [`cleanup of detached elements`, 1],
+    ])(`should handle %s`, (test_name, call_count) => {
+      const element = create_element()
+      element.title = `${test_name} tooltip`
+
+      if (test_name.includes(`child`)) {
+        const child = document.createElement(`div`)
+        child.title = `Child cleanup tooltip`
+        element.appendChild(child)
+      }
+
+      const cleanup = setup_tooltip(
+        element,
+        test_name.includes(`timer`) ? { delay: 1000 } : {},
+      )
+
+      if (test_name.includes(`global`) || test_name.includes(`timer`)) {
+        element.dispatchEvent(new Event(`mouseenter`))
+      }
+
+      if (test_name.includes(`detached`)) element.remove()
+
+      expect(() => {
+        for (let i = 0; i < call_count; i++) cleanup?.()
+      }).not.toThrow()
+    })
+  })
+
+  describe(`Error Handling and Edge Cases`, () => {
+    it.each([
+      [`null elements`, null],
+      [`undefined elements`, undefined],
+    ])(`should handle %s gracefully`, (_desc, element) => {
+      expect(() => tooltip()(element)).not.toThrow()
+    })
+
+    it(`should handle elements without getBoundingClientRect`, () => {
+      const element = create_element()
+      element.title = `No getBoundingClientRect tooltip`
+      delete element.getBoundingClientRect
+
+      setup_tooltip(element)
+      expect(() => element.dispatchEvent(new Event(`mouseenter`))).not.toThrow()
+    })
+
+    it.each([
+      [
+        `DOM mutations during tooltip display`,
+        () => document.body.appendChild(document.createElement(`div`)),
+      ],
+      [
+        `window resize during tooltip display`,
+        () => Object.assign(globalThis, { innerWidth: 800, innerHeight: 600 }),
+      ],
+      [
+        `CSS variable absence`,
+        () =>
+          [`--tooltip-bg`, `--text-color`, `--tooltip-border`].forEach((prop) =>
+            document.documentElement.style.removeProperty(prop)
+          ),
+      ],
+    ])(`should handle %s gracefully`, (description, mutation_fn) => {
+      const element = create_element()
+      element.title = `${description} tooltip`
+      setup_tooltip(element)
+
+      element.dispatchEvent(new Event(`mouseenter`))
+      mutation_fn()
+
+      expect(() => element.dispatchEvent(new Event(`mouseleave`))).not.toThrow()
+    })
+
+    it.each([
+      [`extremely long content`, `A`.repeat(10000)],
+      [`malformed HTML in content`, `<div><span>Unclosed tags<div><span>`],
+    ])(`should handle %s gracefully`, (_desc, content) => {
+      const element = create_element()
+      element.title = content
+      setup_tooltip(element)
+      expect(() => element.dispatchEvent(new Event(`mouseenter`))).not.toThrow()
+    })
+
+    it(`should handle high-frequency events`, () => {
+      const element = create_element()
+      element.title = `High frequency tooltip`
+      setup_tooltip(element, { delay: 10 })
+
+      for (let idx = 0; idx < 100; idx++) {
+        element.dispatchEvent(new Event(idx % 2 === 0 ? `mouseenter` : `mouseleave`))
+      }
+      expect(() => element.dispatchEvent(new Event(`mouseenter`))).not.toThrow()
+    })
+  })
+})
+
+describe(`click_outside`, () => {
+  let cleanup_functions: (() => void)[]
+
+  beforeEach(() => {
+    cleanup_functions = []
+    document.body.innerHTML = ``
+  })
+
+  afterEach(() => {
+    cleanup_functions.forEach((cleanup) => {
+      cleanup()
+    })
+    cleanup_functions = []
+  })
+
+  const create_element = () => {
+    const element = document.createElement(`div`)
+    document.body.appendChild(element)
+    return element
+  }
+
+  const setup_click_outside = (element: HTMLElement, config = {}) => {
+    const cleanup = click_outside(config)(element)
+    if (cleanup) cleanup_functions.push(cleanup)
+    return cleanup
+  }
+
+  const dispatch_click = (target: HTMLElement, path: Element[] = []) => {
+    const event = new Event(`click`, { bubbles: true })
+    Object.defineProperty(event, `target`, { value: target })
+    Object.defineProperty(event, `composedPath`, {
+      value: () =>
+        path.length
+          ? path
+          : [target, document.body, document.documentElement, document, globalThis],
+    })
+    document.dispatchEvent(event)
+    return event
+  }
+
+  it(`should trigger callback on outside click`, () => {
+    const element = create_element()
+    const callback = vi.fn()
+    setup_click_outside(element, { callback })
+
+    const outside_element = create_element()
+    dispatch_click(outside_element)
+
+    expect(callback).toHaveBeenCalledWith(element, {
+      callback,
+      enabled: true,
+      exclude: [],
+    })
+  })
+
+  it(`should not trigger callback on inside click`, () => {
+    const element = create_element()
+    const callback = vi.fn()
+    setup_click_outside(element, { callback })
+
+    dispatch_click(element, [
+      element,
+      document.body,
+      document.documentElement,
+      document,
+      globalThis,
+    ])
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it(`should respect enabled flag`, () => {
+    const element = create_element()
+    const callback = vi.fn()
+    setup_click_outside(element, { callback, enabled: false })
+
+    dispatch_click(create_element())
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it(`should handle exclude selectors`, () => {
+    const element = create_element()
+    const excluded = create_element()
+    excluded.className = `excluded`
+    excluded.closest = vi.fn((selector) => selector === `.excluded` ? excluded : null)
+
+    const callback = vi.fn()
+    setup_click_outside(element, { callback, exclude: [`.excluded`] })
+
+    dispatch_click(excluded)
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it(`should dispatch custom event`, () => {
+    const element = create_element()
+    const custom_event_listener = vi.fn()
+    element.addEventListener(`outside-click`, custom_event_listener)
+
+    setup_click_outside(element)
+    dispatch_click(create_element())
+
+    expect(custom_event_listener).toHaveBeenCalled()
+  })
+
+  it(`should clean up event listeners`, () => {
+    const element = create_element()
+    const cleanup = setup_click_outside(element)
+    expect(cleanup).toBeDefined()
+    expect(() => cleanup?.()).not.toThrow()
+  })
+})


### PR DESCRIPTION
- Add and export `draggable`, `sortable`, `tooltip`, `highlight_matches`, and `click_outside` Svelte attachments.
- Add comprehensive attachment tests and expand `CopyButton` coverage.
- Fix global `CopyButton` mounting across route changes and DOM mutations and support flexible button styling.
- Fix `FileDetails` and its call sites, including full titles, language handling, syntax highlighting, and updated examples.
- Show the table of contents on the homepage with updated styling and layout.