### PR TITLE
fix: prevent infinite loops with array-cloning reactive wrappers (stores, Superforms)

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,6 +1,6 @@
 <!-- eslint-disable-next-line @stylistic/quotes -- TS generics require string literals -->
 <script lang="ts" generics="Option extends import('./types').Option">
-  import { tick } from 'svelte'
+  import { tick, untrack } from 'svelte'
   import { flip } from 'svelte/animate'
   import type { FocusEventHandler, KeyboardEventHandler } from 'svelte/elements'
   import { highlight_matches } from './attachments'
@@ -53,7 +53,7 @@
     loading = false,
     matchingOptions = $bindable([]),
     maxOptions = undefined,
-    maxSelect = null,
+    maxSelect = $bindable(null),
     maxSelectMsg = (current, max) => (max > 1 ? `${current}/${max}` : ``),
     maxSelectMsgClass = ``,
     name = null,
@@ -150,16 +150,30 @@
       : true,
   )
 
+  // Helper to compare arrays/values for equality to avoid unnecessary updates
+  // Prevents infinite loops when value/selected are bound to reactive wrappers
+  // that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.
+  function values_equal(a: unknown, b: unknown): boolean {
+    if (a === b) return true
+    if (Array.isArray(a) && Array.isArray(b)) {
+      return a.length === b.length && a.every((item, idx) => item === b[idx])
+    }
+    return false
+  }
+
+  // Sync selected ↔ value bidirectionally. Use untrack to prevent each effect from
+  // reacting to changes in the "destination" value, and values_equal to prevent
+  // infinite loops with reactive wrappers that clone arrays. See issue #309.
   $effect.pre(() => {
-    // if maxSelect=1, value is the single item in selected (or null if selected is empty)
-    // this solves both https://github.com/janosh/svelte-multiselect/issues/86 and
-    // https://github.com/janosh/svelte-multiselect/issues/136
-    value = maxSelect === 1 ? (selected[0] ?? null) : selected
-  }) // sync selected updates to value
+    const new_value = maxSelect === 1 ? (selected[0] ?? null) : selected
+    if (!values_equal(untrack(() => value), new_value)) value = new_value
+  })
   $effect.pre(() => {
-    if (maxSelect === 1) selected = value ? [value as Option] : []
-    else selected = (value as Option[]) ?? []
-  }) // sync value updates to selected
+    const new_selected = maxSelect === 1
+      ? (value ? [value as Option] : [])
+      : (Array.isArray(value) ? value : [])
+    if (!values_equal(untrack(() => selected), new_selected)) selected = new_selected
+  })
 
   let wiggle = $state(false) // controls wiggle animation when user tries to exceed maxSelect
   let ignore_hover = $state(false) // ignore mouseover during keyboard navigation to prevent scroll-triggered hover

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -153,10 +153,11 @@
   // Helper to compare arrays/values for equality to avoid unnecessary updates
   // Prevents infinite loops when value/selected are bound to reactive wrappers
   // that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.
