### PR TITLE
fix: don't render message `<li>` when duplicateOptionMsg/noMatchingOptionsMsg/createOptionMsg is empty

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1103,12 +1103,12 @@
         {@const no_match = Boolean(matchingOptions?.length === 0 && noMatchingOptionsMsg) &&
         `no-match`}
         {@const msgType = is_dupe || can_create || no_match}
-        {#if msgType}
-          {@const msg = {
+        {@const msg = msgType && {
         dupe: duplicateOptionMsg,
         create: createOptionMsg,
         'no-match': noMatchingOptionsMsg,
       }[msgType]}
+        {#if msg}
           <li
             onclick={(event) => {
               if (msgType === `create` && allowUserOptions) {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1981,6 +1981,35 @@ describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
   )
 })
 
+// Issue #364: empty message props should not render <li> element
+test.each([
+  [`duplicateOptionMsg`, ``],
+  [`duplicateOptionMsg`, null],
+  [`noMatchingOptionsMsg`, ``],
+  [`noMatchingOptionsMsg`, null],
+])(
+  `no .user-msg node is rendered when %s=%j`,
+  async (prop_name, prop_value) => {
+    const is_dupe_test = prop_name === `duplicateOptionMsg`
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [`foo`, `bar`],
+        selected: is_dupe_test ? [`foo`] : [],
+        [prop_name]: prop_value,
+      },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    // Type text that triggers the message condition
+    input.value = is_dupe_test ? `foo` : `nonexistent`
+    input.dispatchEvent(input_event)
+    await tick()
+
+    expect(document.querySelector(`.user-msg`)).toBeNull()
+  },
+)
+
 test.each([[0], [1], [2], [5], [undefined]])(
   `no more than maxOptions are rendered if a positive integer, all options are rendered undefined or 0`,
   (maxOptions) => {


### PR DESCRIPTION
Closes #364

Do not render `MultiSelect` user-message list items when `duplicateOptionMsg`, `noMatchingOptionsMsg`, or `createOptionMsg` is unconfigured, empty, or null.