### PR TITLE
Add `MultiSelect` `onreorder` event and fire `onchange` event on drag-drop reordering

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -693,6 +693,12 @@ Example using several snippets:
    Triggers when all selected options are removed. The `options` payload gives the options that were removed (might not be all if `minSelect` is set).
 
 1. ```ts
+   onselectAll={({ options }) => console.log(options)}
+   ```
+
+   Triggers when the "Select All" option is clicked (requires `selectAllOption` to be enabled). The `options` payload contains the options that were added.
+
+1. ```ts
    onreorder={({ options }) => console.log(options)}
    ```
 
@@ -724,6 +730,7 @@ For example, here's how you might annoy your users with an alert every time one 
     if (type === 'add') alert(`You added ${option}`)
     if (type === 'remove') alert(`You removed ${option}`)
     if (type === 'removeAll') alert(`You removed ${options}`)
+    if (type === 'selectAll') alert(`You selected all: ${options}`)
     if (type === 'reorder') alert(`New order: ${options}`)
   }}
 />
@@ -869,6 +876,7 @@ The second method allows you to pass in custom classes to the important DOM elem
 - `ulOptionsClass`: available options listed in the dropdown when component is in `open` state
 - `liOptionClass`: list items selectable from dropdown list
 - `liActiveOptionClass`: the currently active dropdown list item (i.e. hovered or navigated to with arrow keys)
+- `liSelectAllClass`: the "Select All" option at the top of the dropdown (when `selectAllOption` is enabled)
 - `liUserMsgClass`: user message (last child of dropdown list when no options match user input)
 - `liActiveUserMsgClass`: user message when active (i.e. hovered or navigated to with arrow keys)
 - `maxSelectMsgClass`: small span towards the right end of the input field displaying to the user how many of the allowed number of options they've already selected
@@ -884,6 +892,7 @@ This simplified version of the DOM structure of the component shows where these 
   </ul>
   <span class="maxSelectMsgClass">2/5 selected</span>
   <ul class="options {ulOptionsClass}">
+    <li class="select-all {liSelectAllClass}">Select all</li>
     <li class={liOptionClass}>Option 1</li>
     <li class="{liOptionClass} {liActiveOptionClass}">
       Option 2 (currently active)
