### PR TITLE
Add 4 new event callbacks for user feedback and analytics

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -802,6 +802,30 @@ Example using several snippets:
 
    Triggers when the dropdown list of options disappears. `event` is the DOM's `FocusEvent`, `KeyboardEvent` or `ClickEvent` that triggered the close.
 
+1. ```ts
+   onsearch={({ searchText, matchingCount }) => console.log(searchText, matchingCount)}
+   ```
+
+   Triggers (debounced, 150ms) when the search text changes. Useful for analytics or loading remote options. `searchText` is the current input value, `matchingCount` is the number of options that match.
+
+1. ```ts
+   onmaxreached={({ selected, maxSelect, attemptedOption }) => console.log(attemptedOption)}
+   ```
+
+   Triggers when a user tries to select more options than `maxSelect` allows. Useful for showing feedback. Does not fire for `maxSelect=1` (which uses replace behavior).
+
+1. ```ts
+   onduplicate={({ option }) => console.log(`Duplicate:`, option)}
+   ```
+
+   Triggers when a user tries to add an already-selected option (when `duplicates=false`). Useful for showing feedback to the user.
+
+1. ```ts
+   onactivate={({ option, index }) => console.log(`Active:`, option, index)}
+   ```
+
+   Triggers during keyboard navigation (ArrowUp/ArrowDown) through options. `option` is the newly active option, `index` is its position. Does not fire on mouse hover.
+
 For example, here's how you might annoy your users with an alert every time one or more options are added or removed:
 
 ```svelte

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -277,15 +277,10 @@
       search_initialized = true
       return
     }
-    // Clear any pending timer if onsearch is removed
-    if (!onsearch) {
-      if (search_debounce_timer) clearTimeout(search_debounce_timer)
-      return
-    }
+    if (!onsearch) return // cleanup handles any pending timer
 
-    if (search_debounce_timer) clearTimeout(search_debounce_timer)
     search_debounce_timer = setTimeout(() => {
-      // Use optional chaining in case onsearch is removed while timer is pending
+      // Optional chaining in case onsearch is removed while timer is pending
       onsearch?.({
         searchText: current_search,
         matchingCount: matchingOptions.length,
@@ -766,6 +761,11 @@
       activeIndex = 0
     } else {
       const total = navigable_options.length + (has_user_msg ? 1 : 0)
+      // Guard against division by zero (can happen if options filtered away before effect resets activeIndex)
+      if (total === 0) {
+        activeIndex = null
+        return
+      }
       activeIndex = (activeIndex + direction + total) % total // +total handles negative mod
     }
 

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -277,11 +277,19 @@
       search_initialized = true
       return
     }
-    if (!onsearch) return
+    // Clear any pending timer if onsearch is removed
+    if (!onsearch) {
+      if (search_debounce_timer) clearTimeout(search_debounce_timer)
+      return
+    }
 
     if (search_debounce_timer) clearTimeout(search_debounce_timer)
     search_debounce_timer = setTimeout(() => {
-      onsearch({ searchText: current_search, matchingCount: matchingOptions.length })
+      // Use optional chaining in case onsearch is removed while timer is pending
+      onsearch?.({
+        searchText: current_search,
+        matchingCount: matchingOptions.length,
+      })
     }, 150)
     return () => {
       if (search_debounce_timer) clearTimeout(search_debounce_timer)

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -143,6 +143,10 @@
     ongroupToggle,
     oncollapseAll,
     onexpandAll,
+    onsearch,
+    onmaxreached,
+    onduplicate,
+    onactivate,
     collapseAllGroups = $bindable(),
     expandAllGroups = $bindable(),
     // Keyboard shortcuts for common actions
@@ -260,6 +264,27 @@
     if (last_action) {
       const timer = setTimeout(() => (last_action = null), 1000)
       return () => clearTimeout(timer)
+    }
+  })
+
+  // Debounced onsearch event - fires 150ms after search text stops changing
+  let search_debounce_timer: ReturnType<typeof setTimeout> | null = null
+  let search_initialized = false
+  $effect(() => {
+    const current_search = searchText
+    // Skip initial mount - only fire on actual user input
+    if (!search_initialized) {
+      search_initialized = true
+      return
+    }
+    if (!onsearch) return
+
+    if (search_debounce_timer) clearTimeout(search_debounce_timer)
+    search_debounce_timer = setTimeout(() => {
+      onsearch({ searchText: current_search, matchingCount: matchingOptions.length })
+    }, 150)
+    return () => {
+      if (search_debounce_timer) clearTimeout(search_debounce_timer)
     }
   })
 
@@ -567,6 +592,14 @@
     }
 
     const is_duplicate = selected_keys_set.has(key(option_to_add))
+    const max_reached = maxSelect !== null && maxSelect !== 1 &&
+      selected.length >= maxSelect
+    // Fire events for blocked add attempts
+    if (max_reached) {
+      onmaxreached?.({ selected, maxSelect, attemptedOption: option_to_add })
+    }
+    if (is_duplicate && !duplicates) onduplicate?.({ option: option_to_add })
+
     if (
       (maxSelect === null || maxSelect === 1 || selected.length < maxSelect) &&
       (duplicates || !is_duplicate)
@@ -738,6 +771,9 @@
       await tick()
       document.querySelector(`ul.options > li.active`)?.scrollIntoViewIfNeeded?.()
     }
+
+    // Fire onactivate for keyboard navigation only (not mouse hover)
+    onactivate?.({ option: activeOption, index: activeIndex })
   }
 
   // handle all keyboard events this component receives

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,13 @@ export interface MultiSelectEvents<T extends Option = Option> {
   ongroupToggle?: (data: { group: string; collapsed: boolean }) => unknown // fires when group is collapsed/expanded
   oncollapseAll?: (data: { groups: string[] }) => unknown // fires when all groups are collapsed
   onexpandAll?: (data: { groups: string[] }) => unknown // fires when all groups are expanded
+  // Additional events for user feedback and analytics
+  onsearch?: (data: { searchText: string; matchingCount: number }) => unknown // fires (debounced) when search text changes
+  onmaxreached?: (
+    data: { selected: T[]; maxSelect: number; attemptedOption: T },
+  ) => unknown // fires when user tries to exceed maxSelect
+  onduplicate?: (data: { option: T }) => unknown // fires when user tries to add duplicate (when duplicates=false)
+  onactivate?: (data: { option: T | null; index: number | null }) => unknown // fires on keyboard navigation through options
 }
 
 // Dynamic options loading (https://github.com/janosh/svelte-multiselect/discussions/342)

--- a/src/routes/(demos)/events/+page.md
+++ b/src/routes/(demos)/events/+page.md
@@ -27,8 +27,9 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
 
 <div class="demo-grid">
   <section class="demo-section">
-    Select options, remove them, use "Remove all", create custom options, and interact
-    with the input.
+    Select options, remove them, use "Remove all", create custom options, navigate with
+    arrow keys, and interact with the input. Try selecting 5 options and adding a 6th to
+    trigger `onmaxreached`, or selecting the same option twice to see `onduplicate`.
 
     <label style="display: block; margin-block: 1em">
       <input type="checkbox" bind:checked={allowUserOptions} />
@@ -40,7 +41,6 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
       placeholder="Select colors or type to create custom..."
       {allowUserOptions}
       createOptionMsg="Create custom color..."
-      duplicates
       maxSelect={5}
       onadd={(data) => log_event('onadd', data)}
       onremove={(data) => log_event('onremove', data)}
@@ -49,6 +49,10 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
       oncreate={(data) => log_event('oncreate', data)}
       onopen={(data) => log_event('onopen', data)}
       onclose={(data) => log_event('onclose', data)}
+      onsearch={(data) => log_event('onsearch', data)}
+      onmaxreached={(data) => log_event('onmaxreached', data)}
+      onduplicate={(data) => log_event('onduplicate', data)}
+      onactivate={(data) => log_event('onactivate', data)}
       onblur={(event) =>
       log_event('onblur', { type: event.type, target: event.target?.tagName })}
       onclick={(event) =>
@@ -160,15 +164,19 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
 
 #### Custom Events
 
-| Event         | Description                                    | Data Structure                                                          |
-| ------------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
-| `onadd`       | Fired when an option is added to selection     | `{ option: T }`                                                         |
-| `onremove`    | Fired when an option is removed from selection | `{ option: T }`                                                         |
-| `onremoveAll` | Fired when all options are removed             | `{ options: T[] }`                                                      |
-| `onchange`    | Fired for any selection change                 | `{ option?: T, options?: T[], type: 'add' \| 'remove' \| 'removeAll' }` |
-| `oncreate`    | Fired when user creates a custom option        | `{ option: T }`                                                         |
-| `onopen`      | Fired when dropdown opens                      | `{ event: Event }`                                                      |
-| `onclose`     | Fired when dropdown closes                     | `{ event: Event }`                                                      |
+| Event          | Description                                    | Data Structure                                                          |
+| -------------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
+| `onadd`        | Fired when an option is added to selection     | `{ option: T }`                                                         |
+| `onremove`     | Fired when an option is removed from selection | `{ option: T }`                                                         |
+| `onremoveAll`  | Fired when all options are removed             | `{ options: T[] }`                                                      |
+| `onchange`     | Fired for any selection change                 | `{ option?: T, options?: T[], type: 'add' \| 'remove' \| 'removeAll' }` |
+| `oncreate`     | Fired when user creates a custom option        | `{ option: T }`                                                         |
+| `onopen`       | Fired when dropdown opens                      | `{ event: Event }`                                                      |
+| `onclose`      | Fired when dropdown closes                     | `{ event: Event }`                                                      |
+| `onsearch`     | Fired (debounced) when search text changes     | `{ searchText: string, matchingCount: number }`                         |
+| `onmaxreached` | Fired when user tries to exceed maxSelect      | `{ selected: T[], maxSelect: number, attemptedOption: T }`              |
+| `onduplicate`  | Fired when user tries to add duplicate         | `{ option: T }`                                                         |
+| `onactivate`   | Fired on keyboard navigation through options   | `{ option: T \| null, index: number \| null }`                          |
 
 #### Native DOM Events
 
@@ -218,3 +226,5 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
    ```
 
 1. **Custom Options**: The `oncreate` event only fires when `allowUserOptions` is enabled and users type text that doesn't match existing options.
