### PR TITLE
Fix enter key deselection now preserves `searchText` (matching mouse behavior)

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -432,17 +432,14 @@
       event.stopPropagation()
       close_dropdown(event)
       searchText = ``
-    } // on enter key: toggle active option and reset search text
+    } // on enter key: toggle active option
     else if (event.key === `Enter`) {
       event.stopPropagation()
       event.preventDefault() // prevent enter key from triggering form submission
 
       if (activeOption) {
         if (selected_keys.includes(key(activeOption))) {
-          if (can_remove) {
-            remove(activeOption, event)
-            searchText = `` // always clear on remove (resetFilterOnAdd only applies to add operations)
-          }
+          if (can_remove) remove(activeOption, event)
         } else add(activeOption, event) // add() handles resetFilterOnAdd internally when successful
       } else if (allowUserOptions && searchText.length > 0) {
         // user entered text but no options match, so if allowUserOptions is truthy, we create new option

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -7,7 +7,7 @@
   import CircleSpinner from './CircleSpinner.svelte'
   import Icon from './Icon.svelte'
   import type { MultiSelectProps } from './types'
-  import { fuzzy_match, get_label, get_style } from './utils'
+  import { fuzzy_match, get_label, get_style, is_object } from './utils'
   import Wiggle from './Wiggle.svelte'
 
   let {
@@ -203,38 +203,38 @@
     } else {
       // error on empty options if user is not allowed to create custom options and loading is false
       // and component is not disabled and allowEmpty is false
-      console.error(`MultiSelect received no options`)
+      console.error(`MultiSelect: received no options`)
     }
   }
   if (maxSelect !== null && maxSelect < 1) {
     console.error(
-      `MultiSelect's maxSelect must be null or positive integer, got ${maxSelect}`,
+      `MultiSelect: maxSelect must be null or positive integer, got ${maxSelect}`,
     )
   }
   if (!Array.isArray(selected)) {
     console.error(
-      `MultiSelect's selected prop should always be an array, got ${selected}`,
+      `MultiSelect: selected prop should always be an array, got ${selected}`,
     )
   }
   if (maxSelect && typeof required === `number` && required > maxSelect) {
     console.error(
-      `MultiSelect maxSelect=${maxSelect} < required=${required}, makes it impossible for users to submit a valid form`,
+      `MultiSelect: maxSelect=${maxSelect} < required=${required}, makes it impossible for users to submit a valid form`,
     )
   }
   if (parseLabelsAsHtml && allowUserOptions) {
     console.warn(
-      `Don't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`,
+      `MultiSelect: don't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`,
     )
   }
   if (sortSelected && selectedOptionsDraggable) {
     console.warn(
-      `MultiSelect's sortSelected and selectedOptionsDraggable should not be combined as any ` +
+      `MultiSelect: sortSelected and selectedOptionsDraggable should not be combined as any ` +
         `user re-orderings of selected options will be undone by sortSelected on component re-renders.`,
     )
   }
   if (allowUserOptions && !createOptionMsg && createOptionMsg !== null) {
     console.error(
-      `MultiSelect has allowUserOptions=${allowUserOptions} but createOptionMsg=${createOptionMsg} is falsy. ` +
+      `MultiSelect: allowUserOptions=${allowUserOptions} but createOptionMsg=${createOptionMsg} is falsy. ` +
         `This prevents the "Add option" <span> from showing up, resulting in a confusing user experience.`,
     )
   }
@@ -243,7 +243,7 @@
     (typeof maxOptions != `number` || maxOptions < 0 || maxOptions % 1 != 0)
   ) {
     console.error(
-      `MultiSelect's maxOptions must be undefined or a positive integer, got ${maxOptions}`,
+      `MultiSelect: maxOptions must be undefined or a positive integer, got ${maxOptions}`,
     )
   }
 
@@ -277,10 +277,6 @@
 
   // Helper to check if removing an option would violate minSelect constraint
   const can_remove = $derived(minSelect === null || selected.length > minSelect)
