### PR TITLE
Prevent mouse hover during scroll from overriding `MultiSelect` arrow key navigation

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -160,6 +160,7 @@
   }) // sync value updates to selected
 
   let wiggle = $state(false) // controls wiggle animation when user tries to exceed maxSelect
+  let ignore_hover = $state(false) // ignore mouseover during keyboard navigation to prevent scroll-triggered hover
 
   // Internal state for loadOptions feature (null = never loaded)
   let loaded_options = $state<Option[]>([])
@@ -440,6 +441,7 @@
     } // on up/down arrow keys: update active option
     else if ([`ArrowDown`, `ArrowUp`].includes(event.key)) {
       event.stopPropagation()
+      ignore_hover = true // prevent scroll-triggered mouseover from changing activeIndex
       // if no option is active yet, but there are matching options, make first one active
       if (activeIndex === null && matchingOptions.length > 0) {
         event.preventDefault() // Prevent scroll only if we handle the key
@@ -988,6 +990,7 @@
       bind:this={ul_options}
       style={ulOptionsStyle}
       onscroll={handle_options_scroll}
+      onmousemove={() => (ignore_hover = false)}
     >
       {#if selectAllOption && effective_options.length > 0 &&
         (maxSelect === null || maxSelect > 1)}
@@ -1037,7 +1040,7 @@
           class:disabled
           class="{liOptionClass} {active ? liActiveOptionClass : ``}"
           onmouseover={() => {
-            if (!disabled) activeIndex = idx
+            if (!disabled && !ignore_hover) activeIndex = idx
           }}
           onfocus={() => {
             if (!disabled) activeIndex = idx
@@ -1114,7 +1117,7 @@
             ? duplicateOptionMsg
             : ``}
             class:active={option_msg_is_active}
-            onmouseover={() => (option_msg_is_active = true)}
+            onmouseover={() => !ignore_hover && (option_msg_is_active = true)}
             onfocus={() => (option_msg_is_active = true)}
             onmouseout={() => (option_msg_is_active = false)}
             onblur={() => (option_msg_is_active = false)}

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -429,13 +429,14 @@ test.describe(`multiselect`, () => {
     await page.goto(`/ui`, { waitUntil: `networkidle` })
     await page.click(`#foods input[autocomplete]`)
 
-    // Navigate down to the 5th option (index 4)
+    // Navigate down to the 5th option (index 4 = Lemon)
     for (let idx = 0; idx < 5; idx++) {
       await page.keyboard.press(`ArrowDown`)
     }
 
-    // Check current active option before mouseover
+    // Verify we're at the expected option after keyboard navigation
     const active_before = await page.textContent(`#foods ul.options > li.active`)
+    expect(active_before?.trim()).toBe(foods[4]) // Should be at Lemon (index 4)
 
     // Simulate what happens when scroll triggers mouseover on a different element
     // by directly dispatching a mouseover event WITHOUT moving the mouse
@@ -450,11 +451,9 @@ test.describe(`multiselect`, () => {
     // Check if mouseover changed the active option (it shouldn't with the fix)
     const active_after_hover = await page.textContent(`#foods ul.options > li.active`)
 
-    // With the fix: active option should NOT change after mouseover
-    expect(
-      active_after_hover?.trim(),
-      `mouseover should not change active option during keyboard navigation`,
-    ).toBe(active_before?.trim())
+    // With the fix: active option should NOT change after scroll-triggered mouseover
+    expect(active_after_hover?.trim()).toBe(foods[4]) // Still at Lemon
+    expect(active_after_hover?.trim()).not.toBe(foods[0]) // Not jumped to hovered option (Grapes)
   })
 
   test(`retains its selected state on page reload when bound to localStorage`, async ({ page }) => {


### PR DESCRIPTION
Closes #357

- Prevent mouse hover and pointer position during scrolling from overriding `MultiSelect` arrow-key navigation.
- Add a UI regression test that verifies keyboard navigation remains stable after scrolling.