+
+1. **New Events**: The `onsearch` event is debounced (150ms) to avoid excessive callbacks while typing. `onactivate` only fires during keyboard navigation (arrow keys), not on mouse hover. `onduplicate` only fires when `duplicates={false}` (the default).

--- a/src/routes/(demos)/events/+page.md
+++ b/src/routes/(demos)/events/+page.md
@@ -164,19 +164,19 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
 
 #### Custom Events
 
-| Event          | Description                                    | Data Structure                                                          |
-| -------------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
-| `onadd`        | Fired when an option is added to selection     | `{ option: T }`                                                         |
-| `onremove`     | Fired when an option is removed from selection | `{ option: T }`                                                         |
-| `onremoveAll`  | Fired when all options are removed             | `{ options: T[] }`                                                      |
-| `onchange`     | Fired for any selection change                 | `{ option?: T, options?: T[], type: 'add' \| 'remove' \| 'removeAll' }` |
-| `oncreate`     | Fired when user creates a custom option        | `{ option: T }`                                                         |
-| `onopen`       | Fired when dropdown opens                      | `{ event: Event }`                                                      |
-| `onclose`      | Fired when dropdown closes                     | `{ event: Event }`                                                      |
-| `onsearch`     | Fired (debounced) when search text changes     | `{ searchText: string, matchingCount: number }`                         |
-| `onmaxreached` | Fired when user tries to exceed maxSelect      | `{ selected: T[], maxSelect: number, attemptedOption: T }`              |
-| `onduplicate`  | Fired when user tries to add duplicate         | `{ option: T }`                                                         |
-| `onactivate`   | Fired on keyboard navigation through options   | `{ option: T \| null, index: number \| null }`                          |
+| Event          | Description                                      | Data Structure                                                          |
+| -------------- | ------------------------------------------------ | ----------------------------------------------------------------------- |
+| `onadd`        | Fired when an option is added to selection       | `{ option: T }`                                                         |
+| `onremove`     | Fired when an option is removed from selection   | `{ option: T }`                                                         |
+| `onremoveAll`  | Fired when all options are removed               | `{ options: T[] }`                                                      |
+| `onchange`     | Fired for any selection change                   | `{ option?: T, options?: T[], type: 'add' \| 'remove' \| 'removeAll' }` |
+| `oncreate`     | Fired when user creates a custom option          | `{ option: T }`                                                         |
+| `onopen`       | Fired when dropdown opens                        | `{ event: Event }`                                                      |
+| `onclose`      | Fired when dropdown closes                       | `{ event: Event }`                                                      |
+| `onsearch`     | Fired (debounced 150ms) when search text changes | `{ searchText: string, matchingCount: number }`                         |
+| `onmaxreached` | Fired when user tries to exceed maxSelect        | `{ selected: T[], maxSelect: number, attemptedOption: T }`              |
+| `onduplicate`  | Fired when user tries to add duplicate           | `{ option: T }`                                                         |
+| `onactivate`   | Fired on keyboard navigation through options     | `{ option: T \| null, index: number \| null }`                          |
 
 #### Native DOM Events
 

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -12,7 +12,10 @@ test(`array cloning infinite loop prevention (issue #309)`, async ({ page }) => 
 
   // Selecting an option triggers the store subscription
   await page.click(`#store-binding input[placeholder='Select colors...']`)
-  await page.click(`#store-binding ul.options >> text=Red`)
+  // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+  const dropdown = page.locator(`#store-binding ul.options`)
+  await expect(dropdown).toBeVisible()
+  await dropdown.locator(`text=Red`).click()
 
   // Verify increment stays low (would be 1000+ without fix)
   const status = page.locator(`#store-binding-status`)
@@ -196,7 +199,10 @@ test.describe(`remove single button`, () => {
     await page.goto(`/ui`, { waitUntil: `networkidle` })
 
     await page.click(`#foods input[autocomplete]`)
-    await page.click(`#foods ul.options >> text=🍌 Banana`)
+    // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+    const dropdown = page.locator(`#foods ul.options`)
+    await expect(dropdown).toBeVisible()
+    await dropdown.locator(`text=🍌 Banana`).click()
 
     await page.click(`#foods button[title='Remove 🍌 Banana']`)
 
@@ -359,7 +365,10 @@ test.describe(`accessibility`, () => {
 
   test(`options have aria-selected='false' and selected items have aria-selected='true'`, async ({ page }) => {
     await page.click(`#foods input[autocomplete]`)
-    await page.click(`#foods ul.options > li`)
+    // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+    const dropdown = page.locator(`#foods ul.options`)
+    await expect(dropdown).toBeVisible()
+    await dropdown.locator(`li`).first().click()
     const aria_option = await page.getAttribute(
       `#foods ul.options > li`,
       `aria-selected`,
@@ -515,9 +524,12 @@ test.describe(`multiselect`, () => {
   test(`can select and remove many options`, async ({ page }) => {
     await page.goto(`/ui`, { waitUntil: `networkidle` })
 
+    const dropdown = page.locator(`#foods ul.options`)
     for (const idx of [2, 5, 8]) {
       await page.click(`#foods input[autocomplete]`)
-      await page.click(`#foods ul.options > li >> nth=${idx}`)
+      // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+      await expect(dropdown).toBeVisible()
+      await dropdown.locator(`li >> nth=${idx}`).click()
     }
     const selected = page.locator(`#foods ul.selected`)
     for (const food of `Pear Pineapple Watermelon`.split(` `)) {
@@ -662,7 +674,10 @@ test.describe(`allowUserOptions`, () => {
 
       await page.fill(selector, `foobar`) // filter dropdown options to only show custom one
 
-      await page.click(`#languages ul.options >> text=foobar`)
+      // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+      const dropdown = page.locator(`#languages ul.options`)
+      await expect(dropdown).toBeVisible()
+      await dropdown.locator(`text=foobar`).click()
 
       await expect(page.locator(`#languages ul.selected >> text=foobar`)).toBeVisible()
     },
@@ -694,7 +709,10 @@ test.describe(`allowUserOptions`, () => {
     await page.goto(`/allow-user-options`, { waitUntil: `networkidle` })
 
     await page.click(selector)
-    await page.click(`#languages ul.options >> text=Python`)
+    // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+    const dropdown = page.locator(`#languages ul.options`)
+    await expect(dropdown).toBeVisible()
+    await dropdown.locator(`text=Python`).click()
 
     await page.fill(selector, `foobar`)
     await page.press(selector, `Enter`)
@@ -733,9 +751,12 @@ test.describe(`sortSelected`, () => {
   test(`default sorting is alphabetical by label`, async ({ page }) => {
     await page.goto(`/sort-selected`, { waitUntil: `networkidle` })
 
-    await page.click(`#default-sort input[autocomplete]`)
+    const dropdown = page.locator(`#default-sort ul.options`)
     for (const label of labels) {
-      await page.click(`#default-sort ul.options >> text=${label}`)
+      await page.click(`#default-sort input[autocomplete]`)
+      // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+      await expect(dropdown).toBeVisible()
+      await dropdown.getByText(label, { exact: true }).click()
     }
 
     await expect(page.locator(`#default-sort ul.selected`)).toHaveText(
@@ -746,9 +767,12 @@ test.describe(`sortSelected`, () => {
   test(`custom sorting`, async ({ page }) => {
     await page.goto(`/sort-selected`, { waitUntil: `networkidle` })
 
-    await page.click(`#custom-sort input[autocomplete]`)
+    const dropdown = page.locator(`#custom-sort ul.options`)
     for (const label of labels) {
-      await page.click(`#custom-sort ul.options >> text=${label}`)
+      await page.click(`#custom-sort input[autocomplete]`)
+      // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+      await expect(dropdown).toBeVisible()
+      await dropdown.getByText(label, { exact: true }).click()
     }
 
     await expect(page.locator(`#custom-sort ul.selected`)).toHaveText(
@@ -793,9 +817,12 @@ test.describe(`maxSelect`, () => {
     await page.goto(`/min-max-select`, { waitUntil: `networkidle` })
 
     // Select maxSelect options
+    const dropdown = page.locator(`#languages ul.options`)
     for (let idx = 1; idx < max_select; idx++) {
       await page.click(`#languages input[autocomplete]`)
-      await page.click(`#languages ul.options > li >> nth=${idx}`)
+      // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+      await expect(dropdown).toBeVisible()
+      await dropdown.locator(`li >> nth=${idx}`).click()
     }
   })
 
@@ -813,7 +840,10 @@ test.describe(`maxSelect`, () => {
 
     // Try to add another option - should not work
     await page.click(`#languages input[autocomplete]`)
-    await page.click(`#languages ul.options > li >> nth=0`)
+    // Wait for dropdown to be visible and stable (has 0.2s CSS transition)
+    const dropdown = page.locator(`#languages ul.options`)
+    await expect(dropdown).toBeVisible()
+    await dropdown.locator(`li >> nth=0`).click()
 
     // Verify selected count hasn't changed (still maxSelect)
     await expect(selected_items).toHaveCount(max_select)


### PR DESCRIPTION
Adds 4 new event callbacks inspired by [discussion #262](https://github.com/janosh/svelte-multiselect/discussions/262):

- **`onsearch`**: Fires debounced (150ms) when search text changes. Includes `searchText` and `matchingCount` for analytics or remote option loading.
- **`onmaxreached`**: Fires when user tries to exceed `maxSelect` limit. Useful for showing feedback (does not fire for `maxSelect=1` which uses replace behavior).
- **`onduplicate`**: Fires when user tries to add an already-selected option (when `duplicates=false`). Useful for user feedback.
- **`onactivate`**: Fires during keyboard navigation (ArrowUp/ArrowDown). Includes active `option` and `index`. Does not fire on mouse hover.

- Added type definitions in `types.ts`
- Implemented events in `MultiSelect.svelte`
- Updated events demo page with examples
- Added 28 unit tests with parameterized test cases
- Documented all events in readme