-
-  // Helper to check if an option is an object (not a primitive)
-  const is_object = (opt: unknown): opt is Record<string, unknown> =>
-    typeof opt === `object` && opt !== null
 
   // toggle an option between selected and unselected states (for keepSelectedInDropdown mode)
   function toggle_option(option_to_toggle: Option, event: Event) {
@@ -342,7 +338,7 @@
 
       if (resetFilterOnAdd) searchText = `` // reset search string on selection
       if ([``, undefined, null].includes(option_to_add as string | null)) {
-        console.error(`MultiSelect: encountered falsy option ${option_to_add}`)
+        console.error(`MultiSelect: encountered falsy option`, option_to_add)
         return
       }
       // for maxSelect = 1 we always replace current option with new one
@@ -377,11 +373,12 @@
       ) as Option
     }
     if (option_removed === undefined) {
-      return console.error(
-        `Multiselect can't remove selected option ${
+      console.error(
+        `MultiSelect: can't remove option ${
           JSON.stringify(option_to_drop)
         }, not found in selected list`,
       )
+      return
     }
 
     selected = [...selected] // trigger Svelte rerender
@@ -425,6 +422,44 @@
     } else input?.focus()
   }
 
+  // Check if a user message (create option, duplicate warning, no match) is visible
+  const has_user_msg = $derived(
+    searchText.length > 0 && Boolean(
+      (allowUserOptions && createOptionMsg) ||
+        (!duplicates && selected_labels.includes(searchText)) ||
+        (matchingOptions.length === 0 && noMatchingOptionsMsg),
+    ),
+  )
+
+  // Handle arrow key navigation through options (uses module-scope `has_user_msg`)
+  async function handle_arrow_navigation(direction: 1 | -1) {
+    ignore_hover = true
+
+    // toggle user message when no options match but user can create
+    if (allowUserOptions && !matchingOptions.length && searchText.length > 0) {
+      option_msg_is_active = !option_msg_is_active
+      return
+    }
+    if (activeIndex === null && !matchingOptions.length) return // nothing to navigate
+
+    // activate first option or navigate with wrap-around
+    if (activeIndex === null) {
+      activeIndex = 0
+    } else {
+      const total = matchingOptions.length + (has_user_msg ? 1 : 0)
+      activeIndex = (activeIndex + direction + total) % total // +total handles negative mod
+    }
+
+    // update active state based on new index
+    option_msg_is_active = has_user_msg && activeIndex === matchingOptions.length
+    activeOption = option_msg_is_active ? null : matchingOptions[activeIndex] ?? null
+
+    if (autoScroll) {
+      await tick()
+      document.querySelector(`ul.options > li.active`)?.scrollIntoViewIfNeeded?.()
+    }
+  }
+
   // handle all keyboard events this component receives
   async function handle_keydown(event: KeyboardEvent) {
     // on escape or tab out of input: close options dropdown and reset search text
@@ -450,58 +485,10 @@
         open_dropdown(event)
       }
     } // on up/down arrow keys: update active option
-    else if ([`ArrowDown`, `ArrowUp`].includes(event.key)) {
+    else if (event.key === `ArrowDown` || event.key === `ArrowUp`) {
       event.stopPropagation()
-      ignore_hover = true // prevent scroll-triggered mouseover from changing activeIndex
-      // if no option is active yet, but there are matching options, make first one active
-      if (activeIndex === null && matchingOptions.length > 0) {
-        event.preventDefault() // Prevent scroll only if we handle the key
-        activeIndex = 0
-        return
-      } else if (
-        allowUserOptions && !matchingOptions.length && searchText.length > 0
-      ) {
-        event.preventDefault() // Prevent scroll only if we handle the key
-        // if allowUserOptions is truthy and user entered text but no options match, we make
-        // <li>{addUserMsg}</li> active on keydown (or toggle it if already active)
-        option_msg_is_active = !option_msg_is_active
-        return
-      } else if (activeIndex === null) {
-        // if no option is active and no options are matching, do nothing
-        return
-      }
-      event.preventDefault() // Prevent scroll only if we handle the key
-      // if none of the above special cases apply, we make next/prev option
-      // active with wrap around at both ends
-      const increment = event.key === `ArrowUp` ? -1 : 1
-
-      // Include user message in total count if it exists
-      const has_user_msg = searchText && (
-        (allowUserOptions && createOptionMsg) ||
-        (!duplicates && selected_labels.includes(searchText)) ||
-        (matchingOptions.length === 0 && noMatchingOptionsMsg)
-      )
-      const total_items = matchingOptions.length + (has_user_msg ? 1 : 0)
-
-      activeIndex = (activeIndex + increment) % total_items
-      // in JS % behaves like remainder operator, not real modulo, so negative numbers stay negative
-      // need to do manual wrap around at 0
-      if (activeIndex < 0) activeIndex = total_items - 1
-
-      // Handle user message activation
-      if (has_user_msg && activeIndex === matchingOptions.length) {
-        option_msg_is_active = true
-        activeOption = null
-      } else {
-        option_msg_is_active = false
-        activeOption = matchingOptions[activeIndex] ?? null
-      }
-
-      if (autoScroll) {
-        await tick()
-        const li = document.querySelector(`ul.options > li.active`)
-        if (li) li.scrollIntoViewIfNeeded?.()
-      }
+      event.preventDefault()
+      await handle_arrow_navigation(event.key === `ArrowUp` ? -1 : 1)
     } // on backspace key: remove last selected option
     else if (event.key === `Backspace` && selected.length > 0 && !searchText) {
       event.stopPropagation()
@@ -728,7 +715,7 @@
       load_options_has_more = result.hasMore
       load_options_last_search = search
     } catch (err) {
-      console.error(`MultiSelect loadOptions error:`, err)
+      console.error(`MultiSelect: loadOptions error:`, err)
     } finally {
       load_options_loading = false
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,12 +1,16 @@
 import type { Option } from './types'
 
+// Type guard for checking if a value is a non-null object
+export const is_object = (val: unknown): val is Record<string, unknown> =>
+  typeof val === `object` && val !== null
+
 // Get the label key from an option object or the option itself
 // if it's a string or number
 export const get_label = (opt: Option) => {
-  if (opt instanceof Object) {
+  if (is_object(opt)) {
     if (opt.label === undefined) {
       const opt_str = JSON.stringify(opt)
-      console.error(`MultiSelect option ${opt_str} is an object but has no label key`)
+      console.error(`MultiSelect: option is an object but has no label key`, opt_str)
     }
     return opt.label
   }
@@ -29,9 +33,7 @@ export function get_style(
     if (typeof option.style === `object`) {
       if (key && key in option.style) return option.style[key] ?? ``
       else {
-        console.error(
-          `Invalid style object for option=${JSON.stringify(option)}`,
-        )
+        console.error(`MultiSelect: invalid style object for option`, option)
       }
     }
   }

--- a/src/routes/(demos)/kit-form-actions/+page.server.ts
+++ b/src/routes/(demos)/kit-form-actions/+page.server.ts
@@ -1,9 +1,9 @@
 import { fail } from '@sveltejs/kit'
 import type { Actions } from './$types'
 
-// remove leading underscore to activate this example
-// needs to be disabled for building static site
-// TODO is there a way to make this work on static site?
+// Form actions require a server and cannot work on static sites.
+// The underscore prefix disables this export during static build.
+// To test locally with `pnpm dev`, rename `_actions` to `actions`.
 export const _actions = {
   'validate-form': async ({ request }) => {
     const data = await request.formData()

--- a/src/routes/(demos)/ui/+page.md
+++ b/src/routes/(demos)/ui/+page.md
@@ -44,8 +44,8 @@ This page is used for Playwright testing to ensure
   - invisible `input.form-control` is `aria-hidden`
 - `closeDropdownOnSelect`: when `true`, the input is not focused when an option is selected and the dropdown is closed
 
-<!-- TODO figure out why Playwright test 'loops through the dropdown list with arrow keys making...'
-depends on `html { scroll-behavior: smooth; }` -->
+<!-- Smooth scroll is required for arrow key navigation tests to work correctly.
+The Playwright test 'loops through the dropdown list with arrow keys' depends on this. -->
 <style>
   :global(html) {
     scroll-behavior: smooth;

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -261,7 +261,7 @@ test.describe(`external CSS classes`, () => {
         await page.hover(`ul.options > li:last-child`) // hover last option to give it active state
       }
 
-      await expect(page.locator(`${selector}.${cls}`)).toBeVisible()
+      await expect(page.locator(`${selector}.${cls}`).first()).toBeVisible()
     })
   }
 })
@@ -297,7 +297,7 @@ test.describe(`disabled multiselect`, () => {
 
   test(`renders disabled snippet`, async ({ page }) => {
     await expect(
-      page.locator(`span:has-text('This component is disabled. It won't even open.')`),
+      page.locator(`span`).filter({ hasText: `This component is disabled` }),
     ).toBeVisible()
   })
 })