@@ -943,6 +952,9 @@ Odd as it may seem, you get the most fine-grained control over the styling of ev
 }
 :global(div.multiselect > ul.options > li.disabled) {
   /* options with disabled key set to true (see props above) */
+}
+:global(div.multiselect > ul.options > li.select-all) {
+  /* the "Select All" option at the top of the dropdown */
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -631,15 +631,16 @@ These reflect internal component state:
 
 1. `#snippet option({ option, idx })`: Customize rendering of dropdown options. Receives as props an `option` and the zero-indexed position (`idx`) it has in the dropdown.
 1. `#snippet selectedItem({ option, idx })`: Customize rendering of selected items. Receives as props an `option` and the zero-indexed position (`idx`) it has in the list of selected items.
+1. `#snippet children({ option, idx })`: Convenience snippet that applies to both dropdown options AND selected items. Use this when you want the same custom rendering for both. Takes precedence if `option` or `selectedItem` are not provided.
 1. `#snippet spinner()`: Custom spinner component to display when in `loading` state. Receives no props.
 1. `#snippet disabledIcon()`: Custom icon to display inside the input when in `disabled` state. Receives no props. Use an empty `{#snippet disabledIcon()}{/snippet}` to remove the default disabled icon.
-1. `#snippet expandIcon()`: Allows setting a custom icon to indicate to users that the Multiselect text input field is expandable into a dropdown list. Receives prop `open: boolean` which is true if the Multiselect dropdown is visible and false if it's hidden.
+1. `#snippet expandIcon({ open })`: Allows setting a custom icon to indicate to users that the Multiselect text input field is expandable into a dropdown list. `open` is `true` if the dropdown is visible and `false` if hidden.
 1. `#snippet removeIcon()`: Custom icon to display as remove button. Will be used both by buttons to remove individual selected options and the 'remove all' button that clears all options at once. Receives no props.
 1. `#snippet userMsg({ searchText, msgType, msg })`: Displayed like a dropdown item when the list is empty and user is allowed to create custom options based on text input (or if the user's text input clashes with an existing option). Receives props:
    - `searchText`: The text user typed into search input.
    - `msgType: false | 'create' | 'dupe' | 'no-match'`: `'dupe'` means user input is a duplicate of an existing option. `'create'` means user is allowed to convert their input into a new option not previously in the dropdown. `'no-match'` means user input doesn't match any dropdown items and users are not allowed to create new options. `false` means none of the above.
    - `msg`: Will be `duplicateOptionMsg` or `createOptionMsg` (see [props](#🔣-props)) based on whether user input is a duplicate or can be created as new option. Note this snippet replaces the default UI for displaying these messages so the snippet needs to render them instead (unless purposely not showing a message).
-1. `snippet='after-input'`: Placed after the search input. For arbitrary content like icons or temporary messages. Receives props `selected: Option[]`, `disabled: boolean`, `invalid: boolean`, `id: string | null`, `placeholder: string`, `open: boolean`, `required: boolean`. Can serve as a more dynamic, more customizable alternative to the `placeholder` prop.
+1. `#snippet afterInput({ selected, disabled, invalid, id, placeholder, open, required })`: Placed after the search input. For arbitrary content like icons or temporary messages. Can serve as a more dynamic, more customizable alternative to the `placeholder` prop.
 
 Example using several snippets:
 

--- a/readme.md
+++ b/readme.md
@@ -666,65 +666,72 @@ Example using several snippets:
 
 ## 🎬 &thinsp; Events
 
-`MultiSelect.svelte` dispatches the following events:
+`MultiSelect.svelte` provides the following event callback props:
 
 1. ```ts
-   onadd={(event) => console.log(event.detail.option)}
+   onadd={({ option }) => console.log(option)}
    ```
 
-   Triggers when a new option is selected. The newly selected option is provided as `event.detail.option`.
+   Triggers when a new option is selected. The newly selected option is provided as `option`.
 
 1. ```ts
-   oncreate={(event) => console.log(event.detail.option)}
+   oncreate={({ option }) => console.log(option)}
    ```
 
-   Triggers when a user creates a new option (when `allowUserOptions` is enabled). The created option is provided as `event.detail.option`.
+   Triggers when a user creates a new option (when `allowUserOptions` is enabled). The created option is provided as `option`.
 
 1. ```ts
-   onremove={(event) => console.log(event.detail.option)}`
+   onremove={({ option }) => console.log(option)}
    ```
 
-   Triggers when a single selected option is removed. The removed option is provided as `event.detail.option`.
+   Triggers when a single selected option is removed. The removed option is provided as `option`.
 
 1. ```ts
-   onremoveAll={(event) => console.log(event.detail.options)}`
+   onremoveAll={({ options }) => console.log(options)}
    ```
 
-   Triggers when all selected options are removed. The payload `event.detail.options` gives the options that were removed (might not be all if `minSelect` is set).
+   Triggers when all selected options are removed. The `options` payload gives the options that were removed (might not be all if `minSelect` is set).
 
 1. ```ts
-   onchange={(event) => console.log(`${event.detail.type}: '${event.detail.option}'`)}
+   onreorder={({ options }) => console.log(options)}
    ```
 
-   Triggers when an option is either added (selected) or removed from selected, or all selected options are removed at once. `type` is one of `'add' | 'remove' | 'removeAll'` and payload will be `option: Option` or `options: Option[]`, respectively.
+   Triggers when selected options are reordered via drag-and-drop (enabled by default when `sortSelected` is false). The `options` payload is the newly ordered array of selected options.
 
 1. ```ts
-   onopen={(event) => console.log(`Multiselect dropdown was opened by ${event}`)}
+   onchange={({ type, option, options }) => console.log(type, option ?? options)}
    ```
 
-   Triggers when the dropdown list of options appears. Event is the DOM's `FocusEvent`,`KeyboardEvent` or `ClickEvent` that initiated this Svelte `dispatch` event.
+   Triggers when an option is either added (selected) or removed from selected, all selected options are removed at once, or selected options are reordered via drag-and-drop. `type` is one of `'add' | 'remove' | 'removeAll' | 'selectAll' | 'reorder'` and payload will be `option: Option` or `options: Option[]`, respectively.
 
 1. ```ts
-   onclose={(event) => console.log(`Multiselect dropdown was closed by ${event}`)}
+   onopen={({ event }) => console.log(`Dropdown opened by`, event)}
    ```
 
-   Triggers when the dropdown list of options disappears. Event is the DOM's `FocusEvent`, `KeyboardEvent` or `ClickEvent` that initiated this Svelte `dispatch` event.
+   Triggers when the dropdown list of options appears. `event` is the DOM's `FocusEvent`, `KeyboardEvent` or `ClickEvent` that triggered the open.
+
+1. ```ts
+   onclose={({ event }) => console.log(`Dropdown closed by`, event)}
+   ```
+
+   Triggers when the dropdown list of options disappears. `event` is the DOM's `FocusEvent`, `KeyboardEvent` or `ClickEvent` that triggered the close.
 
 For example, here's how you might annoy your users with an alert every time one or more options are added or removed:
 
 ```svelte
 <MultiSelect
-  onchange={(event) => {
-    if (event.detail.type === 'add') alert(`You added ${event.detail.option}`)
-    if (event.detail.type === 'remove') alert(`You removed ${event.detail.option}`)
-    if (event.detail.type === 'removeAll') alert(`You removed ${event.detail.options}`)
+  onchange={({ type, option, options }) => {
+    if (type === 'add') alert(`You added ${option}`)
+    if (type === 'remove') alert(`You removed ${option}`)
+    if (type === 'removeAll') alert(`You removed ${options}`)
+    if (type === 'reorder') alert(`New order: ${options}`)
   }}
 />
 ```
 
-> Note: Depending on the data passed to the component the `options(s)` payload will either be objects or simple strings/numbers.
+> Note: Depending on the data passed to the component the `option(s)` payload will either be objects or simple strings/numbers.
 
-The above list of events are [Svelte `dispatch` events](https://svelte.dev/tutorial/svelte/component-events). This component also forwards many DOM events from the `<input>` node: `blur`, `change`, `click`, `keydown`, `keyup`, `mousedown`, `mouseenter`, `mouseleave`, `touchcancel`, `touchend`, `touchmove`, `touchstart`. Registering listeners for these events works the same:
+This component also forwards many DOM events from the `<input>` node: `blur`, `change`, `click`, `keydown`, `keyup`, `mousedown`, `mouseenter`, `mouseleave`, `touchcancel`, `touchend`, `touchmove`, `touchstart`. Registering listeners for these events works the same:
 
 ```svelte
 <MultiSelect

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -117,6 +117,7 @@
     onopen,
     onclose,
     onselectAll,
+    onreorder,
     portal: portal_params = {},
     // Select all feature
     selectAllOption = false,
@@ -601,6 +602,8 @@
     }
     selected = new_selected
     drag_idx = null
+    onreorder?.({ options: new_selected })
+    onchange?.({ options: new_selected, type: `reorder` })
   }
 
   const dragstart = (idx: number) => (event: DragEvent) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
-import type { FlipParams } from 'svelte/animate'
 import type { Snippet } from 'svelte'
+import type { FlipParams } from 'svelte/animate'
 import type { HTMLAttributes, HTMLInputAttributes } from 'svelte/elements'
 
 export type Option = string | number | ObjectOption
@@ -33,10 +33,11 @@ export interface MultiSelectEvents<T extends Option = Option> {
   onremove?: (data: { option: T }) => unknown
   onremoveAll?: (data: { options: T[] }) => unknown
   onselectAll?: (data: { options: T[] }) => unknown // fires when select all is triggered
+  onreorder?: (data: { options: T[] }) => unknown // fires when selected options are reordered via drag-and-drop
   onchange?: (data: {
     option?: T
     options?: T[]
-    type: `add` | `remove` | `removeAll` | `selectAll`
+    type: `add` | `remove` | `removeAll` | `selectAll` | `reorder`
   }) => unknown
   onopen?: (data: { event: Event }) => unknown
   onclose?: (data: { event: Event }) => unknown

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -79,7 +79,7 @@ test(`defaultDisabledTitle and custom per-option disabled titles are applied cor
 
   const lis = document.querySelectorAll<HTMLLIElement>(`ul.options > li`)
 
-  expect(lis.length).toBe(3)
+  expect(lis).toHaveLength(3)
   expect([...lis].map((li) => li.title)).toEqual([
     special_disabled_title,
     defaultDisabledTitle,
@@ -115,7 +115,7 @@ test(`applies DOM attributes to input node`, () => {
   const form_input = doc_query<HTMLInputElement>(`input.form-control`)
 
   // make sure the search text filtered the dropdown options
-  expect(lis.length).toBe(1)
+  expect(lis).toHaveLength(1)
 
   expect(input?.value).toBe(searchText)
   expect(input?.id).toBe(id)
@@ -669,7 +669,7 @@ test.each([
   const selected_ul = doc_query(`ul.selected`)
   const remaining_labels = options_set.slice(1).map(get_label).join(` `).trim()
   expect(selected_ul.textContent?.trim()).toBe(remaining_labels)
-  expect(document.querySelectorAll(`ul.selected > li`).length).toBe(
+  expect(document.querySelectorAll(`ul.selected > li`)).toHaveLength(
     initial_selected_count - 1,
   )
 })
@@ -956,7 +956,7 @@ test(`resetFilterOnAdd=true does NOT reset searchText when maxSelect constraint 
 
   // Verify the option was not added
   const selected_items = document.querySelectorAll(`ul.selected li`)
-  expect(selected_items.length).toBe(2)
+  expect(selected_items).toHaveLength(2)
 })
 
 test(`resetFilterOnAdd=true does NOT reset searchText when minSelect constraint prevents remove`, async () => {
@@ -990,7 +990,7 @@ test(`resetFilterOnAdd=true does NOT reset searchText when minSelect constraint 
 
   // Verify the option was not removed
   const selected_items = document.querySelectorAll(`ul.selected li`)
-  expect(selected_items.length).toBe(1)
+  expect(selected_items).toHaveLength(1)
 })
 
 test(`Enter key deselection preserves searchText (matching mouse behavior)`, async () => {
@@ -1025,7 +1025,7 @@ test(`Enter key deselection preserves searchText (matching mouse behavior)`, asy
 
   // Verify the option was removed
   const selected_items = document.querySelectorAll(`ul.selected li`)
-  expect(selected_items.length).toBe(1)
+  expect(selected_items).toHaveLength(1)
 })
 
 test(`2-way binding of selected`, async () => {
@@ -1348,7 +1348,7 @@ test.each([[true], [false]])(
           `user re-orderings of selected options will be undone by sortSelected on component re-renders.`,
       )
     } else {
-      expect(console.warn).toHaveBeenCalledTimes(0)
+      expect(console.warn).not.toHaveBeenCalled()
     }
   },
 )
@@ -1371,7 +1371,7 @@ describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
             `This prevents the "Add option" <span> from showing up, resulting in a confusing user experience.`,
         )
       } else {
-        expect(console.error).toHaveBeenCalledTimes(0)
+        expect(console.error).not.toHaveBeenCalled()
       }
     },
   )
@@ -1395,7 +1395,7 @@ describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
             `MultiSelect: received no options`,
           )
         } else {
-          expect(console.error).toHaveBeenCalledTimes(0)
+          expect(console.error).not.toHaveBeenCalled()
         }
       },
     )
@@ -1583,7 +1583,7 @@ test.each(
     await tick()
   }
 
-  expect(spy.mock.calls.length).toBeGreaterThanOrEqual(1)
+  expect(spy).toHaveBeenCalled()
   const events = spy.mock.calls.map((call) => call[0].event)
   expect(events.some((event) => event instanceof event_type)).toBe(true)
 })
