### PR TITLE
Fix generic type inference in `MultiSelect`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,12 @@ repos:
         types_or: [file]
         language: system
         args: [--config, deno.jsonc, --permit-no-files, --fix]
+      - id: svelte-check
+        name: Svelte type check
+        entry: deno run -A npm:svelte-check --fail-on-warnings --threshold error
+        language: system
+        types_or: [ts, svelte]
+        pass_filenames: false
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         args: [--config, deno.jsonc, --permit-no-files, --fix]
       - id: svelte-check
         name: Svelte type check
-        entry: deno run -A npm:svelte-check --fail-on-warnings --threshold error
+        entry: bash -c 'deno run -A npm:@sveltejs/kit sync && deno run -A npm:svelte-check --fail-on-warnings --threshold error'
         language: system
         types_or: [ts, svelte]
         pass_filenames: false
@@ -49,7 +49,7 @@ repos:
         exclude: changelog\.md
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.37.0
+    rev: v9.39.1
     hooks:
       - id: eslint
         types: [file]

--- a/src/lib/CircleSpinner.svelte
+++ b/src/lib/CircleSpinner.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  interface Props {
+  let { color = `cornflowerblue`, duration = `1.5s`, size = `1em` }: {
     color?: string
     duration?: string
     size?: string
-  }
-  let { color = `cornflowerblue`, duration = `1.5s`, size = `1em` }: Props = $props()
+  } = $props()
 </script>
 
 <div

--- a/src/lib/CmdPalette.svelte
+++ b/src/lib/CmdPalette.svelte
@@ -9,19 +9,6 @@
     action: (label: string) => void
   }
 
