### PR TITLE
Overload `placeholder` prop to support `object | string` with `persistent` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -393,10 +393,34 @@ These are the core props you'll use in most cases:
    Screen width (px) that separates 'mobile' from 'desktop' behavior.
 
 1. ```ts
+   fuzzy: boolean = true
+   ```
+
+   Whether to use fuzzy matching for filtering options. When `true` (default), matches non-consecutive characters (e.g., "ga" matches "Grapes" and "Green Apple"). When `false`, uses substring matching only.
+
+1. ```ts
    highlightMatches: boolean = true
    ```
 
    Whether to highlight matching text in dropdown options.
+
+1. ```ts
+   keepSelectedInDropdown: false | 'plain' | 'checkboxes' = false
+   ```
+
+   Controls whether selected options remain visible in dropdown. `false` (default) hides selected options. `'plain'` shows them with visual distinction. `'checkboxes'` prefixes each option with a checkbox.
+
+1. ```ts
+   selectAllOption: boolean | string = false
+   ```
+
+   Adds a "Select All" option at the top of the dropdown. `true` shows default label, or pass a custom string label.
+
+1. ```ts
+   liSelectAllClass: string = ''
+   ```
+
+   CSS class applied to the "Select All" `<li>` element.
 
 1. ```ts
    parseLabelsAsHtml: boolean = false

--- a/readme.md
+++ b/readme.md
@@ -172,10 +172,18 @@ These are the core props you'll use in most cases:
    ```
 
 1. ```ts
-   placeholder: string | null = null
+   placeholder: string | { text: string; persistent?: boolean } | null = null
    ```
 
-   Text shown when no options are selected.
+   Text shown when no options are selected. Can be a simple string or an object with extended options:
+
+   ```svelte
+   <!-- Simple string -->
+   <MultiSelect placeholder="Choose..." />
+
+   <!-- Object with persistent option (stays visible even when options selected) -->
+   <MultiSelect placeholder={{ text: 'Add items...', persistent: true }} />
+   ```
 
 1. ```ts
    disabled: boolean = false
@@ -401,6 +409,12 @@ These are the core props you'll use in most cases:
    ```
 
    Whether selected options can be reordered by dragging.
+
+1. ```ts
+   selectedFlipParams: FlipParams = { duration: 100 }
+   ```
+
+   Animation parameters for the [Svelte flip animation](https://svelte.dev/docs/svelte/svelte-animate) when reordering selected options via drag-and-drop. Set `{ duration: 0 }` to disable animation. Accepts `duration`, `delay`, and `easing` properties.
 
 ### Message Props
 

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -175,6 +175,14 @@
   let selected_keys = $derived(selected.map(key))
   let selected_labels = $derived(selected.map(get_label))
 
+  // Normalize placeholder prop (supports string or { text, persistent } object)
+  const placeholder_text = $derived(
+    typeof placeholder === `string` ? placeholder : placeholder?.text ?? null,
+  )
+  const placeholder_persistent = $derived(
+    typeof placeholder === `object` && placeholder?.persistent === true,
+  )
+
   // Helper to sort selected options (used by add() and select_all())
   function sort_selected(items: Option[]): Option[] {
     if (sortSelected === true) {
@@ -894,7 +902,7 @@
       {autocomplete}
       {inputmode}
       {pattern}
-      placeholder={selected.length === 0 ? placeholder : null}
+      placeholder={selected.length === 0 || placeholder_persistent ? placeholder_text : null}
       aria-invalid={invalid ? `true` : null}
       ondrop={() => false}
       onmouseup={open_dropdown}
@@ -917,7 +925,7 @@
         disabled,
         invalid,
         id,
-        placeholder,
+        placeholder: placeholder_text,
         open,
         required,
       })}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,12 @@ export type ObjectOption = {
   [key: string]: unknown // allow any other keys users might want
 }
 
+// placeholder can be a simple string or object with extended options
+export type PlaceholderConfig = {
+  text: string
+  persistent?: boolean // keep placeholder visible even when options are selected
+}
+
 // custom events created by MultiSelect
 export interface MultiSelectEvents<T extends Option = Option> {
   onadd?: (data: { option: T }) => unknown
@@ -94,7 +100,10 @@ export interface MultiSelectProps<T extends Option = Option>
   extends
     MultiSelectEvents<T>,
     MultiSelectSnippets<T>,
-    Omit<HTMLAttributes<HTMLDivElement>, `children` | `onchange` | `onclose`> {
+    Omit<
+      HTMLAttributes<HTMLDivElement>,
+      `children` | `onchange` | `onclose` | `placeholder`
+    > {
   activeIndex?: number | null
   activeOption?: T | null
   createOptionMsg?: string | null
@@ -146,7 +155,7 @@ export interface MultiSelectProps<T extends Option = Option>
   outerDivClass?: string
   parseLabelsAsHtml?: boolean // should not be combined with allowUserOptions!
   pattern?: string | null
-  placeholder?: string | null
+  placeholder?: string | PlaceholderConfig | null
   removeAllTitle?: string
   removeBtnTitle?: string
   minSelect?: number | null // null means there is no lower limit for selected.length

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -149,6 +149,69 @@ test(`applies DOM attributes to input node`, () => {
   expect(input?.pattern).toBe(pattern)
 })
 
+// https://github.com/janosh/svelte-multiselect/issues/354
+describe(`placeholder`, () => {
+  test(`string placeholder hidden by default when options selected`, async () => {
+    mount(MultiSelect, {
+      target: document.body,
+      props: { options: [1, 2, 3], placeholder: `Pick a number` },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    expect(input.placeholder).toBe(`Pick a number`)
+
+    // Select an option by clicking
+    const li = doc_query(`ul.options li`)
+    li.click()
+    await tick()
+
+    // Placeholder should be hidden (empty string in DOM)
+    expect(input.placeholder).toBe(``)
+  })
+
+  test(`object placeholder with persistent=true remains visible`, async () => {
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [1, 2, 3],
+        placeholder: { text: `Pick a number`, persistent: true },
+      },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    expect(input.placeholder).toBe(`Pick a number`)
+
+    // Select an option by clicking
+    const li = doc_query(`ul.options li`)
+    li.click()
+    await tick()
+
+    // Placeholder should still be visible
+    expect(input.placeholder).toBe(`Pick a number`)
+  })
+
+  test(`object placeholder without persistent behaves like string`, async () => {
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [1, 2, 3],
+        placeholder: { text: `Pick a number` },
+      },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    expect(input.placeholder).toBe(`Pick a number`)
+
+    // Select an option by clicking
+    const li = doc_query(`ul.options li`)
+    li.click()
+    await tick()
+
+    // Placeholder should be hidden
+    expect(input.placeholder).toBe(``)
+  })
+})
+
 test(`applies custom classes for styling through CSS frameworks`, async () => {
   const prop_elem_map = {
     input: HTMLInputElement,


### PR DESCRIPTION
Closes #354

## Changes

- Overload the `placeholder` prop to support either a string or an object with `text` and `persistent` keys.
- Keep the placeholder visible after options are selected when `persistent: true`.
- Document the previously missing `fuzzy`, `keepSelectedInDropdown`, `selectAllOption`, and `liSelectAllClass` props.
- Add Vitest coverage for string and object placeholder configurations.

## Usage

```svelte
<!-- Simple string (default behavior - hidden when options selected) -->
<MultiSelect placeholder="Choose..." />

<!-- Object with persistent option (stays visible even when options selected) -->
<MultiSelect placeholder={{ text: 'Add items...', persistent: true }} />
```