@@ -1632,7 +1632,7 @@ describe(`keepSelectedInDropdown feature`, () => {
       await tick()
 
       const dropdown_options = document.querySelectorAll(`ul.options > li`)
-      expect(dropdown_options.length).toBe(3)
+      expect(dropdown_options).toHaveLength(3)
 
       // Apple should be selected with appropriate styling
       const apple_option = Array.from(dropdown_options).find((li) =>
@@ -1672,7 +1672,7 @@ describe(`keepSelectedInDropdown feature`, () => {
     await tick()
 
     const dropdown_options = document.querySelectorAll(`ul.options > li`)
-    expect(dropdown_options.length).toBe(2)
+    expect(dropdown_options).toHaveLength(2)
     expect(Array.from(dropdown_options).some((li) => li.textContent?.includes(`Apple`)))
       .toBe(false)
   })
@@ -1784,7 +1784,7 @@ describe(`keepSelectedInDropdown feature`, () => {
       await tick()
 
       const dropdown_options = document.querySelectorAll(`ul.options > li`)
-      expect(dropdown_options.length).toBe(3)
+      expect(dropdown_options).toHaveLength(3)
 
       // No options should have selected styling
       Array.from(dropdown_options).forEach((option) => {
@@ -1811,7 +1811,7 @@ describe(`keepSelectedInDropdown feature`, () => {
       await tick()
 
       const all_selected_options = second_target.querySelectorAll(`ul.options > li`)
-      expect(all_selected_options.length).toBe(3)
+      expect(all_selected_options).toHaveLength(3)
 
       // All options should have selected styling
       Array.from(all_selected_options).forEach((option) => {
@@ -1931,23 +1931,19 @@ describe(`keepSelectedInDropdown feature`, () => {
         const matching_options = Array.from(filtered_options).filter((li) =>
           li.textContent?.includes(`Banana`) || li.textContent?.includes(`Date`)
         )
-        expect(matching_options.length).toBe(2)
+        expect(matching_options).toHaveLength(2)
 
-        // Check that selected options are still visible (if they match the search)
-        const selected_options = Array.from(filtered_options).filter((li) =>
-          li.textContent?.includes(`Apple`) || li.textContent?.includes(`Cherry`)
-        )
-        expect(selected_options.length).toBeGreaterThanOrEqual(0)
+        // Note: selected options Apple/Cherry don't match filter 'a' so they may not be visible
       } else {
         // In default mode, only matching options are shown
-        expect(filtered_options.length).toBe(2) // Banana, Date
+        expect(filtered_options).toHaveLength(2) // Banana, Date
       }
 
       // Check that non-matching non-selected options are not visible
       const non_matching_options = Array.from(filtered_options).filter((li) =>
         li.textContent?.includes(`foo`) || li.textContent?.includes(`qux`)
       )
-      expect(non_matching_options.length).toBe(0)
+      expect(non_matching_options).toHaveLength(0)
     },
   )
 })
@@ -2216,7 +2212,7 @@ test.each([true, false, `if-mobile`] as const)(
 
     // count number of selected items
     const selected_items = document.querySelectorAll(`ul.selected > li`)
-    expect(selected_items.length).toBe(1)
+    expect(selected_items).toHaveLength(1)
 
     // check that dropdown is closed when closeDropdownOnSelect = true
     const dropdown = doc_query(`ul.options`)

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1933,7 +1933,7 @@ describe(`keepSelectedInDropdown feature`, () => {
         )
         expect(matching_options).toHaveLength(2)
 
-        // Note: selected options Apple/Cherry don't match filter 'a' so they may not be visible
+        // Note: selected options Apple/Cherry match filter 'a' with fuzzy search and should be visible
       } else {
         // In default mode, only matching options are shown
         expect(filtered_options).toHaveLength(2) // Banana, Date


### PR DESCRIPTION
Closes #371 and #372

- Add an `onreorder` callback for drag-and-drop reordering and include `reorder` and `selectAll` in `onchange` event types
- Add `onopen` and `onclose` callbacks for open/close interactions
- Add a Select All item and a public styling hook for it
- Update callback documentation and examples