-  function values_equal(a: unknown, b: unknown): boolean {
-    if (a === b) return true
-    if (Array.isArray(a) && Array.isArray(b)) {
-      return a.length === b.length && a.every((item, idx) => item === b[idx])
+  function values_equal(val1: unknown, val2: unknown): boolean {
+    if (val1 === val2) return true
+    if (Array.isArray(val1) && Array.isArray(val2)) {
+      return val1.length === val2.length &&
+        val1.every((item, idx) => item === val2[idx])
     }
     return false
   }

--- a/src/routes/(demos)/persistent/+page.md
+++ b/src/routes/(demos)/persistent/+page.md
@@ -31,3 +31,28 @@ This example shows how to combine MultiSelect with `sessionStorage` to persist t
   {/snippet}
 </MultiSelect>
 ```
+
+## Array Cloning Infinite Loop Prevention (Issue #309)
+
+Tests that binding to reactive wrappers (Svelte stores, Superforms, etc.) that clone arrays on assignment doesn't cause infinite loops. See [issue #309](https://github.com/janosh/svelte-multiselect/issues/309).
+
+```svelte example id="store-binding"
+<script>
+  import MultiSelect from '$lib'
+  import { writable } from 'svelte/store'
+
+  // Regression test for issue #309: store subscriptions would cause infinite
+  // loops without the values_equal() fix in MultiSelect.svelte
+  const options = [`Red`, `Green`, `Blue`]
+  let increment = $state(0)
+  let list_store = writable([])
+
+  list_store.subscribe(() => increment++)
+</script>
+
+<MultiSelect {options} bind:selected={$list_store} placeholder="Select colors..." />
+<p id="store-binding-status">
+  Modified: {increment} times
+  {#if increment > 50}⚠️ Regression!{:else if increment > 1}✅ Fixed{/if}
+</p>
+```

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -364,6 +364,30 @@ test.each([[null], [1]])(
   },
 )
 
+// Bug: value/selected should update when maxSelect changes at runtime
+test.each([
+  {
+    initial: null,
+    changed: 1,
+    selected: [1, 2, 3],
+    expectedValue: 1,
+    expectedSelected: [1],
+  },
+  { initial: 1, changed: null, selected: [1], expectedValue: [1], expectedSelected: [1] },
+])(`value updates when maxSelect changes from $initial to $changed`, async (params) => {
+  const select = mount(Test2WayBind, {
+    target: document.body,
+    props: { options: [1, 2, 3], selected: params.selected, maxSelect: params.initial },
+  })
+  await tick()
+
+  select.maxSelect = params.changed
+  await tick()
+
+  expect(select.value).toEqual(params.expectedValue)
+  expect(select.selected).toEqual(params.expectedSelected)
+})
+
 test(`selected is array of first two options when maxSelect=2`, () => {
   // even though all options have preselected=true
   const options = [1, 2, 3].map((itm) => ({
@@ -422,7 +446,7 @@ test.each([
   expect(console.error).toHaveBeenCalledTimes(expected)
   if (expected > 0) {
     expect(console.error).toHaveBeenCalledWith(
-      `MultiSelect maxSelect=${maxSelect} < required=${required}, makes it impossible for users to submit a valid form`,
+      `MultiSelect: maxSelect=${maxSelect} < required=${required}, makes it impossible for users to submit a valid form`,
     )
   }
 })

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1146,7 +1146,7 @@ test.each([
     expect(console.error).toHaveBeenCalledTimes(expected)
     if (expected > 0) {
       expect(console.error).toHaveBeenCalledWith(
-        `MultiSelect received no options`,
+        `MultiSelect: received no options`,
       )
     }
   },
@@ -1356,8 +1356,8 @@ test.each([[true], [false]])(
     if (sortSelected) {
       expect(console.warn).toHaveBeenCalledTimes(1)
       expect(console.warn).toHaveBeenCalledWith(
-        `MultiSelect's sortSelected and selectedOptionsDraggable should not be combined as any user` +
-          ` re-orderings of selected options will be undone by sortSelected on component re-renders.`,
+        `MultiSelect: sortSelected and selectedOptionsDraggable should not be combined as any ` +
+          `user re-orderings of selected options will be undone by sortSelected on component re-renders.`,
       )
     } else {
       expect(console.warn).toHaveBeenCalledTimes(0)
@@ -1379,7 +1379,7 @@ describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
       if (allowUserOptions && !createOptionMsg && createOptionMsg !== null) {
         expect(console.error).toHaveBeenCalledTimes(1)
         expect(console.error).toHaveBeenCalledWith(
-          `MultiSelect has allowUserOptions=${allowUserOptions} but createOptionMsg=${createOptionMsg} is falsy. ` +
+          `MultiSelect: allowUserOptions=${allowUserOptions} but createOptionMsg=${createOptionMsg} is falsy. ` +
             `This prevents the "Add option" <span> from showing up, resulting in a confusing user experience.`,
         )
       } else {
@@ -1404,7 +1404,7 @@ describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
         if (!allowEmpty && !disabled && !allowUserOptions) {
           expect(console.error).toHaveBeenCalledTimes(1)
           expect(console.error).toHaveBeenCalledWith(
-            `MultiSelect received no options`,
+            `MultiSelect: received no options`,
           )
         } else {
           expect(console.error).toHaveBeenCalledTimes(0)
@@ -1444,7 +1444,8 @@ test(`errors to console when option is an object but has no label key`, () => {
   })
 
   expect(console.error).toHaveBeenCalledWith(
-    `MultiSelect option {"foo":42} is an object but has no label key`,
+    `MultiSelect: option is an object but has no label key`,
+    `{"foo":42}`,
   )
 })
 
@@ -2013,7 +2014,7 @@ test.each([[true], [-1], [3.5], [`foo`], [{}]])(
 
     expect(console.error).toHaveBeenCalledTimes(1)
     expect(console.error).toHaveBeenCalledWith(
-      `MultiSelect's maxOptions must be undefined or a positive integer, got ${maxOptions}`,
+      `MultiSelect: maxOptions must be undefined or a positive integer, got ${maxOptions}`,
     )
   },
 )
@@ -2642,7 +2643,7 @@ describe(`loadOptions feature`, () => {
 
     // Error should be logged
     expect(console_error).toHaveBeenCalledWith(
-      `MultiSelect loadOptions error:`,
+      `MultiSelect: loadOptions error:`,
       expect.any(Error),
     )
     // Component should still function (dropdown visible)

--- a/tests/vitest/Test2WayBind.svelte
+++ b/tests/vitest/Test2WayBind.svelte
@@ -5,7 +5,7 @@
   let {
     activeIndex = null,
     activeOption = null,
-    maxSelect = null,
+    maxSelect = $bindable(null),
     options = $bindable(),
     selected = $bindable(
       options
@@ -39,11 +39,11 @@
     onValueChanged?.(value)
   })
 
-  export { breakpoint, selected, value }
+  export { breakpoint, maxSelect, selected, value }
 </script>
 
 <MultiSelect
-  {maxSelect}
+  bind:maxSelect
   bind:activeIndex
   bind:activeOption
   bind:options

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -23,7 +23,8 @@ describe(`get_label`, () => {
 
     if (should_log_error) {
       expect(console.error).toHaveBeenCalledWith(
-        `MultiSelect option ${JSON.stringify(input)} is an object but has no label key`,
+        `MultiSelect: option is an object but has no label key`,
+        JSON.stringify(input),
       )
     }
   })
@@ -71,7 +72,8 @@ describe(`get_style`, () => {
     get_style(option_obj, `selected`)
 
     expect(console.error).toHaveBeenCalledWith(
-      `Invalid style object for option=${JSON.stringify(option_obj)}`,
+      `MultiSelect: invalid style object for option`,
+      option_obj,
     )
   })
 


### PR DESCRIPTION
Closes #309

- Make `maxSelect` bindable for reactive updates
- Prevent infinite loops when selection arrays are cloned through reactive wrappers such as stores and Superforms
- Document array-cloning loop prevention and regression checks