### PR TITLE
fix: prevent extra binding updates on init and selection

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -151,11 +151,15 @@
       : true,
   )
 
-  // Helper to compare arrays/values for equality to avoid unnecessary updates
+  // Helper to compare arrays/values for equality to avoid unnecessary updates.
   // Prevents infinite loops when value/selected are bound to reactive wrappers
   // that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.
+  // Treats null/undefined/[] as equivalent empty states to prevent extra updates on init (#369).
   function values_equal(val1: unknown, val2: unknown): boolean {
     if (val1 === val2) return true
+    const empty1 = val1 == null || (Array.isArray(val1) && val1.length === 0)
+    const empty2 = val2 == null || (Array.isArray(val2) && val2.length === 0)
+    if (empty1 && empty2) return true
     if (Array.isArray(val1) && Array.isArray(val2)) {
       return val1.length === val2.length &&
         val1.every((item, idx) => item === val2[idx])

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -312,7 +312,7 @@ test.each([[null], [1]])(
       props: { options: [1, 2, 3], maxSelect },
     })
 
-    // On init, value stays null (no unnecessary sync from [] to null). See issue #369.
+    // On init, value stays null (no unnecessary sync from null to []). See issue #369.
     expect(select.value).toEqual(null)
 
     await tick()
@@ -2837,13 +2837,12 @@ describe(`binding update event count`, () => {
       await tick()
       await tick()
 
+      // The effect in Test2WayBind fires at least once on mount with initial value
+      expect(spy.mock.calls.length).toBeGreaterThanOrEqual(1)
       // The fix ensures value stays null (no sync to [])
       // Without fix: spy would be called with [] for maxSelect=null
-      if (maxSelect === null) {
-        // For multi-select, value should stay null, not get synced to []
-        const last_call = spy.mock.calls[spy.mock.calls.length - 1]?.[0]
-        expect(last_call).toBeNull()
-      }
+      const last_value = spy.mock.calls[spy.mock.calls.length - 1][0]
+      expect(last_value, `value should be null, not []`).toBeNull()
     },
   )
 })


### PR DESCRIPTION
Closes #369

- Treat `null`, `undefined`, and empty arrays as equivalent empty values during initialization and reactive resets while preserving element-wise comparison for non-empty selections
- Prevent incorrect synchronization between `null` and `[]` on initialization