### PR TITLE
v11.4.0 + fix Svelte Playground links and npm package compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,7 +10,7 @@ A concise description of what's going wrong.
 
 Start from any of these templates and paste the link of your finished repro into this issue.
 
-[![REPL](https://img.shields.io/badge/Svelte-REPL-blue?label=Svelte)](https://svelte.dev/repl/3a217c39932047a09f61d6425b04a7c3) [![Open in StackBlitz](https://img.shields.io/badge/StackBlitz-darkblue?logo=stackblitz)](https://stackblitz.com/github/janosh/svelte-multiselect)
+[![Playground](https://img.shields.io/badge/Svelte-Playground-blue?label=Svelte)](https://svelte.dev/playground/a5a14b8f15d64cb083b567292480db05) [![Open in StackBlitz](https://img.shields.io/badge/StackBlitz-darkblue?logo=stackblitz)](https://stackblitz.com/github/janosh/svelte-multiselect)
 
 Steps to reproduce the problem:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         exclude: changelog\.md
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.0.0-alpha.1
+    rev: v10.0.0-beta.0
     hooks:
       - id: eslint
         types: [file]

--- a/package.json
+++ b/package.json
@@ -5,8 +5,15 @@
   "homepage": "https://janosh.github.io/svelte-multiselect",
   "repository": "https://github.com/janosh/svelte-multiselect",
   "license": "MIT",
-  "version": "11.3.0",
+  "version": "11.4.0",
   "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest --run && playwright test",
+    "check": "svelte-check"
+  },
   "svelte": "./dist/index.js",
   "bugs": "https://github.com/janosh/svelte-multiselect/issues",
   "peerDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 [![GitHub Pages](https://github.com/janosh/svelte-multiselect/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/janosh/svelte-multiselect/actions/workflows/gh-pages.yml)
 [![NPM version](https://img.shields.io/npm/v/svelte-multiselect?logo=NPM&color=purple)](https://npmjs.com/package/svelte-multiselect)
 [![Needs Svelte version](https://img.shields.io/npm/dependency-version/svelte-multiselect/peer/svelte?color=teal&logo=Svelte&label=Svelte)](https://github.com/sveltejs/svelte/blob/master/packages/svelte/CHANGELOG.md)
-[![REPL](https://img.shields.io/badge/Svelte-REPL-blue?label=Try%20it!)](https://svelte.dev/repl/a5a14b8f15d64cb083b567292480db05)
+[![Playground](https://img.shields.io/badge/Svelte-Playground-blue?label=Try%20it!)](https://svelte.dev/playground/a5a14b8f15d64cb083b567292480db05)
 [![Open in StackBlitz](https://img.shields.io/badge/Open%20in-StackBlitz-darkblue?logo=stackblitz)](https://stackblitz.com/github/janosh/svelte-multiselect)
 
 </h4>

--- a/src/lib/CodeExample.svelte
+++ b/src/lib/CodeExample.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   // see svelte.config.js where this component is passed to mdsvexamples
-  import { Icon } from '$lib'
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
+  import Icon from './Icon.svelte'
 
   let {
     src = ``,

--- a/src/lib/CopyButton.svelte
+++ b/src/lib/CopyButton.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { CopyButton, Icon } from '$lib'
   import type { Snippet } from 'svelte'
   import { mount } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
+  import CopyButton from './CopyButton.svelte'
+  import Icon from './Icon.svelte'
   import type { IconName } from './icons'
 
   type State = `ready` | `success` | `error`

--- a/src/lib/CopyButton.svelte
+++ b/src/lib/CopyButton.svelte
@@ -37,9 +37,7 @@
     if (!global && !global_selector) return
 
     const apply_copy_buttons = () => {
-      const btn_style = `position: absolute; top: 6pt; right: 6pt; ${
-        rest.style ?? ``
-      }`
+      const style = `position: absolute; top: 6pt; right: 6pt; ${rest.style ?? ``}`
       const skip_sel = skip_selector ?? as
       for (const code of document.querySelectorAll(global_selector ?? `pre > code`)) {
         const pre = code.parentElement
@@ -50,14 +48,7 @@
         ) {
           mount(CopyButton, {
             target: pre,
-            props: {
-              content,
-              as,
-              labels,
-              ...rest,
-              style: btn_style,
-              'data-sms-copy': ``,
-            },
+            props: { content, as, labels, ...rest, style, 'data-sms-copy': `` },
           })
         }
       }

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -6,11 +6,11 @@
   // - string: just a path ("/about")
   // - [string, string]: [path, custom_label] ("/about", "About Us")
   // - [string, string[]]: [parent_path, child_paths] ("/docs", ["/docs", "/docs/intro"])
-  import { Icon } from '$lib'
   import type { Page } from '@sveltejs/kit'
   import type { Snippet } from 'svelte'
-  import { click_outside } from 'svelte-multiselect'
   import type { HTMLAttributes } from 'svelte/elements'
+  import { click_outside } from './attachments'
+  import Icon from './Icon.svelte'
 
   let { routes = [], children, link, menu_props, link_props, page, labels, ...rest }:
     & {

--- a/src/site/Examples.md
+++ b/src/site/Examples.md
@@ -87,7 +87,7 @@
 
 <label for="fav-languages">Favorite programming languages? <span>multi-select with custom snippet</span></label>
 
-```svelte example collapsible repl="https://svelte.dev/repl/e3b88f59f62b498d943ecf7756ab75d7"
+```svelte example collapsible repl="https://svelte.dev/playground/e3b88f59f62b498d943ecf7756ab75d7"
 <script lang="ts">
   import MultiSelect from 'svelte-multiselect'
   import { languages } from '$site/options'
@@ -112,7 +112,7 @@ selected = {JSON.stringify(selected) || `[]`}
 
 <label for="fav-ml-tool">Favorite machine learning framework? <span>single-select with loading indicator on text input</span></label>
 
-```svelte example collapsible repl="https://svelte.dev/repl/79e22e1905c94456aa21564b4d5f8759"
+```svelte example collapsible repl="https://svelte.dev/playground/79e22e1905c94456aa21564b4d5f8759"
 <script lang="ts">
   import MultiSelect from 'svelte-multiselect'
   import { ml_libs } from '$site/options'
@@ -146,7 +146,7 @@ value = {JSON.stringify(value) || `null`}
 
 <label for="confetti-select">Chance of Confetti <span>max select with custom filter function and callback on item selection</span></label>
 
-```svelte example collapsible repl="https://svelte.dev/repl/516279bd62ec424986115263c2cdc169"
+```svelte example collapsible repl="https://svelte.dev/playground/516279bd62ec424986115263c2cdc169"
 <script lang="ts">
   import MultiSelect from 'svelte-multiselect'
   import { frontend_libs } from '$site/options'
@@ -189,7 +189,7 @@ value = {JSON.stringify(value) || `null`}
 
 <label for="color-select">Color select <span>with form submission</span></label>
 
-```svelte example collapsible repl="https://svelte.dev/repl/3a217c39932047a09f61d6425b04a7c3"
+```svelte example collapsible repl="https://svelte.dev/playground/3a217c39932047a09f61d6425b04a7c3"
 <script lang="ts">
   import MultiSelect from 'svelte-multiselect'
   import { colors } from '$site/options'
@@ -228,7 +228,7 @@ value = {JSON.stringify(value) || `null`}
 
 <label for="countries">What country are you from? <span><code>minSelect=1</code> means no <code>x</code> button to remove the selected option</span></label>
 
-```svelte example collapsible repl="https://svelte.dev/repl/4ff40862436e4bfbb2bd55d234352bb1"
+```svelte example collapsible repl="https://svelte.dev/playground/4ff40862436e4bfbb2bd55d234352bb1"
 <script lang="ts">
   import MultiSelect from 'svelte-multiselect'
   import { countries } from '$site/options'

--- a/tests/vitest/CodeExample.test.ts
+++ b/tests/vitest/CodeExample.test.ts
@@ -38,7 +38,7 @@ test(`renders nav with button when collapsible is true`, () => {
 })
 
 test(`renders links in nav when repl is provided`, () => {
-  const meta = { collapsible: true, repl: `https://svelte.dev/repl` }
+  const meta = { collapsible: true, repl: `https://svelte.dev/playground` }
   mount(CodeExample, { target: document.body, props: { src, meta } })
 
   const repl_link = document.querySelector(`nav a[href="${meta.repl}"]`)


### PR DESCRIPTION
Closes #367

- Release version 11.4.0
- Add npm scripts for development, build, preview, test, and check
- Replace Svelte REPL links with Svelte Playground links across docs and examples
- Improve npm package compatibility by switching several imports to local module resolution