### PR TITLE
Add pinned dropdown feature to Nav component

### DIFF
--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -106,11 +106,24 @@
       setTimeout(() => {
         document
           .querySelector<HTMLElement>(
-            `.dropdown[data-href="${href}"] [role="menuitem"]`,
+            `.dropdown[data-href="${CSS.escape(href)}"] [role="menuitem"]`,
           )
           ?.focus()
       }, 0)
     }
+  }
+
+  function handle_dropdown_mouseenter(href: string) {
+    if (is_touch_device) return
+    const is_this_pinned = pinned_dropdown === href
+    if (pinned_dropdown && !is_this_pinned) pinned_dropdown = null
+    hovered_dropdown = href
+  }
+
+  function handle_dropdown_focusin(href: string) {
+    const is_this_pinned = pinned_dropdown === href
+    if (pinned_dropdown && !is_this_pinned) pinned_dropdown = null
+    hovered_dropdown = href
   }
 
   function onkeydown(event: KeyboardEvent) {
@@ -339,16 +352,11 @@
           data-href={parsed_route.href}
           role="group"
           aria-current={child_is_active ? `true` : undefined}
-          onmouseenter={() => {
-            if (!is_touch_device) {
-              if (pinned_dropdown && !is_pinned) pinned_dropdown = null
-              hovered_dropdown = parsed_route.href
-            }
-          }}
+          onmouseenter={() => handle_dropdown_mouseenter(parsed_route.href)}
           onmouseleave={() => {
             if (!is_touch_device && !is_pinned) hovered_dropdown = null
           }}
-          onfocusin={() => (hovered_dropdown = parsed_route.href)}
+          onfocusin={() => handle_dropdown_focusin(parsed_route.href)}
           onfocusout={(event) => {
             const next = event.relatedTarget as Node | null
             if (!next || !(event.currentTarget as HTMLElement).contains(next)) {

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -555,7 +555,6 @@
   .dropdown > div:first-child {
     display: flex;
     align-items: center;
-    gap: 0;
     border-radius: var(--nav-border-radius);
     background-color: var(--nav-link-bg);
     transition: background-color 0.2s;
@@ -612,7 +611,6 @@
     padding: var(--nav-dropdown-padding, 3pt 0);
     display: none;
     flex-direction: column;
-    gap: 0;
     z-index: var(--nav-dropdown-z-index, 100);
   }
   .dropdown > div:last-child.visible {

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -143,11 +143,10 @@
       return
     }
 
+    // Check if dropdown is open (either via hover or pinned)
+    const is_open = hovered_dropdown === href || pinned_dropdown === href
     // Arrow key navigation within open dropdown
-    if (
-      hovered_dropdown === href &&
-      (key === `ArrowDown` || key === `ArrowUp`)
-    ) {
+    if (is_open && (key === `ArrowDown` || key === `ArrowUp`)) {
       event.preventDefault()
       const direction = key === `ArrowDown` ? 1 : -1
       focused_item_index = Math.max(
@@ -156,13 +155,13 @@
       )
       document
         .querySelectorAll<HTMLElement>(
-          `.dropdown[data-href="${href}"] [role="menuitem"]`,
+          `.dropdown[data-href="${CSS.escape(href)}"] [role="menuitem"]`,
         )
         ?.[focused_item_index]?.focus()
     }
 
     // Open dropdown with ArrowDown when closed
-    if (hovered_dropdown !== href && key === `ArrowDown`) {
+    if (!is_open && key === `ArrowDown`) {
       event.preventDefault()
       toggle_dropdown(href, true)
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,20 +1,11 @@
 import type { Option } from './types'
 
-// Generates a cryptographically secure RFC 4122 v4 UUID
-// Uses native randomUUID in secure contexts, falls back to getRandomValues for HTTP
+let uuid_counter = 0
+
+// Generates a UUID for component IDs. Uses crypto when available, falls back to counter.
 export function get_uuid(): string {
-  if (globalThis.isSecureContext && globalThis.crypto?.randomUUID) {
-    return globalThis.crypto.randomUUID()
-  }
-  if (!globalThis.crypto?.getRandomValues) {
-    throw new Error(`crypto.getRandomValues not available`)
-  }
-  const buf = new Uint8Array(16)
-  globalThis.crypto.getRandomValues(buf)
-  // Set version (4) and variant (RFC 4122) bits
-  buf[6] = (buf[6] & 0x0f) | 0x40
-  buf[8] = (buf[8] & 0x3f) | 0x80
-  const hex = [...buf].map((b) => b.toString(16).padStart(2, `0`)).join(``)
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
+  const hex = (Date.now().toString(16) + (uuid_counter++).toString(16)).padStart(32, `0`)
   return hex.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, `$1-$2-$3-$4-$5`)
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,10 @@ import type { Option } from './types'
 
 let uuid_counter = 0
 
-// Generates a UUID for component IDs. Uses crypto when available, falls back to counter.
+// Generates a UUID for component IDs. Uses native crypto.randomUUID when available.
+// Fallback uses timestamp+counter - sufficient for DOM IDs (uniqueness, not security).
+// Cryptographic randomness is unnecessary here since these IDs are only used for
+// associating labels with inputs and ensuring unique DOM element identifiers.
 export function get_uuid(): string {
   if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
   const hex = (Date.now().toString(16) + (uuid_counter++).toString(16)).padStart(32, `0`)

--- a/src/routes/(demos)/+layout.svelte
+++ b/src/routes/(demos)/+layout.svelte
@@ -18,9 +18,7 @@
       current={page.url.pathname}
       style="max-width: var(--main-max-width); margin: 2em auto"
       onkeyup={null}
-      link_props={{
-        style: `background: var(--surface); padding: 2pt 6pt; border-radius: 3px;`,
-      }}
+      link_props={{ style: `background: var(--surface); border-radius: 3px;` }}
     />
   {/if}
 </main>

--- a/src/routes/(demos)/+layout.svelte
+++ b/src/routes/(demos)/+layout.svelte
@@ -18,7 +18,7 @@
       current={page.url.pathname}
       style="max-width: var(--main-max-width); margin: 2em auto"
       onkeyup={null}
-      link_props={{ style: `background: var(--surface); border-radius: 3px;` }}
+      link_props={{ style: `background: var(--surface); padding: 2pt 6pt; border-radius: 3px;` }}
     />
   {/if}
 </main>

--- a/src/site/DemoNav.svelte
+++ b/src/site/DemoNav.svelte
@@ -1,27 +1,77 @@
 <script lang="ts">
   import { page } from '$app/state'
   import { Nav } from '$lib'
-  import { demo_pages } from '../routes/(demos)'
+  import type { NavRoute } from '$lib/types'
 
   let props = $props()
+
+  const grouped_routes: NavRoute[] = [
+    `/`,
+    {
+      href: `#basics`,
+      label: `Basics`,
+      children: [`/form`, `/events`, `/disabled`],
+    },
+    {
+      href: `#selection`,
+      label: `Selection`,
+      children: [
+        `/min-max-select`,
+        `/duplicates`,
+        `/sort-selected`,
+        `/keep-selected`,
+        `/allow-user-options`,
+      ],
+    },
+    {
+      href: `#styling`,
+      label: `Styling`,
+      children: [
+        `/ui`,
+        `/css-classes`,
+        `/snippets`,
+        `/parse-labels-as-html`,
+        `/portal`,
+      ],
+    },
+    {
+      href: `#data`,
+      label: `Data`,
+      children: [`/grouping`, `/infinite-scroll`],
+    },
+    {
+      href: `#integration`,
+      label: `Integration`,
+      children: [`/kit-form-actions`, `/persistent`, `/attachments`],
+    },
+    {
+      href: `#components`,
+      label: `Components`,
+      children: [`/nav`, `/cmd-palette`],
+    },
+  ]
 </script>
 
 <Nav
   {...props}
-  routes={[`/`, ...demo_pages]}
+  routes={grouped_routes}
   {page}
-  style={`max-width: var(--main-max-width); ${props.style ?? ``}`}
+  style={`max-width: var(--main-max-width); --nav-link-bg: rgba(0, 0, 0, 0.05); --nav-item-padding: 2pt 4pt; ${
+    props.style ?? ``
+  }`}
   menu_props={{ style: `gap: 10pt` }}
   labels={{
     '/': `Home`,
     '/ui': `UI`,
     '/css-classes': `CSS Classes`,
-    '/kit-form-actions': `SvelteKit Form Actions`,
+    '/kit-form-actions': `Form Actions`,
     '/cmd-palette': `CmdPalette`,
+    '/min-max-select': `Min/Max`,
+    '/allow-user-options': `User Options`,
+    '/sort-selected': `Sort Selected`,
+    '/keep-selected': `Keep Selected`,
+    '/parse-labels-as-html': `HTML Labels`,
+    '/infinite-scroll': `Infinite Scroll`,
     ...(props.labels ?? {}),
-  }}
-  link_props={{
-    style: `background: rgba(0, 0, 0, 0.05); border-radius: 3px; padding: 2pt 4pt`,
-    ...(props.link_props ?? {}),
   }}
 />

--- a/src/site/DemoNav.svelte
+++ b/src/site/DemoNav.svelte
@@ -2,8 +2,9 @@
   import { page } from '$app/state'
   import { Nav } from '$lib'
   import type { NavRoute } from '$lib/types'
+  import type { ComponentProps } from 'svelte'
 
-  let props = $props()
+  let props: Partial<ComponentProps<typeof Nav>> = $props()
 
   // NOTE: Update this list when adding/removing demo pages in src/routes/(demos)/
   const grouped_routes: NavRoute[] = [
@@ -53,7 +54,7 @@
   ]
 
   const base_style =
-    `max-width: var(--main-max-width); --nav-link-bg: rgba(0, 0, 0, 0.05); --nav-item-padding: 2pt 4pt;`
+    `max-width: var(--main-max-width); --nav-link-bg: rgba(0, 0, 0, 0.05); --nav-item-padding: 2pt 4pt; `
 </script>
 
 <Nav

--- a/src/site/DemoNav.svelte
+++ b/src/site/DemoNav.svelte
@@ -11,6 +11,7 @@
   routes={[`/`, ...demo_pages]}
   {page}
   style={`max-width: var(--main-max-width); ${props.style ?? ``}`}
+  menu_props={{ style: `gap: 10pt` }}
   labels={{
     '/': `Home`,
     '/ui': `UI`,
@@ -20,7 +21,7 @@
     ...(props.labels ?? {}),
   }}
   link_props={{
-    style: `background: var(--surface); padding: 2pt 6pt; border-radius: 3px;`,
+    style: `background: rgba(0, 0, 0, 0.05); border-radius: 3px; padding: 2pt 4pt`,
     ...(props.link_props ?? {}),
   }}
 />

--- a/src/site/DemoNav.svelte
+++ b/src/site/DemoNav.svelte
@@ -5,6 +5,7 @@
 
   let props = $props()
 
+  // NOTE: Update this list when adding/removing demo pages in src/routes/(demos)/
   const grouped_routes: NavRoute[] = [
     `/`,
     {
@@ -50,15 +51,16 @@
       children: [`/nav`, `/cmd-palette`],
     },
   ]
+
+  const base_style =
+    `max-width: var(--main-max-width); --nav-link-bg: rgba(0, 0, 0, 0.05); --nav-item-padding: 2pt 4pt;`
 </script>
 
 <Nav
   {...props}
   routes={grouped_routes}
   {page}
-  style={`max-width: var(--main-max-width); --nav-link-bg: rgba(0, 0, 0, 0.05); --nav-item-padding: 2pt 4pt; ${
-    props.style ?? ``
-  }`}
+  style={base_style + (props.style ?? ``)}
   menu_props={{ style: `gap: 10pt` }}
   labels={{
     '/': `Home`,

--- a/src/site/LanguageSnippet.svelte
+++ b/src/site/LanguageSnippet.svelte
@@ -33,9 +33,7 @@
 <style>
   span {
     display: flex;
-  }
-  img {
-    transform: translateY(2px);
+    align-items: center;
   }
   img[alt='Rust'] {
     filter: invert(1);

--- a/tests/playwright/Nav.test.ts
+++ b/tests/playwright/Nav.test.ts
@@ -21,4 +21,32 @@ test.describe(`Nav dropdown`, () => {
     await dropdown.hover()
     await expect(dropdown.locator(`div[role="menu"] a`).first()).toBeVisible()
   })
+
+  test(`click pins dropdown: stays open on mouse leave, closes on click outside/Escape/toggle`, async ({ page }) => {
+    await page.goto(`/nav`, { waitUntil: `networkidle` })
+
+    const dropdown = page.locator(`.dropdown`).first()
+    const menu = dropdown.locator(`div[role="menu"]`)
+    const toggle = dropdown.locator(`[data-dropdown-toggle]`)
+
+    // Click pins open, mouse leave doesn't close
+    await toggle.click()
+    await expect(menu).toHaveCSS(`display`, `flex`)
+    await page.mouse.move(0, 0)
+    await expect(menu).toHaveCSS(`display`, `flex`)
+
+    // Click outside closes
+    await page.locator(`body`).click({ position: { x: 10, y: 10 } })
+    await expect(menu).toHaveCSS(`display`, `none`)
+
+    // Escape closes
+    await toggle.click()
+    await page.keyboard.press(`Escape`)
+    await expect(menu).toHaveCSS(`display`, `none`)
+
+    // Toggle click closes
+    await toggle.click()
+    await toggle.click()
+    await expect(menu).toHaveCSS(`display`, `none`)
+  })
 })

--- a/tests/vitest/DemoNav.test.ts
+++ b/tests/vitest/DemoNav.test.ts
@@ -10,12 +10,11 @@ test(`DemoNav grouped_routes contains all demo pages`, () => {
   mount(DemoNav, { target: document.body })
 
   // Extract all hrefs from the rendered nav (excluding group headers like #basics)
-  const rendered_hrefs = Array.from(document.querySelectorAll(`nav a`))
-    .map((link) => link.getAttribute(`href`))
-    .filter((href) => href && !href.startsWith(`#`))
+  const hrefs = Array.from(document.querySelectorAll(`nav a`)).flatMap((link) => {
+    const href = link.getAttribute(`href`)
+    return href && !href.startsWith(`#`) ? [href] : []
+  })
 
-  // Filter already ensures non-null, so cast is safe
-  const hrefs = rendered_hrefs as string[]
   const missing = demo_pages.filter((page) => !hrefs.includes(page))
   const extra = hrefs.filter((href) => href !== `/` && !demo_pages.includes(href))
 

--- a/tests/vitest/DemoNav.test.ts
+++ b/tests/vitest/DemoNav.test.ts
@@ -1,0 +1,24 @@
+// Test that DemoNav's grouped_routes stays in sync with actual demo pages
+import { DemoNav } from '$site'
+import { mount } from 'svelte'
+import { expect, test, vi } from 'vitest'
+import { demo_pages } from '../../src/routes/(demos)'
+
+vi.mock(`$app/state`, () => ({ page: { url: { pathname: `/` } } }))
+
+test(`DemoNav grouped_routes contains all demo pages`, () => {
+  mount(DemoNav, { target: document.body })
+
+  // Extract all hrefs from the rendered nav (excluding group headers like #basics)
+  const rendered_hrefs = Array.from(document.querySelectorAll(`nav a`))
+    .map((link) => link.getAttribute(`href`))
+    .filter((href) => href && !href.startsWith(`#`))
+
+  // Filter already ensures non-null, so cast is safe
+  const hrefs = rendered_hrefs as string[]
+  const missing = demo_pages.filter((page) => !hrefs.includes(page))
+  const extra = hrefs.filter((href) => href !== `/` && !demo_pages.includes(href))
+
+  expect(missing, `Demo pages missing from DemoNav`).toEqual([])
+  expect(extra, `Routes in DemoNav not in demo_pages`).toEqual([])
+})

--- a/tests/vitest/FileDetails.svelte.test.ts
+++ b/tests/vitest/FileDetails.svelte.test.ts
@@ -15,9 +15,13 @@ test(`FileDetails renders files in ordered list with titles and contents`, () =>
   expect(document.querySelectorAll(`li > details`).length).toBe(2)
   expect(document.querySelectorAll(`summary`).length).toBe(2)
 
-  // Check contents
+  // Check titles and contents
+  const summaries = document.querySelectorAll(`summary`)
   const contents = document.querySelectorAll(`pre > code`)
-  files.forEach((file, idx) => expect(contents[idx].textContent).toBe(file.content))
+  files.forEach((file, idx) => {
+    expect(summaries[idx].textContent).toBe(file.title)
+    expect(contents[idx].textContent).toBe(file.content)
+  })
 })
 
 test(`toggle all button opens, closes, and handles partial open state`, async () => {
@@ -26,41 +30,27 @@ test(`toggle all button opens, closes, and handles partial open state`, async ()
     { title: `file2`, content: `content2` },
     { title: `file3`, content: `content3` },
   ]
-
-  const toggle_all_btn_title = `toggle all`
   mount(FileDetails, {
     target: document.body,
-    props: { files, toggle_all_btn_title },
+    props: { files, toggle_all_btn_title: `toggle all` },
   })
   await tick()
 
   const details = Array.from(document.querySelectorAll(`details`))
-  const btn = doc_query(`button[title='${toggle_all_btn_title}']`)
+  const btn = doc_query(`button[title='toggle all']`)
+  const all_open = () => details.every((d) => d.open)
+  const all_closed = () => details.every((d) => !d.open)
 
-  // Initially all closed
-  for (const detail of details) {
-    expect(detail.open).toBe(false)
-  }
-
-  // Click to open all
+  expect(all_closed()).toBe(true) // initially closed
   btn.click()
-  for (const [idx, detail] of details.entries()) {
-    expect(detail.open, `detail ${idx} after open`).toBe(true)
-  }
-
-  // Click to close all
+  expect(all_open()).toBe(true) // opened all
   btn.click()
-  for (const [idx, detail] of details.entries()) {
-    expect(detail.open, `detail ${idx} after close`).toBe(false)
-  }
+  expect(all_closed()).toBe(true) // closed all
 
-  // Manually open some details, then click to close all
-  details[0].open = true
-  details[1].open = true
+  // partial open state: clicking closes all
+  details[0].open = details[1].open = true
   btn.click()
-  for (const [idx, detail] of details.entries()) {
-    expect(detail.open, `detail ${idx} after partial close`).toBe(false)
-  }
+  expect(all_closed()).toBe(true)
 })
 
 test(`node refs are trimmed when files are removed to prevent memory leaks`, async () => {

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -1056,6 +1056,31 @@ describe(`Nav`, () => {
       },
     )
 
+    test(`ArrowDown navigates within pinned dropdown after mouse leave`, async () => {
+      mount(Nav, {
+        target: document.body,
+        props: { routes: [[`/parent`, [`/parent`, `/parent/child1`, `/parent/child2`]]] },
+      })
+      const { dropdown, dropdown_menu } = query_dropdown_elements()
+      const toggle = doc_query(`[data-dropdown-toggle]`)
+
+      // Pin dropdown open via click
+      await click(toggle)
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      // Mouse leaves, but dropdown stays pinned
+      mouse_leave(dropdown)
+      await tick()
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      // ArrowDown should navigate within dropdown, not close it
+      toggle.dispatchEvent(
+        new KeyboardEvent(`keydown`, { key: `ArrowDown`, bubbles: true }),
+      )
+      await new Promise((r) => setTimeout(r, 0))
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+    })
+
     test(`pinned dropdown stays open on focus out`, async () => {
       mount(Nav, {
         target: document.body,

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -932,6 +932,280 @@ describe(`Nav`, () => {
     expect(doc_query(`a[href="/about"]`).getAttribute(`aria-current`)).toBe(`page`)
   })
 
+  describe(`pinned dropdown feature`, () => {
+    // Helper to dispatch mouse events
+    const mouse_enter = (el: Element) =>
+      el.dispatchEvent(new MouseEvent(`mouseenter`, { bubbles: true }))
+    const mouse_leave = (el: Element) =>
+      el.dispatchEvent(new MouseEvent(`mouseleave`, { bubbles: true }))
+
+    test(`clicking arrow icon pins dropdown open`, async () => {
+      mount(Nav, {
+        target: document.body,
+        props: { routes: [[`/parent`, [`/parent`, `/parent/child`]]] },
+      })
+      const { dropdown, dropdown_menu } = get_dropdown_elements()
+      const toggle_button = dropdown.querySelector(
+        `[data-dropdown-toggle]`,
+      ) as HTMLElement
+
+      // Initially closed
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(false)
+
+      // Click to pin open
+      await click(toggle_button)
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+      expect(toggle_button.getAttribute(`aria-expanded`)).toBe(`true`)
+
+      // Click again to unpin and close
+      await click(toggle_button)
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(false)
+      expect(toggle_button.getAttribute(`aria-expanded`)).toBe(`false`)
+    })
+
+    test(`pinned dropdown stays open on mouse leave`, async () => {
+      mount(Nav, {
+        target: document.body,
+        props: { routes: [[`/parent`, [`/parent`, `/parent/child`]]] },
+      })
+      const { dropdown, dropdown_menu } = get_dropdown_elements()
+      const toggle_button = dropdown.querySelector(
+        `[data-dropdown-toggle]`,
+      ) as HTMLElement
+
+      // Click to pin
+      await click(toggle_button)
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      // Mouse leave should NOT close pinned dropdown
+      mouse_leave(dropdown)
+      await tick()
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      // Mouse leave on dropdown menu should also NOT close
+      mouse_leave(dropdown_menu)
+      await tick()
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+    })
+
+    test(`hover-opened dropdown closes on mouse leave (not pinned)`, async () => {
+      mount(Nav, {
+        target: document.body,
+        props: { routes: [[`/parent`, [`/parent`, `/parent/child`]]] },
+      })
+      const { dropdown, dropdown_menu } = get_dropdown_elements()
+
+      // Open via hover
+      mouse_enter(dropdown)
+      await tick()
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      // Mouse leave should close (not pinned)
+      mouse_leave(dropdown)
+      await tick()
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(false)
+    })
+
+    test.each([
+      [`click outside`, async () => {
+        const outside = document.createElement(`div`)
+        document.body.appendChild(outside)
+        outside.dispatchEvent(
+          new MouseEvent(`click`, { bubbles: true, cancelable: true }),
+        )
+        await tick()
+        outside.remove()
+      }],
+      [`child route click`, async (menu: HTMLElement) => {
+        await click(menu.querySelector(`a`) as HTMLElement)
+      }],
+      [`Escape key`, async () => {
+        globalThis.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape` }))
+        await tick()
+      }],
+    ])(`pinned dropdown closes on %s`, async (_trigger, close_action) => {
+      mount(Nav, {
+        target: document.body,
+        props: { routes: [[`/parent`, [`/parent`, `/parent/child`]]] },
+      })
+      const { dropdown_menu } = get_dropdown_elements()
+      await click(doc_query(`[data-dropdown-toggle]`))
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      await close_action(dropdown_menu)
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(false)
+    })
+
+    test(`hovering different dropdown closes pinned dropdown`, async () => {
+      mount(Nav, {
+        target: document.body,
+        props: {
+          routes: [
+            [`/first`, [`/first`, `/first/child`]],
+            [`/second`, [`/second`, `/second/child`]],
+          ],
+        },
+      })
+      const [dropdown1, dropdown2] = Array.from(document.querySelectorAll(`.dropdown`))
+      const menu1 = dropdown1.querySelector(`div:last-child`) as HTMLElement
+      const menu2 = dropdown2.querySelector(`div:last-child`) as HTMLElement
+      const toggle1 = dropdown1.querySelector(`[data-dropdown-toggle]`) as HTMLElement
+
+      // Pin first dropdown
+      await click(toggle1)
+      expect(menu1.classList.contains(`visible`)).toBe(true)
+      expect(menu2.classList.contains(`visible`)).toBe(false)
+
+      // Hover second dropdown - should close first (pinned) and open second
+      mouse_enter(dropdown2)
+      await tick()
+      expect(menu1.classList.contains(`visible`)).toBe(false)
+      expect(menu2.classList.contains(`visible`)).toBe(true)
+    })
+
+    test(`clicking to pin different dropdown closes first pinned dropdown`, async () => {
+      mount(Nav, {
+        target: document.body,
+        props: {
+          routes: [
+            [`/first`, [`/first`, `/first/child`]],
+            [`/second`, [`/second`, `/second/child`]],
+          ],
+        },
+      })
+      const [dropdown1, dropdown2] = Array.from(document.querySelectorAll(`.dropdown`))
+      const menu1 = dropdown1.querySelector(`div:last-child`) as HTMLElement
+      const menu2 = dropdown2.querySelector(`div:last-child`) as HTMLElement
+      const toggle1 = dropdown1.querySelector(`[data-dropdown-toggle]`) as HTMLElement
+      const toggle2 = dropdown2.querySelector(`[data-dropdown-toggle]`) as HTMLElement
+
+      // Pin first dropdown
+      await click(toggle1)
+      expect(menu1.classList.contains(`visible`)).toBe(true)
+      expect(menu2.classList.contains(`visible`)).toBe(false)
+
+      // Click to pin second dropdown - should close first and open second
+      await click(toggle2)
+      expect(menu1.classList.contains(`visible`)).toBe(false)
+      expect(menu2.classList.contains(`visible`)).toBe(true)
+    })
+
+    test.each([`Enter`, ` `, `ArrowDown`])(
+      `keyboard %s pins dropdown open`,
+      async (key) => {
+        mount(Nav, {
+          target: document.body,
+          props: { routes: [[`/parent`, [`/parent`, `/parent/child`]]] },
+        })
+        const { dropdown, dropdown_menu } = get_dropdown_elements()
+        const toggle_button = dropdown.querySelector(
+          `[data-dropdown-toggle]`,
+        ) as HTMLElement
+
+        toggle_button.dispatchEvent(new KeyboardEvent(`keydown`, { key, bubbles: true }))
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+        // Mouse leave should NOT close (pinned via keyboard)
+        mouse_leave(dropdown)
+        await tick()
+        expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+      },
+    )
+
+    test(`pinned dropdown stays open on focus out (closes via click outside)`, async () => {
+      mount(Nav, {
+        target: document.body,
+        props: { routes: [[`/parent`, [`/parent`, `/parent/child1`, `/parent/child2`]]] },
+      })
+      const { dropdown, dropdown_menu } = get_dropdown_elements()
+      const toggle_button = dropdown.querySelector(
+        `[data-dropdown-toggle]`,
+      ) as HTMLElement
+      const child_links = dropdown_menu.querySelectorAll(`a`)
+
+      await click(toggle_button)
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      // Focus within dropdown - stays open
+      dropdown.dispatchEvent(
+        new FocusEvent(`focusout`, { bubbles: true, relatedTarget: child_links[0] }),
+      )
+      await tick()
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      // Focus outside dropdown - still stays open (pinned closes via click_outside, not focusout)
+      const external = document.createElement(`button`)
+      document.body.appendChild(external)
+      dropdown.dispatchEvent(
+        new FocusEvent(`focusout`, { bubbles: true, relatedTarget: external }),
+      )
+      await tick()
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+      external.remove()
+    })
+
+    test(`aria-expanded reflects pinned state correctly`, async () => {
+      mount(Nav, {
+        target: document.body,
+        props: { routes: [[`/parent`, [`/parent`, `/parent/child`]]] },
+      })
+      const { dropdown, dropdown_menu } = get_dropdown_elements()
+      const toggle_button = dropdown.querySelector(
+        `[data-dropdown-toggle]`,
+      ) as HTMLElement
+
+      // Initially collapsed
+      expect(toggle_button.getAttribute(`aria-expanded`)).toBe(`false`)
+
+      // Pin open
+      await click(toggle_button)
+      expect(toggle_button.getAttribute(`aria-expanded`)).toBe(`true`)
+
+      // Mouse leave - should stay expanded (pinned)
+      mouse_leave(dropdown)
+      await tick()
+      expect(toggle_button.getAttribute(`aria-expanded`)).toBe(`true`)
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      // Unpin
+      await click(toggle_button)
+      expect(toggle_button.getAttribute(`aria-expanded`)).toBe(`false`)
+    })
+
+    test(`pinned state clears when burger menu closes`, async () => {
+      Object.defineProperty(globalThis, `innerWidth`, { value: 500, writable: true })
+      mount(Nav, {
+        target: document.body,
+        props: {
+          routes: [[`/parent`, [`/parent`, `/parent/child`]]],
+          breakpoint: 767,
+        },
+      })
+      await tick()
+
+      const burger_button = doc_query(`.burger`)
+      const { dropdown_menu } = get_dropdown_elements()
+      const toggle_button = doc_query(`[data-dropdown-toggle]`)
+
+      // Open burger menu
+      await click(burger_button)
+      expect(burger_button.getAttribute(`aria-expanded`)).toBe(`true`)
+
+      // Pin dropdown
+      await click(toggle_button)
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(true)
+
+      // Press Escape - should close both burger menu and dropdown
+      globalThis.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape` }))
+      await tick()
+      expect(burger_button.getAttribute(`aria-expanded`)).toBe(`false`)
+      expect(dropdown_menu.classList.contains(`visible`)).toBe(false)
+
+      Object.defineProperty(globalThis, `innerWidth`, { value: 1024, writable: true })
+    })
+  })
+
   // Regression tests: JSON.stringify crashes on BigInt, functions, circular refs
   describe(`non-serializable route properties`, () => {
     const circular_route: Record<string, unknown> = { href: `/circular` }


### PR DESCRIPTION
- Clicking a dropdown toggle now pins it open, persisting after mouse leave
- Pinned dropdowns close on click outside, Escape key, child route click, or re-toggle
- Hovering a different dropdown automatically closes any pinned dropdown
- Update keyboard, focus, and ARIA behavior for pinned and hover states
- Refine route grouping, labels, spacing, mobile padding, and active/open styling
- Add a rotating ChevronDown icon and border-left indicators for child routes
- Simplify `get_uuid` to use a counter fallback instead of complex getRandomValues
- Clean up FileDetails test assertions