### PR TITLE
Add `MultiSelect` prop `selectedFlipParams` for customizable flip animation

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -121,6 +121,8 @@
     liSelectAllClass = ``,
     // Dynamic options loading
     loadOptions,
+    // Animation parameters for selected options flip animation
+    selectedFlipParams = { duration: 100 },
     ...rest
   }: MultiSelectProps<Option> = $props()
 
@@ -836,7 +838,7 @@
         class={liSelectedClass}
         role="option"
         aria-selected="true"
-        animate:flip={{ duration: 100 }}
+        animate:flip={selectedFlipParams}
         draggable={selectedOptionsDraggable && !disabled && selected.length > 1}
         ondragstart={dragstart(idx)}
         ondragover={(event) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,4 @@
+import type { FlipParams } from 'svelte/animate'
 import type { Snippet } from 'svelte'
 import type { HTMLAttributes, HTMLInputAttributes } from 'svelte/elements'
 
@@ -168,4 +169,7 @@ export interface MultiSelectProps<T extends Option = Option>
   // Dynamic options loading for large datasets (https://github.com/janosh/svelte-multiselect/discussions/342)
   // Pass a function for simple usage, or an object with config for advanced usage
   loadOptions?: LoadOptions<T>
+  // Animation parameters for selected options flip animation (https://github.com/janosh/svelte-multiselect/issues/356)
+  // Set { duration: 0 } to disable animation
+  selectedFlipParams?: FlipParams
 }

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -710,8 +710,8 @@ test.describe(`snippets`, () => {
   })
 })
 
+// https://github.com/janosh/svelte-multiselect/issues/176
 test(`dragging selected options across each other changes their order`, async ({ page }) => {
-  // https://github.com/janosh/svelte-multiselect/issues/176
   await page.goto(`/persistent`, { waitUntil: `networkidle` })
   let selected = await page.textContent(`ul.selected`)
   expect(selected?.trim()).toBe(`1  Python 2  TypeScript 3  C 4  Haskell`)

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1120,8 +1120,8 @@ class DragEvent extends MouseEvent {
   }
 }
 
+// https://github.com/janosh/svelte-multiselect/issues/176
 test(`dragging selected options across each other changes their order`, async () => {
-  // https://github.com/janosh/svelte-multiselect/issues/176
   const options = [1, 2, 3]
   mount(MultiSelect, {
     target: document.body,


### PR DESCRIPTION
Closes #356

- Add a `selectedFlipParams` prop for configuring selected-item flip animations.
- Add tests for drag-and-drop reordering of selected items.