### PR TITLE
Add selection history with undo/redo support

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,9 +6,6 @@ export default {
     port: 3005,
     reuseExistingServer: true,
   },
+  workers: 16,
   testDir: `tests/playwright`,
-  timeout: 15000, // 15s for CI environments
-  expect: {
-    timeout: 5000, // 5s for assertions
-  },
 } satisfies PlaywrightTestConfig

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -202,8 +202,7 @@
 
   // Platform detection for keyboard shortcuts (Mac uses Cmd, others use Ctrl)
   const is_mac = typeof navigator !== `undefined` &&
-    (navigator.userAgentData?.platform === `macOS` ||
-      /Mac|iPhone|iPad|iPod/.test(navigator.userAgent))
+    /Mac|iPhone|iPad|iPod/.test(navigator.userAgent)
   const mod_key = is_mac ? `meta` : `ctrl`
 
   // Default shortcuts
@@ -305,8 +304,8 @@
 
   // Track changes to selected via $effect (catches internal + external changes)
   $effect(() => {
-    // Disabled when falsy OR non-positive number (negative numbers would behave unexpectedly)
-    const history_disabled = !history || (typeof history === `number` && history <= 0)
+    // Disabled when max_history is 0 (handles false, 0, negative, non-finite inputs)
+    const history_disabled = !(max_history > 0)
     if (history_disabled) {
       // Clear history when disabled so re-enabling starts fresh
       history_stack = []
@@ -346,13 +345,13 @@
 
   // Derived canUndo/canRedo (update bindable props reactively)
   $effect(() => {
-    canUndo = !!history && !disabled && history_index > 0
-    canRedo = !!history && !disabled && history_index < history_stack.length - 1
+    canUndo = max_history > 0 && !disabled && history_index > 0
+    canRedo = max_history > 0 && !disabled && history_index < history_stack.length - 1
   })
 
   // Undo: restore previous state
   undo = () => {
-    if (!history || disabled || history_index <= 0) return false
+    if (max_history <= 0 || disabled || history_index <= 0) return false
     const previous = [...selected]
     history_index--
     selected = [...history_stack[history_index]]
@@ -363,7 +362,7 @@
 
   // Redo: restore next state
   redo = () => {
-    if (!history || disabled || history_index >= history_stack.length - 1) {
+    if (max_history <= 0 || disabled || history_index >= history_stack.length - 1) {
       return false
     }
     const previous = [...selected]

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -295,7 +295,11 @@
 
   // History tracking for undo/redo
   const max_history = $derived(
-    history === true ? 50 : typeof history === `number` ? history : 0,
+    history === true
+      ? 50
+      : typeof history === `number` && Number.isFinite(history)
+      ? Math.max(0, Math.floor(history))
+      : 0,
   )
   let history_stack = $state<Option[][]>([])
   let history_index = $state(-1) // -1 = no history yet

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -5,11 +5,10 @@
   import type { FocusEventHandler, KeyboardEventHandler } from 'svelte/elements'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
   import { highlight_matches } from './attachments'
-  import { get_uuid } from './utils'
   import CircleSpinner from './CircleSpinner.svelte'
   import Icon from './Icon.svelte'
   import type { GroupedOptions, KeyboardShortcuts, MultiSelectProps } from './types'
-  import { fuzzy_match, get_label, get_style, has_group, is_object } from './utils'
+  import * as utils from './utils'
   import Wiggle from './Wiggle.svelte'
 
   let {
@@ -27,12 +26,12 @@
     duplicateOptionMsg = `This option is already selected`,
     duplicates = false,
     keepSelectedInDropdown = false,
-    key = (opt) => `${get_label(opt)}`.toLowerCase(),
+    key = (opt) => `${utils.get_label(opt)}`.toLowerCase(),
     filterFunc = (opt, searchText) => {
       if (!searchText) return true
-      const label = `${get_label(opt)}`
+      const label = `${utils.get_label(opt)}`
       return fuzzy
-        ? fuzzy_match(searchText, label)
+        ? utils.fuzzy_match(searchText, label)
         : label.toLowerCase().includes(searchText.toLowerCase())
     },
     fuzzy = true,
@@ -165,7 +164,7 @@
 
   // Generate unique IDs for ARIA associations (combobox pattern)
   // Uses provided id prop or generates a random one using crypto API
-  const internal_id = $derived(id ?? `sms-${get_uuid().slice(0, 8)}`)
+  const internal_id = $derived(id ?? `sms-${utils.get_uuid().slice(0, 8)}`)
   const listbox_id = $derived(`${internal_id}-listbox`)
 
   // Parse shortcut string into modifier+key parts
@@ -203,15 +202,14 @@
 
   // Platform detection for keyboard shortcuts (Mac uses Cmd, others use Ctrl)
   const is_mac = typeof navigator !== `undefined` &&
-    // @ts-expect-error userAgentData not in all TS libs yet
     (navigator.userAgentData?.platform === `macOS` ||
       /Mac|iPhone|iPad|iPod/.test(navigator.userAgent))
   const mod_key = is_mac ? `meta` : `ctrl`
 
   // Default shortcuts
   const default_shortcuts: KeyboardShortcuts = {
-    select_all: `ctrl+a`,
-    clear_all: `ctrl+shift+a`,
+    select_all: `${mod_key}+a`,
+    clear_all: `${mod_key}+shift+a`,
     open: null,
     close: null,
     undo: `${mod_key}+z`,
@@ -303,11 +301,22 @@
   )
   let history_stack = $state<Option[][]>([])
   let history_index = $state(-1) // -1 = no history yet
-  let prev_selected: Option[] = [] // track previous value for change detection
+  let prev_selected: Option[] | null = null // null = uninitialized, sync on first run
 
   // Track changes to selected via $effect (catches internal + external changes)
   $effect(() => {
-    if (!history) {
+    // Disabled when falsy OR non-positive number (negative numbers would behave unexpectedly)
+    const history_disabled = !history || (typeof history === `number` && history <= 0)
+    if (history_disabled) {
+      // Clear history when disabled so re-enabling starts fresh
+      history_stack = []
+      history_index = -1
+      // Don't read `selected` here to avoid creating unnecessary reactive dependency
+      prev_selected = null
+      return
+    }
+    // Initialize prev_selected on first run to avoid phantom undo from [] → initial selection
+    if (prev_selected === null) {
       prev_selected = [...selected]
       return
     }
@@ -402,7 +411,7 @@
 
   // Cache selected keys and labels to avoid repeated .map() calls
   let selected_keys = $derived(selected.map(key))
-  let selected_labels = $derived(selected.map(get_label))
+  let selected_labels = $derived(selected.map(utils.get_label))
   // Sets for O(1) lookups (used in template, has_user_msg, group_header_state, batch operations)
   let selected_keys_set = $derived(new Set(selected_keys))
   let selected_labels_set = $derived(new Set(selected_labels))
@@ -411,7 +420,7 @@
   let disabled_option_keys = $derived(
     new Set(
       effective_options
-        .filter((opt) => is_object(opt) && opt.disabled)
+        .filter((opt) => utils.is_object(opt) && opt.disabled)
         .map(key),
     ),
   )
@@ -427,7 +436,7 @@
     const ungrouped: Option[] = []
 
     for (const opt of matchingOptions) {
-      if (has_group(opt)) {
+      if (utils.has_group(opt)) {
         const existing = groups_map.get(opt.group)
         if (existing) existing.push(opt)
         else groups_map.set(opt.group, [opt])
@@ -569,7 +578,7 @@
   function sort_selected(items: Option[]): Option[] {
     if (sortSelected === true) {
       return items.toSorted((op1, op2) =>
-        `${get_label(op1)}`.localeCompare(`${get_label(op2)}`)
+        `${utils.get_label(op1)}`.localeCompare(`${utils.get_label(op2)}`)
       )
     } else if (typeof sortSelected === `function`) {
       return items.toSorted(sortSelected)
@@ -637,9 +646,9 @@
   // Check if option matches search text (label or optionally group name)
   const matches_search = (opt: Option, search: string): boolean => {
     if (filterFunc(opt, search)) return true
-    if (searchMatchesGroups && search && has_group(opt)) {
+    if (searchMatchesGroups && search && utils.has_group(opt)) {
       return fuzzy
-        ? fuzzy_match(search, opt.group)
+        ? utils.fuzzy_match(search, opt.group)
         : opt.group.toLowerCase().includes(search.toLowerCase())
     }
     return false
@@ -763,7 +772,7 @@
 
       clear_validity()
       handle_dropdown_after_select(event)
-      last_action = { type: `add`, label: `${get_label(option_to_add)}` }
+      last_action = { type: `add`, label: `${utils.get_label(option_to_add)}` }
       onadd?.({ option: option_to_add })
       onchange?.({ option: option_to_add, type: `add` })
     }
@@ -799,7 +808,7 @@
 
     selected = selected.filter((_, remove_idx) => remove_idx !== idx)
     clear_validity()
-    last_action = { type: `remove`, label: `${get_label(option_removed)}` }
+    last_action = { type: `remove`, label: `${utils.get_label(option_removed)}` }
     onremove?.({ option: option_removed })
     onchange?.({ option: option_removed, type: `remove` })
   }
@@ -1399,7 +1408,7 @@
     style={ulSelectedStyle}
   >
     {#each selected as option, idx (duplicates ? `${key(option)}-${idx}` : key(option))}
-      {@const selectedOptionStyle = [get_style(option, `selected`), liSelectedStyle]
+      {@const selectedOptionStyle = [utils.get_style(option, `selected`), liSelectedStyle]
         .filter(Boolean)
         .join(` `) || null}
       <li
@@ -1423,16 +1432,16 @@
         {:else if children}
           {@render children({ option, idx })}
         {:else if parseLabelsAsHtml}
-          {@html get_label(option)}
+          {@html utils.get_label(option)}
         {:else}
-          {get_label(option)}
+          {utils.get_label(option)}
         {/if}
         {#if !disabled && can_remove}
           <button
             onclick={(event) => remove(option, event)}
             onkeydown={if_enter_or_space((event) => remove(option, event))}
             type="button"
-            title="{removeBtnTitle} {get_label(option)}"
+            title="{removeBtnTitle} {utils.get_label(option)}"
             class="remove"
           >
             {#if removeIcon}
@@ -1645,10 +1654,10 @@
         title = null,
         selectedTitle = null,
         disabledTitle = defaultDisabledTitle,
-      } = is_object(option_item) ? option_item : { label: option_item }}
+      } = utils.is_object(option_item) ? option_item : { label: option_item }}
             {@const active = activeIndex === flat_idx && flat_idx >= 0}
             {@const selected = is_selected(label)}
-            {@const optionStyle = [get_style(option_item, `option`), liOptionStyle]
+            {@const optionStyle = [utils.get_style(option_item, `option`), liOptionStyle]
         .filter(Boolean)
         .join(` `) || null}
             {#if is_option_visible(flat_idx)}
@@ -1680,7 +1689,7 @@
                     type="checkbox"
                     class="option-checkbox"
                     checked={selected}
-                    aria-label="Toggle {get_label(option_item)}"
+                    aria-label="Toggle {utils.get_label(option_item)}"
                     tabindex="-1"
                   />
                 {/if}
@@ -1689,9 +1698,9 @@
                 {:else if children}
                   {@render children({ option: option_item, idx: flat_idx })}
                 {:else if parseLabelsAsHtml}
-                  {@html get_label(option_item)}
+                  {@html utils.get_label(option_item)}
                 {:else}
-                  {get_label(option_item)}
+                  {utils.get_label(option_item)}
                 {/if}
               </li>
             {/if}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,6 +52,9 @@ export interface MultiSelectEvents<T extends Option = Option> {
   ) => unknown // fires when user tries to exceed maxSelect
   onduplicate?: (data: { option: T }) => unknown // fires when user tries to add duplicate (when duplicates=false)
   onactivate?: (data: { option: T | null; index: number | null }) => unknown // fires on keyboard navigation through options
+  // History/undo-redo events
+  onundo?: (data: { previous: T[]; current: T[] }) => unknown // fires when undo is triggered
+  onredo?: (data: { previous: T[]; current: T[] }) => unknown // fires when redo is triggered
 }
 
 // Dynamic options loading (https://github.com/janosh/svelte-multiselect/discussions/342)
@@ -223,6 +226,14 @@ export interface MultiSelectProps<T extends Option = Option>
   expandAllGroups?: () => void
   // Keyboard shortcuts for common actions
   shortcuts?: Partial<KeyboardShortcuts>
+  // Selection history for undo/redo support (enabled by default)
+  // true (default) = 50 max states, number = custom max, false/0 = disabled
+  // Note: need at least 2 states for undo (history=2 allows 1 undo, history=1 effectively disables)
+  history?: boolean | number
+  undo?: () => boolean // bindable method to undo last selection change
+  redo?: () => boolean // bindable method to redo last undone change
+  canUndo?: boolean // bindable read-only state for UI indicators
+  canRedo?: boolean // bindable read-only state for UI indicators
 }
 
 // Keyboard shortcuts for MultiSelect actions.
@@ -238,6 +249,8 @@ export interface KeyboardShortcuts {
   clear_all?: string | null // default: 'ctrl+shift+a'
   open?: string | null // default: null (use existing behavior)
   close?: string | null // default: null (Escape already works)
+  undo?: string | null // default: platform-aware (meta+z on Mac, ctrl+z elsewhere)
+  redo?: string | null // default: platform-aware (meta+shift+z on Mac, ctrl+shift+z elsewhere)
 }
 
 // Nav component types

--- a/src/routes/(demos)/history/+page.md
+++ b/src/routes/(demos)/history/+page.md
@@ -13,12 +13,16 @@ History tracking works out of the box with a default max of 50 entries. Pass a n
   import { colors } from '$site/options'
 
   let selected = $state([])
-  let undo
-  let redo
+  let undo = $state()
+  let redo = $state()
   let canUndo = $state(false)
   let canRedo = $state(false)
   let events = $state([])
-  const mod_key = navigator?.platform?.includes?.('Mac') ? 'Cmd' : 'Ctrl'
+  // Use same platform detection as component (userAgentData is modern API, userAgent is fallback)
+  const is_mac = typeof navigator !== 'undefined' &&
+    (navigator.userAgentData?.platform === 'macOS' ||
+      /Mac|iPhone|iPad|iPod/.test(navigator.userAgent))
+  const mod_key = is_mac ? 'Cmd' : 'Ctrl'
 
   function log_event(name, data) {
     events = [
@@ -140,11 +144,13 @@ History tracking works out of the box with a default max of 50 entries. Pass a n
     font-size: 0.9em;
   }
   .event-log {
-    background: light-dark(#f5f5f5, rgba(0, 0, 0, 0.3));
+    background: light-dark(#f0f7ff, rgba(66, 153, 225, 0.1));
     padding: 1em;
     border-radius: 8px;
     overflow-y: auto;
     align-self: start;
+    height: 100%;
+    box-sizing: border-box;
   }
   .event-log h4 {
     margin: 0 0 0.5em 0;

--- a/src/routes/(demos)/history/+page.md
+++ b/src/routes/(demos)/history/+page.md
@@ -49,7 +49,6 @@ History tracking works out of the box with a default max of 50 entries. Pass a n
 
     <MultiSelect
       options={colors}
-      history={true}
       placeholder="Select colors..."
       bind:selected
       bind:undo

--- a/src/routes/(demos)/history/+page.md
+++ b/src/routes/(demos)/history/+page.md
@@ -1,0 +1,220 @@
+## Selection History (Undo/Redo)
+
+Selection history is **enabled by default**, allowing users to undo and redo their selections with `Ctrl+Z` / `Cmd+Z` and `Ctrl+Shift+Z` / `Cmd+Shift+Z`. This is useful for complex selection workflows where users might want to revert changes.
+
+### Basic Usage
+
+History tracking works out of the box with a default max of 50 entries. Pass a number to customize the limit, or `false`/`0` to disable.
+
+```svelte example
+<script>
+  import MultiSelect from '$lib'
+  import { ColorSnippet } from '$site'
+  import { colors } from '$site/options'
+
+  let selected = $state([])
+  let undo
+  let redo
+  let canUndo = $state(false)
+  let canRedo = $state(false)
+  let events = $state([])
+  const mod_key = navigator?.platform?.includes?.('Mac') ? 'Cmd' : 'Ctrl'
+
+  function log_event(name, data) {
+    events = [
+      { name, data: JSON.stringify(data), time: new Date().toLocaleTimeString() },
+      ...events.slice(0, 4),
+    ]
+  }
+</script>
+
+<div class="demo-grid" id="history-demo">
+  <section class="controls" id="history-multiselect">
+    <p class="tip">
+      Use <kbd>{mod_key}+Z</kbd> to undo and <kbd>{mod_key}+Shift+Z</kbd> to redo.
+    </p>
+
+    <div class="button-group">
+      <button id="undo-btn" onclick={() => undo?.()} disabled={!canUndo}>
+        ↩ Undo
+      </button>
+      <button id="redo-btn" onclick={() => redo?.()} disabled={!canRedo}>
+        Redo ↪
+      </button>
+    </div>
+
+    <MultiSelect
+      options={colors}
+      history={true}
+      placeholder="Select colors..."
+      bind:selected
+      bind:undo
+      bind:redo
+      bind:canUndo
+      bind:canRedo
+      onundo={(data) => log_event('onundo', data)}
+      onredo={(data) => log_event('onredo', data)}
+    >
+      {#snippet children({ idx, option })}
+        <ColorSnippet {idx} {option} />
+      {/snippet}
+    </MultiSelect>
+
+    <p class="status">
+      <span id="selection-count">Selected: {selected.length} item{
+          selected.length !== 1 ? 's' : ''
+        }</span>
+      <span>canUndo: <strong id="can-undo-status">{canUndo}</strong></span>
+      <span>canRedo: <strong id="can-redo-status">{canRedo}</strong></span>
+    </p>
+  </section>
+
+  <section class="event-log" id="history-event-log">
+    <h4>Event Log</h4>
+    {#each events as entry}
+      <div class="log-entry">
+        <span class="event-name">{entry.name}</span>
+        <span class="time">{entry.time}</span>
+        <pre>{entry.data}</pre>
+      </div>
+    {:else}
+      <p class="no-events">Undo/redo events will appear here</p>
+    {/each}
+  </section>
+</div>
+
+<style>
+  .demo-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1em;
+    margin: 2em 0;
+  }
+  .controls {
+    background: light-dark(#f0f7ff, rgba(66, 153, 225, 0.1));
+    padding: 1.5em;
+    border-radius: 8px;
+    align-self: start;
+  }
+  .button-group {
+    display: flex;
+    gap: 0.5em;
+    margin-bottom: 1.5em;
+  }
+  .button-group button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3em;
+    padding: 0.2em 0.5em;
+    border: 1px solid light-dark(#ccc, #555);
+    background: light-dark(#fff, #333);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8em;
+  }
+  .button-group button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .button-group button:not(:disabled):hover {
+    background: light-dark(#f0f0f0, #444);
+  }
+  .tip {
+    font-size: 0.85em;
+    color: light-dark(#666, #999);
+    margin: 0 0 1em 0;
+  }
+  .status {
+    display: flex;
+    gap: 1em;
+    font-size: 0.85em;
+    color: light-dark(#666, #aaa);
+    margin-top: 1em;
+  }
+  kbd {
+    background: light-dark(#eee, #444);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 0.9em;
+  }
+  .event-log {
+    background: light-dark(#f5f5f5, rgba(0, 0, 0, 0.3));
+    padding: 1em;
+    border-radius: 8px;
+    overflow-y: auto;
+    align-self: start;
+  }
+  .event-log h4 {
+    margin: 0 0 0.5em 0;
+  }
+  .log-entry {
+    background: light-dark(#fff, rgba(255, 255, 255, 0.05));
+    padding: 0.5em;
+    border-radius: 4px;
+    margin-bottom: 0.5em;
+    font-size: 0.85em;
+  }
+  .event-name {
+    color: #4299e1;
+    font-weight: bold;
+  }
+  .time {
+    float: right;
+    color: light-dark(#999, #666);
+  }
+  .log-entry pre {
+    margin: 0.5em 0 0 0;
+    font-size: 0.9em;
+    background: light-dark(#eee, rgba(0, 0, 0, 0.3));
+    padding: 0.3em;
+    border-radius: 2px;
+  }
+  .no-events {
+    color: light-dark(#999, #666);
+    font-style: italic;
+    text-align: center;
+  }
+</style>
+```
+
+### Props Reference
+
+| Prop      | Type                | Default | Description                                                                                  |
+| --------- | ------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| `history` | `boolean \| number` | `true`  | Enable history (default). `true` = max 50 entries, number = custom limit, `false` = disabled |
+| `undo`    | `() => boolean`     | -       | Bindable function to undo last change. Returns `false` if nothing to undo                    |
+| `redo`    | `() => boolean`     | -       | Bindable function to redo last undone change. Returns `false` if nothing to redo             |
+| `canUndo` | `boolean`           | `false` | Bindable state indicating if undo is available                                               |
+| `canRedo` | `boolean`           | `false` | Bindable state indicating if redo is available                                               |
+
+### Events
+
+| Event    | Data                              | Description                  |
+| -------- | --------------------------------- | ---------------------------- |
+| `onundo` | `{ previous: T[], current: T[] }` | Fired after undo is executed |
+| `onredo` | `{ previous: T[], current: T[] }` | Fired after redo is executed |
+
+### Keyboard Shortcuts
+
+History supports platform-aware keyboard shortcuts:
+
+- **Mac**: `Cmd+Z` (undo), `Cmd+Shift+Z` (redo)
+- **Windows/Linux**: `Ctrl+Z` (undo), `Ctrl+Shift+Z` (redo)
+
+Custom shortcuts can be configured via the `shortcuts` prop:
+
+```svelte
+<MultiSelect
+  history={true}
+  shortcuts={{ undo: 'alt+z', redo: 'alt+shift+z' }}
+/>
+```
+
+### Implementation Notes
+
+- History tracks all changes to `selected`, including external prop updates
+- Taking a new action after undoing clears the redo stack (standard behavior)
+- Undo/redo are blocked when the component is `disabled`
+- History entries store full snapshots of the `selected` array

--- a/src/site/DemoNav.svelte
+++ b/src/site/DemoNav.svelte
@@ -23,6 +23,7 @@
         `/sort-selected`,
         `/keep-selected`,
         `/allow-user-options`,
+        `/history`,
       ],
     },
     {

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -1585,13 +1585,13 @@ test.describe(`history / undo-redo feature`, () => {
     const undo_btn = page.locator(`#undo-btn`)
     const selection_count = page.locator(`#selection-count`)
 
-    // Select 3 options
+    // Select 3 different options (clicking same option toggles it due to duplicates=false)
     await page.click(`#history-multiselect input[autocomplete]`)
-    for (let idx = 0; idx < 3; idx++) {
-      await page.locator(`#history-multiselect ul.options li`).first().click()
-      await page.waitForTimeout(100)
+    for (const expected_count of [1, 2, 3]) {
+      await page.locator(`#history-multiselect ul.options li`).nth(expected_count - 1)
+        .click()
+      await expect(selection_count).toContainText(`${expected_count} item`)
     }
-    await expect(selection_count).toContainText(`3 items`)
 
     // Undo 3 times
     for (const expected of [`2 items`, `1 item`, `0 items`]) {
@@ -1608,10 +1608,10 @@ test.describe(`history / undo-redo feature`, () => {
     const redo_btn = page.locator(`#redo-btn`)
     const input = page.locator(`#history-multiselect input[autocomplete]`)
 
-    // Select, then undo
+    // Select, then deselect (clicking same option toggles), then undo
     await input.click()
     await page.locator(`#history-multiselect ul.options li`).first().click()
-    await page.waitForTimeout(100)
+    await expect(undo_btn).toBeEnabled()
     await page.locator(`#history-multiselect ul.options li`).first().click()
     await undo_btn.click()
     await expect(redo_btn).toBeEnabled()
@@ -1693,11 +1693,11 @@ test.describe(`history / undo-redo feature`, () => {
     const undo_btn = page.locator(`#undo-btn`)
     const selection_count = page.locator(`#selection-count`)
 
-    // Select 2, remove via X button
+    // Select 2 different options (clicking same option toggles it due to duplicates=false)
     await page.click(`#history-multiselect input[autocomplete]`)
-    await page.locator(`#history-multiselect ul.options li`).first().click()
-    await page.waitForTimeout(100)
-    await page.locator(`#history-multiselect ul.options li`).first().click()
+    await page.locator(`#history-multiselect ul.options li`).nth(0).click()
+    await expect(selection_count).toContainText(`1 item`)
+    await page.locator(`#history-multiselect ul.options li`).nth(1).click()
     await expect(selection_count).toContainText(`2 items`)
 
     // Remove all
@@ -1716,14 +1716,15 @@ test.describe(`history / undo-redo feature`, () => {
     const selection_count = page.locator(`#selection-count`)
     const input = page.locator(`#history-multiselect input[autocomplete]`)
 
-    // Select, close, reopen, select again
+    // Select, close, reopen, select different option (clicking same toggles due to duplicates=false)
     await input.click()
-    await page.locator(`#history-multiselect ul.options li`).first().click()
+    await page.locator(`#history-multiselect ul.options li`).nth(0).click()
+    await expect(selection_count).toContainText(`1 item`)
     await page.click(`body`, { position: { x: 10, y: 10 } })
-    await page.waitForTimeout(100)
+    await expect(page.locator(`#history-multiselect ul.options`)).toBeHidden()
 
     await input.click()
-    await page.locator(`#history-multiselect ul.options li`).first().click()
+    await page.locator(`#history-multiselect ul.options li`).nth(1).click()
     await expect(selection_count).toContainText(`2 items`)
 
     // Undo still works

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -5009,3 +5009,318 @@ describe(`onactivate event`, () => {
     expect(onactivate_spy).toHaveBeenCalledTimes(1)
   })
 })
+
+describe(`history / undo-redo`, () => {
+  test(`history enabled by default - undo/redo bound without explicit history prop`, async () => {
+    let undo_fn: (() => boolean) | undefined
+    let redo_fn: (() => boolean) | undefined
+
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [1, 2, 3],
+        // Note: no history prop - should be enabled by default
+        get undo() {
+          return undo_fn
+        },
+        set undo(fn) {
+          undo_fn = fn
+        },
+        get redo() {
+          return redo_fn
+        },
+        set redo(fn) {
+          redo_fn = fn
+        },
+      },
+    })
+    await tick()
+
+    // History is enabled by default, so undo/redo should be functional
+    expect(undo_fn).toBeInstanceOf(Function)
+    expect(redo_fn).toBeInstanceOf(Function)
+  })
+
+  test(`undo/redo functions bound and canUndo/canRedo initially false`, async () => {
+    let undo_fn: (() => boolean) | undefined
+    let redo_fn: (() => boolean) | undefined
+    let can_undo = true
+    let can_redo = true
+
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [1, 2, 3],
+        history: true,
+        get undo() {
+          return undo_fn
+        },
+        set undo(fn) {
+          undo_fn = fn
+        },
+        get redo() {
+          return redo_fn
+        },
+        set redo(fn) {
+          redo_fn = fn
+        },
+        get canUndo() {
+          return can_undo
+        },
+        set canUndo(val) {
+          can_undo = val
+        },
+        get canRedo() {
+          return can_redo
+        },
+        set canRedo(val) {
+          can_redo = val
+        },
+      },
+    })
+    await tick()
+
+    expect(undo_fn).toBeInstanceOf(Function)
+    expect(redo_fn).toBeInstanceOf(Function)
+    expect(can_undo).toBe(false)
+    expect(can_redo).toBe(false)
+    expect(undo_fn?.()).toBe(false) // nothing to undo
+    expect(redo_fn?.()).toBe(false) // nothing to redo
+  })
+
+  test.each([`undo`, `redo`] as const)(
+    `%s returns false when disabled=true`,
+    async (method) => {
+      let fn: (() => boolean) | undefined
+      const props = {
+        options: [1, 2, 3],
+        history: true,
+        disabled: true,
+        get [method]() {
+          return fn
+        },
+        set [method](f: (() => boolean) | undefined) {
+          fn = f
+        },
+      }
+      mount(MultiSelect, { target: document.body, props })
+      await tick()
+      expect(fn?.()).toBe(false)
+    },
+  )
+
+  test.each([true, false, 0, 1, 50] as const)(
+    `history=%s accepts prop without error`,
+    async (history_val) => {
+      let undo_fn: (() => boolean) | undefined
+      mount(MultiSelect, {
+        target: document.body,
+        props: {
+          options: [1, 2, 3],
+          history: history_val,
+          get undo() {
+            return undo_fn
+          },
+          set undo(fn) {
+            undo_fn = fn
+          },
+        },
+      })
+      await tick()
+      expect(undo_fn).toBeInstanceOf(Function)
+      expect(undo_fn?.()).toBe(false)
+    },
+  )
+
+  test.each(
+    [
+      [`default`, {}, `z`, { ctrlKey: true }],
+      [`custom`, { shortcuts: { undo: `alt+u` } }, `u`, { altKey: true }],
+      [`null`, { shortcuts: { undo: null } }, `z`, { ctrlKey: true }],
+    ] as const,
+  )(`%s shortcuts don't throw`, async (_desc, extra, key, modifiers) => {
+    const props = $state<MultiSelectProps>({
+      options: [1, 2, 3],
+      history: true,
+      ...extra,
+    })
+    mount(MultiSelect, { target: document.body, props })
+    await tick()
+
+    const input = doc_query<HTMLInputElement>(`input`)
+    input.focus()
+    input.dispatchEvent(
+      new KeyboardEvent(`keydown`, { key, bubbles: true, ...modifiers }),
+    )
+    await tick()
+  })
+
+  test.each([`onundo`, `onredo`] as const)(
+    `%s callback prop accepted`,
+    async (event_name) => {
+      const spy = vi.fn()
+      mount(MultiSelect, {
+        target: document.body,
+        props: { options: [1, 2, 3], history: true, [event_name]: spy },
+      })
+      await tick()
+      expect(spy).not.toHaveBeenCalled()
+    },
+  )
+
+  test.each([
+    [`object options`, [{ label: `A`, value: 1 }, { label: `B`, value: 2 }], {}],
+    [`maxSelect=1`, [1, 2, 3], { maxSelect: 1 }],
+    [`preselected`, [{ label: `A`, preselected: true }, { label: `B` }], {}],
+    [`sortSelected`, [3, 1, 2], { sortSelected: true }],
+    [`duplicates`, [1, 2, 3], { duplicates: true }],
+    [`allowUserOptions`, [1, 2, 3], { allowUserOptions: true }],
+    [`minSelect`, [1, 2, 3], { minSelect: 1 }],
+    [`grouped`, [{ label: `A`, group: `G1` }, { label: `B`, group: `G2` }], {}],
+  ])(`compatible with %s`, async (_desc, options, extra) => {
+    let undo_fn: (() => boolean) | undefined
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options,
+        history: true,
+        get undo() {
+          return undo_fn
+        },
+        set undo(fn) {
+          undo_fn = fn
+        },
+        ...extra,
+      },
+    })
+    await tick()
+    expect(undo_fn).toBeInstanceOf(Function)
+  })
+
+  test(`history is isolated per component instance`, async () => {
+    let undo_1: (() => boolean) | undefined
+    let undo_2: (() => boolean) | undefined
+
+    const div1 = document.createElement(`div`)
+    const div2 = document.createElement(`div`)
+    document.body.append(div1, div2)
+
+    mount(MultiSelect, {
+      target: div1,
+      props: {
+        options: [1, 2],
+        history: true,
+        get undo() {
+          return undo_1
+        },
+        set undo(fn) {
+          undo_1 = fn
+        },
+      },
+    })
+    mount(MultiSelect, {
+      target: div2,
+      props: {
+        options: [`a`, `b`],
+        history: true,
+        get undo() {
+          return undo_2
+        },
+        set undo(fn) {
+          undo_2 = fn
+        },
+      },
+    })
+    await tick()
+
+    expect(undo_1).toBeDefined()
+    expect(undo_2).toBeDefined()
+    expect(undo_1).not.toBe(undo_2)
+
+    div1.remove()
+    div2.remove()
+  })
+
+  test(`undo restores previous selection state, redo restores undone state`, async () => {
+    let selected = $state<number[]>([])
+    let undo_fn: (() => boolean) | undefined
+    let redo_fn: (() => boolean) | undefined
+    let can_undo = false
+    let can_redo = false
+
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [1, 2, 3],
+        history: true,
+        get selected() {
+          return selected
+        },
+        set selected(val) {
+          selected = val
+        },
+        get undo() {
+          return undo_fn
+        },
+        set undo(fn) {
+          undo_fn = fn
+        },
+        get redo() {
+          return redo_fn
+        },
+        set redo(fn) {
+          redo_fn = fn
+        },
+        get canUndo() {
+          return can_undo
+        },
+        set canUndo(val) {
+          can_undo = val
+        },
+        get canRedo() {
+          return can_redo
+        },
+        set canRedo(val) {
+          can_redo = val
+        },
+      },
+    })
+    await tick()
+
+    // Initial state: empty selection, no undo/redo available
+    expect(selected).toEqual([])
+    expect(can_undo).toBe(false)
+    expect(can_redo).toBe(false)
+
+    // Select first option
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.focus()
+    await tick()
+    const first_option = doc_query(`ul.options li`)
+    first_option.click()
+    await tick()
+
+    expect(selected).toEqual([1])
+    expect(can_undo).toBe(true)
+    expect(can_redo).toBe(false)
+
+    // Undo should restore empty state
+    expect(undo_fn?.()).toBe(true)
+    await tick()
+    expect(selected).toEqual([])
+    expect(can_undo).toBe(false)
+    expect(can_redo).toBe(true)
+
+    // Calling undo again when nothing to undo should return false and not change state
+    expect(undo_fn?.()).toBe(false)
+    await tick()
+    expect(selected).toEqual([]) // state unchanged
+
+    // Redo should restore selection
+    expect(redo_fn?.()).toBe(true)
+    await tick()
+    expect(selected).toEqual([1])
+    expect(can_undo).toBe(true)
+    expect(can_redo).toBe(false)
+  })
+})


### PR DESCRIPTION
- **History enabled by default** - Works out of the box with `Ctrl+Z`/`Cmd+Z` (undo) and `Ctrl+Shift+Z`/`Cmd+Shift+Z` (redo)
- Configurable per instance via `history` prop: `true` (default, 50 max entries), number (custom limit), or `false`/`0` (disabled)
- Bindable `undo`/`redo` functions and `canUndo`/`canRedo` state for custom UI controls
- `onundo`/`onredo` events fire with `{ previous, current }` selection arrays
- Keyboard shortcuts are customizable

## New Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `history` | `boolean \| number` | `true` | Enable history. `true` = 50 max, number = custom, `false` = disabled |
| `undo` | `() => boolean` | - | Bindable function to undo last change |
| `redo` | `() => boolean` | - | Bindable function to redo last undone change |
| `canUndo` | `boolean` | `false` | Bindable state: is undo available? |
| `canRedo` | `boolean` | `false` | Bindable state: is redo available? |

## Demo

New `/history` demo page showcasing:
- Undo/redo buttons with disabled state
- Platform-aware keyboard shortcuts
- Event logging