### PR TITLE
Don't open dropdown when clicking on selected options

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -846,6 +846,7 @@
         ondragenter={() => (drag_idx = idx)}
         class:active={drag_idx === idx}
         style={selectedOptionStyle}
+        onmouseup={(event) => event.stopPropagation()}
       >
         {#if selectedItem}
           {@render selectedItem({

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -785,6 +785,25 @@ test.each([2, 5, 10])(
   },
 )
 
+// https://github.com/janosh/svelte-multiselect/issues/353
+test(`clicking on selected options does not open dropdown`, async () => {
+  mount(MultiSelect, {
+    target: document.body,
+    props: { options: [1, 2, 3], selected: [1, 2] },
+  })
+
+  // starts with closed dropdown
+  expect(doc_query(`ul.options.hidden`)).toBeInstanceOf(HTMLUListElement)
+
+  // click on a selected option (not the remove button)
+  const selected_li = doc_query(`ul.selected > li`)
+  selected_li.dispatchEvent(new MouseEvent(`mouseup`, { bubbles: true }))
+  await tick()
+
+  // dropdown should still be closed
+  expect(doc_query(`ul.options.hidden`)).toBeInstanceOf(HTMLUListElement)
+})
+
 test(`closes dropdown on tab out`, async () => {
   mount(MultiSelect, { target: document.body, props: { options: [1, 2, 3] } })
   // starts with closed dropdown


### PR DESCRIPTION
Clicking selected-option `<li>` elements no longer opens the dropdown. Previously, the `mouseup` event bubbled to the outer div and triggered `open_dropdown()`; selected items now stop propagation.

The input and remove buttons still work as expected:
- The input has its own `mouseup` handler that opens the dropdown.
- Remove buttons already use `click` and call `event.stopPropagation()`.

Closes #353.