-  interface Props
-    extends Omit<ComponentProps<typeof MultiSelect<Action>>, `options`> {
-    actions: Action[]
-    triggers?: string[]
-    close_keys?: string[]
-    fade_duration?: number // in ms
-    dialog_style?: string // for dialog
-    // for span in option snippet, has no effect when specifying a custom option snippet
-    open?: boolean
-    dialog?: HTMLDialogElement | null
-    input?: HTMLInputElement | null
-    placeholder?: string
-  }
   let {
     actions,
     triggers = [`k`],
@@ -33,7 +20,18 @@
     input = $bindable(null),
     placeholder = `Filter actions...`,
     ...rest
-  }: Props = $props()
+  }: Omit<ComponentProps<typeof MultiSelect<Action>>, `options`> & {
+    actions: Action[]
+    triggers?: string[]
+    close_keys?: string[]
+    fade_duration?: number // in ms
+    dialog_style?: string // for dialog
+    // for span in option snippet, has no effect when specifying a custom option snippet
+    open?: boolean
+    dialog?: HTMLDialogElement | null
+    input?: HTMLInputElement | null
+    placeholder?: string
+  } = $props()
 
   $effect(() => {
     if (open && input && document.activeElement !== input) input.focus()

--- a/src/lib/CodeExample.svelte
+++ b/src/lib/CodeExample.svelte
@@ -3,7 +3,14 @@
   import { Icon } from '$lib'
   import type { Snippet } from 'svelte'
 
-  interface Props {
+  let {
+    src = ``,
+    meta = {},
+    open = $bindable(!meta.collapsible),
+    title,
+    example,
+    code,
+  }: {
     // src+meta are passed in by mdsvexamples
     src?: string // code fence content, sadly without indentation so we prefer node?.innerText below
     meta?: { // code fence metadata
@@ -21,15 +28,7 @@
     title?: Snippet<[]>
     example?: Snippet<[]>
     code?: Snippet<[]>
-  }
-  let {
-    src = ``,
-    meta = {},
-    open = $bindable(!meta.collapsible),
-    title,
-    example,
-    code,
-  }: Props = $props()
+  } = $props()
 
   let { id, collapsible, code_above, repl, github, repo, file } = $derived(meta)
   const links = { target: `_blank`, rel: `noreferrer` }

--- a/src/lib/CopyButton.svelte
+++ b/src/lib/CopyButton.svelte
@@ -7,16 +7,6 @@
 
   type State = `ready` | `success` | `error`
 
-  interface Props extends Omit<HTMLAttributes<HTMLButtonElement>, `children`> {
-    content?: string
-    state?: State
-    global_selector?: string | null
-    global?: boolean
-    skip_selector?: string | null
-    as?: string
-    labels?: Record<State, { icon: IconName; text: string }>
-    children?: Snippet<[{ state: State; icon: IconName; text: string }]>
-  }
   let {
     content = ``,
     state = $bindable(`ready`),
@@ -31,7 +21,16 @@
     },
     children,
     ...rest
-  }: Props = $props()
+  }: Omit<HTMLAttributes<HTMLButtonElement>, `children`> & {
+    content?: string
+    state?: State
+    global_selector?: string | null
+    global?: boolean
+    skip_selector?: string | null
+    as?: string
+    labels?: Record<State, { icon: IconName; text: string }>
+    children?: Snippet<[{ state: State; icon: IconName; text: string }]>
+  } = $props()
 
   $effect(() => {
     if (!global && !global_selector) return

--- a/src/lib/FileDetails.svelte
+++ b/src/lib/FileDetails.svelte
@@ -10,14 +10,6 @@
     node?: HTMLDetailsElement | null
   }
 
-  interface Props {
-    files?: File[]
-    toggle_all_btn_title?: string
-    default_lang?: string
-    as?: string
-    style?: string | null
-    title_snippet?: Snippet<[{ idx: number } & File]>
-  }
   let {
     files = $bindable([]),
     toggle_all_btn_title = `Toggle all`,
@@ -25,7 +17,14 @@
     as = `ol`,
     style = null,
     title_snippet,
-  }: Props = $props()
+  }: {
+    files?: File[]
+    toggle_all_btn_title?: string
+    default_lang?: string
+    as?: string
+    style?: string | null
+    title_snippet?: Snippet<[{ idx: number } & File]>
+  } = $props()
 
   function toggle_all() {
     const any_open = files.some((file) => file.node?.open)

--- a/src/lib/GitHubCorner.svelte
+++ b/src/lib/GitHubCorner.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
   // Display an animated Octocat in a corner of the screen to link to the GitHub repo.
-
-  interface Props {
+  let {
+    href,
+    title = `View code on GitHub`,
+    aria_label = title,
+    target = `_self`,
+    color = null,
+    fill = null,
+    corner = `top-right`,
+    style = ``,
+  }: {
     // adapted from https://github.com/tholman/github-corners
     href: string
     title?: string
@@ -12,17 +20,7 @@
     // bottomLeft/Right look bad, shouldn't normally be used
     corner?: `top-left` | `top-right` | `bottom-left` | `bottom-right`
     style?: string
-  }
-  let {
-    href,
-    title = `View code on GitHub`,
-    aria_label = title,
-    target = `_self`,
-    color = null,
-    fill = null,
-    corner = `top-right`,
-    style = ``,
-  }: Props = $props()
+  } = $props()
 </script>
 
 <a

--- a/src/lib/Icon.svelte
+++ b/src/lib/Icon.svelte
@@ -2,10 +2,7 @@
   import type { HTMLAttributes } from 'svelte/elements'
   import { icon_data, type IconName } from './icons'
 
-  interface Props extends HTMLAttributes<SVGSVGElement> {
-    icon: IconName
-  }
-  let { icon, ...rest }: Props = $props()
+  let { icon, ...rest }: HTMLAttributes<SVGSVGElement> & { icon: IconName } = $props()
 
   const data = $derived.by(() => {
     if (!(icon in icon_data)) {

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,15 +1,13 @@
-<script lang="ts">
+<script lang="ts" generics="Option extends import('./types').Option">
   import { tick } from 'svelte'
   import { flip } from 'svelte/animate'
   import type { FocusEventHandler, KeyboardEventHandler } from 'svelte/elements'
   import { highlight_matches } from './attachments'
   import CircleSpinner from './CircleSpinner.svelte'
   import Icon from './Icon.svelte'
-  import type { MultiSelectProps, Option as T } from './types'
+  import type { MultiSelectProps } from './types'
   import { fuzzy_match, get_label, get_style } from './utils'
   import Wiggle from './Wiggle.svelte'
-
-  type Option = $$Generic<T>
 
   let {
     activeIndex = $bindable(null),
@@ -117,7 +115,7 @@
     onclose,
     portal: portal_params = {},
     ...rest
-  }: MultiSelectProps = $props()
+  }: MultiSelectProps<Option> = $props()
 
   $effect.pre(() => {
     // if maxSelect=1, value is the single item in selected (or null if selected is empty)
@@ -208,7 +206,7 @@
   })
 
   // toggle an option between selected and unselected states (for keepSelectedInDropdown mode)
-  function toggle_option(option_to_toggle: T, event: Event) {
+  function toggle_option(option_to_toggle: Option, event: Event) {
     const is_currently_selected = selected.map(key).includes(key(option_to_toggle))
 
     if (is_currently_selected) {
@@ -219,7 +217,7 @@
   }
 
   // add an option to selected list
-  function add(option_to_add: T, event: Event) {
+  function add(option_to_add: Option, event: Event) {
     event.stopPropagation()
     if (maxSelect !== null && selected.length >= maxSelect) wiggle = true
     if (
@@ -302,7 +300,7 @@
   }
 
   // remove an option from selected list
-  function remove(option_to_drop: T, event: Event) {
+  function remove(option_to_drop: Option, event: Event) {
     event.stopPropagation()
     if (selected.length === 0) return
 
@@ -454,7 +452,7 @@
     event.stopPropagation()
 
     // Keep the first minSelect items, remove the rest
-    let removed_options: T[] = []
+    let removed_options: Option[] = []
     if (minSelect === null) {
       // If no minSelect constraint, remove all
       removed_options = selected

--- a/src/lib/PrevNext.svelte
+++ b/src/lib/PrevNext.svelte
@@ -4,22 +4,6 @@
 
   export type Item = [string, unknown]
 
-  interface Props extends Omit<HTMLAttributes<HTMLElement>, `children` | `onkeyup`> {
-    items?: (string | Item)[]
-    node?: string
-    current?: string
-    log?: `verbose` | `errors` | `silent`
-    nav_options?: { replace_state: boolean; no_scroll: boolean }
-    titles?: { prev: string; next: string }
-    onkeyup?:
-      | ((obj: { prev: Item; next: Item }) => Record<string, string | undefined>)
-      | null
-    prev_snippet?: Snippet<[{ item: Item }]>
-    children?: Snippet<[{ kind: `prev` | `next`; item: Item }]>
-    between?: Snippet<[]>
-    next_snippet?: Snippet<[{ item: Item }]>
-    min_items?: number
-  }
   let {
     items = [],
     node = `nav`,
@@ -34,7 +18,22 @@
     next_snippet,
     min_items = 3,
     ...rest
-  }: Props = $props()
+  }: Omit<HTMLAttributes<HTMLElement>, `children` | `onkeyup`> & {
+    items?: (string | Item)[]
+    node?: string
+    current?: string
+    log?: `verbose` | `errors` | `silent`
+    nav_options?: { replace_state: boolean; no_scroll: boolean }
+    titles?: { prev: string; next: string }
+    onkeyup?:
+      | ((obj: { prev: Item; next: Item }) => Record<string, string | undefined>)
+      | null
+    prev_snippet?: Snippet<[{ item: Item }]>
+    children?: Snippet<[{ kind: `prev` | `next`; item: Item }]>
+    between?: Snippet<[]>
+    next_snippet?: Snippet<[{ item: Item }]>
+    min_items?: number
+  } = $props()
 
   // Convert items to consistent [key, value] format
   let items_arr = $derived(

--- a/src/lib/Toggle.svelte
+++ b/src/lib/Toggle.svelte
@@ -2,17 +2,6 @@
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
 
-  interface Props extends HTMLAttributes<HTMLLabelElement> {
-    checked?: boolean // whether the toggle is on or off
-    required?: boolean
-    input_style?: string
-    id?: string | null
-    onclick?: (event: MouseEvent) => void
-    onchange?: (event: Event) => void
-    onblur?: (event: FocusEvent) => void
-    onkeydown?: (event: KeyboardEvent) => void
-    children?: Snippet<[]>
-  }
   let {
     checked = $bindable(false),
     required = false,
@@ -24,7 +13,17 @@
     onkeydown,
     children,
     ...rest
-  }: Props = $props()
+  }: HTMLAttributes<HTMLLabelElement> & {
+    checked?: boolean // whether the toggle is on or off
+    required?: boolean
+    input_style?: string
+    id?: string | null
+    onclick?: (event: MouseEvent) => void
+    onchange?: (event: Event) => void
+    onblur?: (event: FocusEvent) => void
+    onkeydown?: (event: KeyboardEvent) => void
+    children?: Snippet<[]>
+  } = $props()
 
   // normally input type=checkbox toggles on space bar, this handler also responds to enter
   function handle_keydown(event: KeyboardEvent) {

--- a/src/lib/Wiggle.svelte
+++ b/src/lib/Wiggle.svelte
@@ -2,7 +2,17 @@
   import type { Snippet } from 'svelte'
   import { Spring } from 'svelte/motion'
 
-  interface Props {
+  let {
+    wiggle = $bindable(false),
+    angle = 0,
+    scale = 1,
+    dx = 0,
+    dy = 0,
+    duration = 200,
+    stiffness = 0.05,
+    damping = 0.1,
+    children,
+  }: {
     // bind to this state and set it to true from parent
     wiggle?: boolean
     // intended use case: set max value during wiggle for one of angle, scale, dx, dy through props
@@ -14,18 +24,7 @@
     stiffness?: number
     damping?: number
     children?: Snippet
-  }
-  let {
-    wiggle = $bindable(false),
-    angle = 0,
-    scale = 1,
-    dx = 0,
-    dy = 0,
-    duration = 200,
-    stiffness = 0.05,
-    damping = 0.1,
-    children,
-  }: Props = $props()
+  } = $props()
 
   const store = Spring.of(
     () => (wiggle ? { scale, angle, dx, dy } : { angle: 0, scale: 1, dx: 0, dy: 0 }),

--- a/src/routes/(demos)/+layout.svelte
+++ b/src/routes/(demos)/+layout.svelte
@@ -6,10 +6,7 @@
   import type { Snippet } from 'svelte'
   import { demo_pages } from './index'
 
-  interface Props {
-    children?: Snippet
-  }
-  let { children }: Props = $props()
+  let { children }: { children?: Snippet<[]> } = $props()
 </script>
 
 <h1>
@@ -25,7 +22,7 @@
     items={demo_pages}
     current={page.url.pathname}
     style="max-width: var(--main-max-width); margin: auto"
-    on_keyup={null}
+    onkeyup={null}
   />
 </main>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,10 +9,7 @@
   import '../app.css'
   import { routes } from './(demos)'
 
-  interface Props {
-    children?: Snippet
-  }
-  let { children }: Props = $props()
+  let { children }: { children?: Snippet<[]> } = $props()
 
   const actions = routes.map(({ route }) => ({
     label: route,

--- a/src/site/ColorSnippet.svelte
+++ b/src/site/ColorSnippet.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  interface Props {
+  import type { HTMLAttributes } from 'svelte/elements'
+
+  let { option, idx = null, ...rest }: {
     option: string
     idx?: number | null
-    style?: string | null
-  }
-  let { option, idx = null, style = null }: Props = $props()
+  } & HTMLAttributes<HTMLDivElement> = $props()
 </script>
 
-<div {style}>
+<div {...rest}>
   {#if idx !== null}{idx + 1}{/if}
   {#if typeof CSS !== `undefined` && CSS.supports(`color`, option)}
     <span style:background={option}></span>

--- a/src/site/Confetti.svelte
+++ b/src/site/Confetti.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   // let emojis rain across the screen to playfully show some event was triggered
   import { onMount } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
   import { fade } from 'svelte/transition'
 
-  interface Props {
+  let { speed = 0.5, n_items = 50, freeze = false, ...rest }: {
     speed?: number
     n_items?: number
     freeze?: boolean
-  }
-  let { speed = 0.5, n_items = 50, freeze = false }: Props = $props()
+  } & HTMLAttributes<HTMLDivElement> = $props()
 
   const emojis = [`🥳`, `🎉`, `✨`]
 
@@ -63,7 +63,7 @@
   })
 </script>
 
-<div transition:fade>
+<div transition:fade {...rest}>
   {#each confetti as con (JSON.stringify(con))}
     <span style:left="{con.x}%" style:top="{con.y}%" style:transform="scale({con.r})">
       {con.emoji}

--- a/src/site/DemoNav.svelte
+++ b/src/site/DemoNav.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { page } from '$app/state'
+  import type { HTMLAttributes } from 'svelte/elements'
   import { demo_pages } from '../routes/(demos)'
 
-  interface Props {
-    style?: string | null
-  }
-  let { style = null }: Props = $props()
+  let { ...props }: HTMLAttributes<HTMLElementTagNameMap[`nav`]> = $props()
 
   let is_current = $derived((path: string) => {
     if (`/${path}` == page.url.pathname) return `page`
@@ -13,7 +11,7 @@
   })
 </script>
 
-<nav {style}>
+<nav {...props}>
   {#each demo_pages as href, idx (href)}
     {#if idx > 0}<strong>&bull;</strong>{/if}
     <a {href} aria-current={is_current(href)}>{href}</a>

--- a/src/site/LanguageSnippet.svelte
+++ b/src/site/LanguageSnippet.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  interface Props {
+  import type { HTMLAttributes } from 'svelte/elements'
+
+  let { option, idx = undefined, height = `20px`, gap = `5pt`, ...rest }: {
     option: string
     idx?: number | undefined
     height?: string
     gap?: string
-  }
-  let { option, idx = undefined, height = `20px`, gap = `5pt` }: Props = $props()
+  } & HTMLAttributes<HTMLSpanElement> = $props()
 
   let lang = $derived(
     option.toLowerCase().replaceAll(`+`, `plus`).replace(`#`, `sharp`),
@@ -21,7 +22,7 @@
   })
 </script>
 
-<span style:gap>
+<span style:gap {...rest}>
   {#if idx !== undefined}
     <strong>{idx + 1}</strong>
   {/if}

--- a/src/site/RepoSnippet.svelte
+++ b/src/site/RepoSnippet.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import type { ObjectOption } from '$lib'
   import { Icon } from '$lib'
+  import type { HTMLAttributes } from 'svelte/elements'
 
-  interface Props {
+  let { option, idx, onclick, ...rest }: {
     option: ObjectOption
     idx: number
     onclick?: () => void
-  }
-  let { option, idx, onclick }: Props = $props()
+  } & HTMLAttributes<HTMLSpanElement> = $props()
 </script>
 
-<span>
+<span {...rest}>
   {idx + 1}
   <strong>{option.label}</strong>
   <small>
@@ -20,7 +20,7 @@
       target="_blank"
       rel="noreferrer"
     >
-      <Icon icon="GitHub" width="14pt" />{option.repo_handle}
+      <Icon icon="GitHub" style="width: 14pt" />{option.repo_handle}
     </a>
   </small>
 </span>

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1398,7 +1398,7 @@ describe(`keepSelectedInDropdown feature`, () => {
   const options = [`Apple`, `Banana`, `Cherry`]
   const options_with_date = [`Apple`, `Banana`, `Cherry`, `Date`]
 
-  test.each([`plain`, `checkboxes`])(
+  test.each([`plain`, `checkboxes`] as const)(
     `keeps selected options visible in dropdown when mode is %s`,
     async (mode) => {
       const selected = [`Apple`]
@@ -1457,7 +1457,7 @@ describe(`keepSelectedInDropdown feature`, () => {
       .toBe(false)
   })
 
-  test.each([`plain`, `checkboxes`])(
+  test.each([`plain`, `checkboxes`] as const)(
     `toggles option selection when clicked in %s mode`,
     async (mode) => {
       const onChange_spy = vi.fn()
@@ -1507,7 +1507,7 @@ describe(`keepSelectedInDropdown feature`, () => {
     },
   )
 
-  test.each([`plain`, `checkboxes`])(
+  test.each([`plain`, `checkboxes`] as const)(
     `shows correct visual indicators in %s mode`,
     async (mode) => {
       const selected = [`Apple`, `Cherry`]
@@ -1550,7 +1550,7 @@ describe(`keepSelectedInDropdown feature`, () => {
     },
   )
 
-  test.each([`plain`, `checkboxes`])(
+  test.each([`plain`, `checkboxes`] as const)(
     `handles edge cases correctly in %s mode`,
     async (mode) => {
       // Test empty selection
@@ -1604,7 +1604,7 @@ describe(`keepSelectedInDropdown feature`, () => {
     },
   )
 
-  test.each([`plain`, `checkboxes`])(
+  test.each([`plain`, `checkboxes`] as const)(
     `respects minSelect constraint when toggling in %s mode`,
     async (mode) => {
       mount(MultiSelect, {
@@ -1648,7 +1648,7 @@ describe(`keepSelectedInDropdown feature`, () => {
     },
   )
 
-  test.each([`plain`, `checkboxes`])(
+  test.each([`plain`, `checkboxes`] as const)(
     `keyboard navigation works correctly in %s mode`,
     async (mode) => {
       const onChange_spy = vi.fn()
@@ -1685,7 +1685,7 @@ describe(`keepSelectedInDropdown feature`, () => {
     },
   )
 
-  test.each([`plain`, `checkboxes`])(
+  test.each([`plain`, `checkboxes`] as const)(
     `search filtering works correctly in %s mode`,
     (mode) => {
       const selected = [`Apple`, `Cherry`]
@@ -1804,7 +1804,7 @@ test.each([[true], [-1], [3.5], [`foo`], [{}]])(
 
     mount(MultiSelect, {
       target: document.body,
-      props: { options: [1, 2, 3], maxOptions },
+      props: { options: [1, 2, 3], maxOptions: maxOptions as number },
     })
 
     expect(console.error).toHaveBeenCalledTimes(1)

--- a/tests/vitest/PrevNext.test.ts
+++ b/tests/vitest/PrevNext.test.ts
@@ -3,12 +3,12 @@ import { mount } from 'svelte'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 const items = [`page1`, `page2`, `page3`, `page4`]
-const items_with_labels = [
+const items_with_labels: [string, string][] = [
   [`page1`, `First Page`],
   [`page2`, `Second Page`],
   [`page3`, `Third Page`],
   [`page4`, `Fourth Page`],
-] as const
+]
 
 describe(`PrevNext`, () => {
   let target: HTMLElement


### PR DESCRIPTION
Fixes #339

**Reference:** https://multiselect.janosh.dev/#--typescript
> "The type of options is inferred automatically from the data you pass"

Update `MultiSelect` to use Svelte 5's `generics` attribute instead of the deprecated `$$Generic` syntax, enabling proper generic type inference from the `options` prop.

TypeScript previously inferred `filterFunc` parameters as the broad `Option` union (`string | number | ObjectOption`), requiring manual assertions. It now infers the exact option shape from `options`, such as `{ label: string, value: number }`.

```svelte
<MultiSelect
  options={[{ label: 'Option 1', value: 1 }]}
  filterFunc={(option, search_text) => {
    return option.label.toLowerCase().includes(search_text.toLowerCase())
  }}
/>
```

### Related type-safety updates

- Fix related type errors in tests and components and simplify several prop/type declarations.
- Forward standard HTML attributes from several components.