@@ -533,8 +533,8 @@ test.describe(`allowUserOptions`, () => {
     await page.fill(selector, `foobar`)
 
     await expect(
-      page.locator(`text=True polyglots can enter custom languages!`),
-    ).toBeVisible()
+      page.locator(`#languages ul.options li.user-msg`),
+    ).toContainText(`True polyglots can enter custom languages!`)
   })
 
   // https://github.com/janosh/svelte-multiselect/issues/89
@@ -616,6 +616,10 @@ test.describe(`sortSelected`, () => {
 test.describe(`parseLabelsAsHtml`, () => {
   test(`renders anchor tags as links`, async ({ page }) => {
     await page.goto(`/parse-labels-as-html`, { waitUntil: `networkidle` })
+
+    // Open the dropdown to see the anchor in options
+    await page.click(`input[autocomplete]`)
+    await expect(page.locator(`ul.options`)).toBeVisible()
 
     await expect(
       page.locator(`a[href='https://wikipedia.org/wiki/Red_pill_and_blue_pill']`),

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -468,24 +468,27 @@ test.describe(`multiselect`, () => {
   test(`retains its selected state on page reload when bound to localStorage`, async ({ page }) => {
     await page.goto(`/persistent`, { waitUntil: `networkidle` })
 
-    await page.click(`#languages input[autocomplete]`)
+    // Clear any pre-selected items first
+    const remove_buttons = page.locator(`#languages button[title^="Remove"]`)
+    const count = await remove_buttons.count()
+    for (let idx = 0; idx < count; idx++) {
+      await remove_buttons.first().click()
+    }
 
-    // Wait for dropdown to be visible before selecting options
-    const haskell_option = page.locator(`ul.options li:has-text("Haskell")`).first()
-    await haskell_option.waitFor({ state: `visible` })
-    await haskell_option.click()
+    // Open dropdown and wait for it to be visible
+    await page.click(`#languages input[autocomplete]`)
+    await page.locator(`#languages ul.options`).waitFor({ state: `visible` })
+
+    await page.locator(`#languages ul.options li:has-text("Haskell")`).first().click()
 
     await page.fill(`#languages input[autocomplete]`, `java`)
-
-    const js_option = page.locator(`ul.options li:has-text("JavaScript")`).first()
-    await js_option.waitFor({ state: `visible` })
-    await js_option.click()
+    await page.locator(`#languages ul.options li:has-text("JavaScript")`).first().click()
 
     await page.reload()
 
-    const selected_text = await page.textContent(`text=4 Haskell 5 JavaScript`)
-    expect(selected_text).toContain(`JavaScript`)
-    expect(selected_text).toContain(`Haskell`)
+    const selected = page.locator(`#languages ul.selected`)
+    await expect(selected).toContainText(`Haskell`)
+    await expect(selected).toContainText(`JavaScript`)
   })
 })
 

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -470,11 +470,13 @@ test.describe(`multiselect`, () => {
 
     await page.click(`#languages input[autocomplete]`)
 
-    await page.locator(`ul.options li:has-text("Haskell")`).first().click()
+    // Wait for dropdown to be visible before selecting options
+    const haskell_option = page.locator(`ul.options li:has-text("Haskell")`).first()
+    await haskell_option.waitFor({ state: `visible` })
+    await haskell_option.click()
 
     await page.fill(`#languages input[autocomplete]`, `java`)
 
-    // Wait for the dropdown to filter and stabilize before clicking
     const js_option = page.locator(`ul.options li:has-text("JavaScript")`).first()
     await js_option.waitFor({ state: `visible` })
     await js_option.click()
@@ -655,7 +657,7 @@ test.describe(`parseLabelsAsHtml`, () => {
 
     const has_expected_error = logs.some((msg) =>
       msg.includes(
-        `Don't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`,
+        `MultiSelect: don't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`,
       )
     )
 

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -470,12 +470,14 @@ test.describe(`multiselect`, () => {
 
     await page.click(`#languages input[autocomplete]`)
 
-    await page.click(`text=Haskell >> nth=0`)
+    await page.locator(`ul.options li:has-text("Haskell")`).first().click()
 
     await page.fill(`#languages input[autocomplete]`, `java`)
 
-    // Wait for the filtered option to be stable before clicking
-    await page.locator(`ul.options li:has-text("JavaScript")`).first().click()
+    // Wait for the dropdown to filter and stabilize before clicking
+    const js_option = page.locator(`ul.options li:has-text("JavaScript")`).first()
+    await js_option.waitFor({ state: `visible` })
+    await js_option.click()
 
     await page.reload()
 

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -493,9 +493,9 @@ test.describe(`allowUserOptions`, () => {
 
     // ensure custom option was not added to options
     await page.fill(selector, `Durian`)
-    await expect(page.locator(`div.multiselect > ul.option >> text=Durian`)).toHaveCount(
-      0,
-    )
+    await expect(
+      page.locator(`div.multiselect > ul.options >> text=Durian`),
+    ).toHaveCount(0)
   })
 
   test(

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -474,7 +474,8 @@ test.describe(`multiselect`, () => {
 
     await page.fill(`#languages input[autocomplete]`, `java`)
 
-    await page.click(`text=JavaScript`)
+    // Wait for the filtered option to be stable before clicking
+    await page.locator(`ul.options li:has-text("JavaScript")`).first().click()
 
     await page.reload()
 

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1014,9 +1014,9 @@ test(`resetFilterOnAdd=true does NOT reset searchText when minSelect constraint 
   expect(selected_items.length).toBe(1)
 })
 
-test(`resetFilterOnAdd=false still clears searchText when removing via Enter key`, async () => {
-  // This test verifies that resetFilterOnAdd only applies to add operations,
-  // not remove operations (matching remove_all() behavior)
+test(`Enter key deselection preserves searchText (matching mouse behavior)`, async () => {
+  // This test verifies that deselecting with Enter key preserves searchText,
+  // consistent with mouse click deselection behavior (fixes #362)
   mount(MultiSelect, {
     target: document.body,
     props: {
@@ -1041,9 +1041,8 @@ test(`resetFilterOnAdd=false still clears searchText when removing via Enter key
   input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
   await tick()
 
-  // searchText should be cleared even though resetFilterOnAdd=false
-  // because resetFilterOnAdd only applies to add operations
-  expect(input.value).toBe(``)
+  // searchText should be preserved (matching mouse click deselection behavior)
+  expect(input.value).toBe(`1`)
 
   // Verify the option was removed
   const selected_items = document.querySelectorAll(`ul.selected li`)


### PR DESCRIPTION
Fixes #362

- Preserve the search text when deselecting with Enter, matching mouse behavior.
- Refine keyboard navigation and Enter handling for consistent option activation, add a utility type guard, and prefix user-facing errors with `MultiSelect:`.
- Update unit and E2E coverage and clarify demo comments about server-backed form actions and the smooth-scroll test requirement.