### PR TITLE
Use :where() for user-overridable CSS selectors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,6 @@ jobs:
     uses: janosh/workflows/.github/workflows/deno-test.yml@main
     with:
       deno-version: 2.3.7
-      test-cmd: deno task vitest --run
+      test-cmd: npx vitest --run
       e2e-install-cmd: npx playwright install chromium
       e2e-test-cmd: npx playwright test

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1888,8 +1888,8 @@
       var(--sms-group-option-indent, 1.5ex)
     );
   }
-  /* Collapse/expand animation for group chevron icon */
-  :where(ul.options > li.group-header) :global(svg) {
+  /* Collapse/expand animation for group chevron icon - internal, keep :is() for specificity */
+  :is(ul.options > li.group-header) :global(svg) {
     transition: transform var(--sms-group-collapse-duration, 0.15s) ease-out;
   }
   /* Keep :is() for internal buttons without class props */

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1609,7 +1609,9 @@
     border: 0;
   }
 
-  :is(div.multiselect) {
+  /* Use :where() for elements with user-overridable class props (outerDivClass, ulSelectedClass, liSelectedClass)
+     so user-provided classes take precedence. See: https://github.com/janosh/svelte-multiselect/issues/380 */
+  :where(div.multiselect) {
     position: relative;
     align-items: center;
     display: flex;
@@ -1626,27 +1628,27 @@
     min-height: var(--sms-min-height, 22pt);
     margin: var(--sms-margin);
   }
-  :is(div.multiselect.open) {
+  :where(div.multiselect.open) {
     /* increase z-index when open to ensure the dropdown of one <MultiSelect />
     displays above that of another slightly below it on the page */
     z-index: var(--sms-open-z-index, 4);
   }
-  :is(div.multiselect:focus-within) {
+  :where(div.multiselect:focus-within) {
     border: var(--sms-focus-border, 1pt solid var(--sms-active-color, cornflowerblue));
   }
-  :is(div.multiselect.disabled) {
+  :where(div.multiselect.disabled) {
     background: var(--sms-disabled-bg, light-dark(lightgray, #444));
     cursor: not-allowed;
   }
 
-  :is(div.multiselect > ul.selected) {
+  :where(div.multiselect > ul.selected) {
     display: flex;
     flex: 1;
     padding: 0;
     margin: 0;
     flex-wrap: wrap;
   }
-  :is(div.multiselect > ul.selected > li) {
+  :where(div.multiselect > ul.selected > li) {
     align-items: center;
     border-radius: 3pt;
     display: flex;
@@ -1661,10 +1663,10 @@
     padding: var(--sms-selected-li-padding, 1pt 5pt);
     color: var(--sms-selected-text-color, var(--sms-text-color));
   }
-  :is(div.multiselect > ul.selected > li[draggable='true']) {
+  :where(div.multiselect > ul.selected > li[draggable='true']) {
     cursor: grab;
   }
-  :is(div.multiselect > ul.selected > li.active) {
+  :where(div.multiselect > ul.selected > li.active) {
     background: var(
       --sms-li-active-bg,
       var(--sms-active-color, light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)))
@@ -1698,7 +1700,7 @@
     margin: auto 0; /* CSS reset */
     padding: 0; /* CSS reset */
   }
-  :is(div.multiselect > ul.selected > input) {
+  :where(div.multiselect > ul.selected > input) {
     border: none;
     outline: none;
     background: none;
@@ -1712,7 +1714,7 @@
   }
 
   /* When options are selected, placeholder is hidden in which case we minimize input width to avoid adding unnecessary width to div.multiselect */
-  :is(div.multiselect > ul.selected > input:not(:placeholder-shown)) {
+  :where(div.multiselect > ul.selected > input:not(:placeholder-shown)) {
     min-width: 1px; /* Minimal width to remain interactive */
   }
 
@@ -1733,7 +1735,8 @@
     pointer-events: none;
   }
 
-  ul.options {
+  /* Use :where() for ul.options elements with class props (ulOptionsClass, liOptionClass, liUserMsgClass) */
+  :where(ul.options) {
     list-style: none;
     /* top, left, width, position are managed by portal when active */
     /* but provide defaults for non-portaled or initial state */
@@ -1761,24 +1764,24 @@
     padding: var(--sms-options-padding);
     margin: var(--sms-options-margin, 6pt 0 0 0);
   }
-  ul.options.hidden {
+  :where(ul.options.hidden) {
     visibility: hidden;
     opacity: 0;
     transform: translateY(50px);
     pointer-events: none;
   }
-  ul.options > li {
+  :where(ul.options > li) {
     padding: 3pt 1ex;
     cursor: pointer;
     scroll-margin: var(--sms-options-scroll-margin, 100px);
     border-left: 3px solid transparent;
   }
-  ul.options .user-msg {
+  :where(ul.options .user-msg) {
     /* block needed so vertical padding applies to span */
     display: block;
     padding: 3pt 2ex;
   }
-  ul.options > li.selected {
+  :where(ul.options > li.selected) {
     background: var(
       --sms-li-selected-plain-bg,
       light-dark(rgba(0, 123, 255, 0.1), rgba(100, 180, 255, 0.2))
@@ -1788,26 +1791,26 @@
       3px solid var(--sms-active-color, cornflowerblue)
     );
   }
-  ul.options > li.active {
+  :where(ul.options > li.active) {
     background: var(
       --sms-li-active-bg,
       var(--sms-active-color, light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)))
     );
   }
-  ul.options > li.disabled {
+  :where(ul.options > li.disabled) {
     cursor: not-allowed;
     background: var(--sms-li-disabled-bg, light-dark(#f5f5f6, #2a2a2a));
     color: var(--sms-li-disabled-text, light-dark(#b8b8b8, #666));
   }
-  /* Checkbox styling for keepSelectedInDropdown='checkboxes' mode */
-  ul.options > li > input.option-checkbox {
+  /* Checkbox styling for keepSelectedInDropdown='checkboxes' mode - internal, no class prop */
+  :is(ul.options > li > input.option-checkbox) {
     width: 16px;
     height: 16px;
     margin-right: 6px;
     accent-color: var(--sms-active-color, cornflowerblue);
   }
-  /* Select all option styling */
-  ul.options > li.select-all {
+  /* Select all option styling - has liSelectAllClass prop */
+  :where(ul.options > li.select-all) {
     border-bottom: var(
       --sms-select-all-border-bottom,
       1px solid light-dark(lightgray, #555)
@@ -1817,7 +1820,7 @@
     background: var(--sms-select-all-bg, transparent);
     margin-bottom: var(--sms-select-all-margin-bottom, 2pt);
   }
-  ul.options > li.select-all:hover {
+  :where(ul.options > li.select-all:hover) {
     background: var(
       --sms-select-all-hover-bg,
       var(
@@ -1829,8 +1832,8 @@
       )
     );
   }
-  /* Group header styling */
-  ul.options > li.group-header {
+  /* Group header styling - has liGroupHeaderClass prop */
+  :where(ul.options > li.group-header) {
     display: flex;
     align-items: center;
     font-weight: var(--sms-group-header-font-weight, 600);
@@ -1843,30 +1846,31 @@
     text-transform: var(--sms-group-header-text-transform, uppercase);
     letter-spacing: var(--sms-group-header-letter-spacing, 0.5px);
   }
-  ul.options > li.group-header:not(:first-child) {
+  :where(ul.options > li.group-header:not(:first-child)) {
     margin-top: var(--sms-group-header-margin-top, 4pt);
     border-top: var(--sms-group-header-border-top, 1px solid light-dark(#eee, #333));
   }
-  ul.options > li.group-header.collapsible {
+  :where(ul.options > li.group-header.collapsible) {
     cursor: pointer;
   }
-  ul.options > li.group-header.collapsible:hover {
+  :where(ul.options > li.group-header.collapsible:hover) {
     background: var(
       --sms-group-header-hover-bg,
       light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05))
     );
   }
-  ul.options > li.group-header .group-label {
+  /* Internal elements without class props - keep :is() for specificity */
+  :is(ul.options > li.group-header .group-label) {
     flex: 1;
   }
-  ul.options > li.group-header .group-count {
+  :is(ul.options > li.group-header .group-count) {
     opacity: 0.6;
     font-size: 0.9em;
     font-weight: normal;
     margin-left: 4pt;
   }
   /* Sticky group headers when enabled */
-  ul.options > li.group-header.sticky {
+  :where(ul.options > li.group-header.sticky) {
     position: sticky;
     top: 0;
     z-index: 1;
@@ -1876,17 +1880,20 @@
     );
   }
   /* Indent grouped options for visual hierarchy */
-  ul.options > li:not(.group-header):not(.select-all):not(.user-msg):not(.loading-more) {
+  :where(
+    ul.options > li:not(.group-header):not(.select-all):not(.user-msg):not(.loading-more)
+  ) {
     padding-left: var(
       --sms-group-item-padding-left,
       var(--sms-group-option-indent, 1.5ex)
     );
   }
   /* Collapse/expand animation for group chevron icon */
-  ul.options > li.group-header :global(svg) {
+  :where(ul.options > li.group-header) :global(svg) {
     transition: transform var(--sms-group-collapse-duration, 0.15s) ease-out;
   }
-  ul.options > li.group-header button.group-select-all {
+  /* Keep :is() for internal buttons without class props */
+  :is(ul.options > li.group-header button.group-select-all) {
     font-size: 0.9em;
     font-weight: normal;
     text-transform: none;
@@ -1899,23 +1906,23 @@
     border-radius: 3pt;
     aspect-ratio: auto; /* override global button aspect-ratio: 1 */
   }
-  ul.options > li.group-header button.group-select-all:hover {
+  :is(ul.options > li.group-header button.group-select-all:hover) {
     background: var(
       --sms-group-select-all-hover-bg,
       light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1))
     );
   }
-  ul.options > li.group-header button.group-select-all.deselect {
+  :is(ul.options > li.group-header button.group-select-all.deselect) {
     color: var(--sms-group-deselect-color, light-dark(#c44, #f77));
   }
-  :is(span.max-select-msg) {
+  :where(span.max-select-msg) {
     padding: 0 3pt;
   }
   ::highlight(sms-search-matches) {
     color: light-dark(#1a8870, mediumaquamarine);
   }
-  /* Loading more indicator for infinite scrolling */
-  ul.options > li.loading-more {
+  /* Loading more indicator for infinite scrolling - internal, no class prop */
+  :is(ul.options > li.loading-more) {
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -442,20 +442,21 @@
     z-index: var(--nav-toggle-btn-z-index, 10);
   }
   .burger span {
+    width: 100%;
     height: 0.18rem;
-    background-color: var(--text-color);
+    background-color: var(--text);
     border-radius: 8px;
     transition: all 0.2s linear;
-    transform-origin: 1px;
+    transform-origin: center;
   }
   .burger[aria-expanded='true'] span:first-child {
-    transform: rotate(45deg);
+    transform: translateY(0.4rem) rotate(45deg);
   }
   .burger[aria-expanded='true'] span:nth-child(2) {
     opacity: 0;
   }
   .burger[aria-expanded='true'] span:nth-child(3) {
-    transform: rotate(-45deg);
+    transform: translateY(-0.4rem) rotate(-45deg);
   }
   /* Mobile styles */
   @media (max-width: 767px) {

--- a/src/routes/(demos)/events/+page.md
+++ b/src/routes/(demos)/events/+page.md
@@ -97,12 +97,12 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
     margin: 2em 0;
   }
   .demo-section {
-    background: rgba(255, 255, 255, 0.05);
+    background: light-dark(#f9f9f9, rgba(255, 255, 255, 0.05));
     padding: 1.5em;
     border-radius: 8px;
   }
   .event-log {
-    background: rgba(0, 0, 0, 0.3);
+    background: light-dark(#f5f5f5, rgba(0, 0, 0, 0.3));
     border-radius: 8px;
     max-height: 60vh;
     overflow-y: auto;
@@ -113,13 +113,12 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
     display: flex;
     justify-content: space-between;
     align-items: center;
-    position: sticky;
-    background-color: black;
-    top: 0;
-    padding: 1ex 1em;
+    background-color: var(--surface);
+    height: max-content;
+    padding: 1pt 9pt;
   }
   .log-entry {
-    background: rgba(255, 255, 255, 0.05);
+    background: light-dark(#fff, rgba(255, 255, 255, 0.05));
     border-radius: 4px;
     padding: 1ex 1em;
     border-left: 3px solid #4299e1;
@@ -137,10 +136,10 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
   }
   .timestamp {
     font-size: 0.8em;
-    color: #a0aec0;
+    color: light-dark(#666, #a0aec0);
   }
   .log-data {
-    background: rgba(0, 0, 0, 0.3);
+    background: light-dark(#eee, rgba(0, 0, 0, 0.3));
     padding: 0.5em;
     border-radius: 3px;
     font-size: 0.8em;
@@ -149,7 +148,7 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
     word-break: break-word;
   }
   .no-events {
-    color: #a0aec0;
+    color: light-dark(#666, #a0aec0);
     font-style: italic;
     text-align: center;
     padding: 2em;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,10 +33,6 @@
 
 <CopyButton global />
 
-{#if !page.error && page.url.pathname !== `/`}
-  <a href="." aria-label="Back to index page">&laquo; home</a>
-{/if}
-
 {@render children?.()}
 
 {#if page.url.pathname === `/`}
@@ -52,14 +48,6 @@
 <Footer />
 
 <style>
-  a[href='.'] {
-    position: absolute;
-    top: 1.5em;
-    left: 1.5em;
-    padding: 2pt 6pt;
-    background: var(--surface);
-    border-radius: 3px;
-  }
   :global(aside.toc.desktop) {
     position: fixed;
     font-size: 0.75rem;

--- a/src/site/DemoNav.svelte
+++ b/src/site/DemoNav.svelte
@@ -8,10 +8,11 @@
 
 <Nav
   {...props}
-  routes={demo_pages}
+  routes={[`/`, ...demo_pages]}
   {page}
   style={`max-width: var(--main-max-width); ${props.style ?? ``}`}
   labels={{
+    '/': `Home`,
     '/ui': `UI`,
     '/css-classes': `CSS Classes`,
     '/kit-form-actions': `SvelteKit Form Actions`,


### PR DESCRIPTION
Fixes #380: User-provided class props (e.g., `liSelectedClass="bg-gray-400"`) now override component default styles.

## Changes

### CSS Specificity Fix

- Replace `:is()` with `:where()` for selectors with corresponding class props (`outerDivClass`, `ulSelectedClass`, `liSelectedClass`, `inputClass`, `ulOptionsClass`, `liOptionClass`, etc.)
- Keep `:is()` for internal elements without class props (`.group-label`, `.group-count`, buttons, checkboxes) to protect from global style conflicts
- Add 7 Playwright tests verifying CSS specificity behavior

### Why this works

- `:where()` has zero specificity (0,0,0), so any user class (e.g., `.bg-gray-400` with specificity 0,1,0) wins
- `:is()` preserves normal specificity for internal elements, protecting them from accidental global style overrides
- CSS variable customization continues to work as a fallback

### Navigation and demo polish

- Add Home link to demo nav and remove redundant back link from layout
- Fix Nav.svelte CSS variable name: `--text-color` → `--text`
- Improve the mobile hamburger animation, color tokens, and light/dark demo theming