### PR TITLE
Add tooltip shrink-to-fit algorithm and fix reactive content updates

### DIFF
--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -516,7 +516,7 @@
   }
   .menu > span > a {
     line-height: 1.3;
-    padding: var(--nav-item-padding);
+    padding: var(--nav-item-padding, 2pt 6pt);
     text-decoration: none;
     color: inherit;
   }
@@ -576,7 +576,7 @@
   }
   .dropdown > div:first-child > a, .dropdown > div:first-child > span {
     line-height: 1.3;
-    padding: var(--nav-item-padding);
+    padding: var(--nav-item-padding, 2pt 6pt);
     text-decoration: none;
     color: inherit;
     border-radius: var(--nav-border-radius) 0 0 var(--nav-border-radius);

--- a/src/routes/(demos)/attachments/+page.md
+++ b/src/routes/(demos)/attachments/+page.md
@@ -142,6 +142,39 @@ Exported from `svelte-multiselect/attachments`:
   </button>
 </div>
 
+<!-- Long word shrink-to-fit demo: tooltip contracts when long words cause early wrapping -->
+<div style="display: flex; gap: 1em; margin: 2em 0; flex-wrap: wrap">
+  <button
+    {@attach tooltip({
+      content: `Donaudampfschifffahrtsgesellschaftskapitän is a German compound word`,
+      placement: `top`,
+    })}
+  >
+    Long German word
+  </button>
+  <button
+    {@attach tooltip({
+      content: `pneumonoultramicroscopicsilicovolcanoconiosis is very long`,
+      placement: `bottom`,
+    })}
+  >
+    Medical term
+  </button>
+  <button
+    {@attach tooltip({
+      content: `supercalifragilisticexpialidocious sounds quite atrocious`,
+      placement: `right`,
+    })}
+  >
+    Mary Poppins
+  </button>
+  <button
+    {@attach tooltip({ content: `antidisestablishmentarianism`, placement: `left` })}
+  >
+    Single long word
+  </button>
+</div>
+
 <style>
   button {
     padding: 0.35em 0.7em;

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -597,14 +597,11 @@ test.describe(`multiselect`, () => {
     const active_after_synthetic_hover = await active_option.textContent()
     expect(active_after_synthetic_hover?.trim()).toBe(foods[2]) // Still Watermelon
 
-    // Now move mouse for real - dispatch mousemove on the target li (bubbles to ul,
-    // resetting ignore_hover), then dispatch mouseover on same li to activate it
+    // Move mouse for real - mousemove bubbles to ul (resets ignore_hover), then
+    // mouseover activates the option
     await page.evaluate(() => {
-      const all_lis = document.querySelectorAll(`#foods ul.options > li`)
-      const fifth_li = all_lis[4]
-      // Dispatch mousemove on the li (bubbles to ul, resets ignore_hover)
+      const fifth_li = document.querySelectorAll(`#foods ul.options > li`)[4]
       fifth_li?.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
-      // Then dispatch mouseover on the same li (activates it)
       fifth_li?.dispatchEvent(new MouseEvent(`mouseover`, { bubbles: true }))
     })
 

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -597,11 +597,12 @@ test.describe(`multiselect`, () => {
     const active_after_synthetic_hover = await active_option.textContent()
     expect(active_after_synthetic_hover?.trim()).toBe(foods[2]) // Still Watermelon
 
-    // Move mouse for real - mousemove bubbles to ul (resets ignore_hover), then
-    // mouseover activates the option
+    // Now move mouse for real - dispatch mousemove on ul.options (where the handler
+    // is attached) to reset ignore_hover, then mouseover on the target li
     await page.evaluate(() => {
+      const ul = document.querySelector(`#foods ul.options`)
       const fifth_li = document.querySelectorAll(`#foods ul.options > li`)[4]
-      fifth_li?.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
+      ul?.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
       fifth_li?.dispatchEvent(new MouseEvent(`mouseover`, { bubbles: true }))
     })
 

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -584,6 +584,9 @@ test.describe(`multiselect`, () => {
     const active_option = page.locator(`#foods ul.options > li.active`)
     await expect(active_option).toHaveText(foods[2]) // Watermelon
 
+    // Wait for any async scroll operations to complete from arrow navigation
+    await page.waitForTimeout(100)
+
     // Simulate scroll-triggered mouseover (no actual mouse movement)
     await page.evaluate(() => {
       const first_option = document.querySelector(`#foods ul.options > li`)
@@ -594,13 +597,14 @@ test.describe(`multiselect`, () => {
     const active_after_synthetic_hover = await active_option.textContent()
     expect(active_after_synthetic_hover?.trim()).toBe(foods[2]) // Still Watermelon
 
-    // Now move mouse for real - this should re-enable hover via mousemove on ul.options
+    // Now move mouse for real - dispatch mousemove on the target li (bubbles to ul,
+    // resetting ignore_hover), then dispatch mouseover on same li to activate it
     await page.evaluate(() => {
-      const ul = document.querySelector(`#foods ul.options`)
-      const fifth_li = document.querySelectorAll(`#foods ul.options > li`)[4]
-      // Dispatch mousemove on ul (resets ignore_hover)
-      ul?.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
-      // Then dispatch mouseover on the target li
+      const all_lis = document.querySelectorAll(`#foods ul.options > li`)
+      const fifth_li = all_lis[4]
+      // Dispatch mousemove on the li (bubbles to ul, resets ignore_hover)
+      fifth_li?.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
+      // Then dispatch mouseover on the same li (activates it)
       fifth_li?.dispatchEvent(new MouseEvent(`mouseover`, { bubbles: true }))
     })
 

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -208,19 +208,6 @@ describe(`tooltip`, () => {
       expect(element.hasAttribute(`data-original-title`)).toBe(false)
       expect(element.getAttribute(`title`)).toBe(`Disabled tooltip`)
     })
-
-    it.each([
-      [`invalid placement`, { placement: `invalid` }],
-      [`null options`, null],
-    ])(`should handle %s gracefully`, (_desc, options) => {
-      const element = create_element()
-      element.title = `test`
-      const factory = options === null
-        ? tooltip(undefined)
-        : tooltip(options as Parameters<typeof tooltip>[0])
-      factory(element)
-      expect(element.getAttribute(`data-original-title`)).toBe(`test`)
-    })
   })
 
   describe(`Child Element Handling`, () => {
@@ -628,9 +615,17 @@ describe(`click_outside`, () => {
     expect(listener).toHaveBeenCalled()
   })
 
-  it(`should clean up without throwing`, () => {
-    const cleanup = click_outside({})(create_element())
-    expect(() => cleanup?.()).not.toThrow()
+  it(`cleanup stops triggering callbacks`, () => {
+    const element = create_element()
+    const callback = vi.fn()
+    const cleanup = click_outside({ callback })(element)
+
+    dispatch_click(create_element())
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    cleanup?.()
+    dispatch_click(create_element())
+    expect(callback).toHaveBeenCalledTimes(1) // Still 1, not called again
   })
 })
 

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -523,6 +523,38 @@ describe(`tooltip`, () => {
       expect(tooltip_el).toBeTruthy()
       expect(tooltip_el.textContent).toBe(expected_text)
     })
+
+    it.each([
+      [`called and strips XSS`, true, `<script>xss</script>Safe`, 1, `Safe`],
+      [`skipped when allow_html: false`, false, `Plain`, 0, `Plain`],
+    ])(`sanitize_html %s`, (_desc, allow_html, title, call_count, expected_text) => {
+      const sanitizer = vi.fn((html: string) =>
+        html.replace(/<script[^>]*>.*?<\/script>/gi, ``)
+      )
+      const element = create_element()
+      element.title = title
+      mock_bounds(element)
+      setup_tooltip(element, { delay: 0, allow_html, sanitize_html: sanitizer })
+
+      trigger_tooltip(element)
+      expect(sanitizer).toHaveBeenCalledTimes(call_count)
+      const tooltip_el = document.querySelector(`.custom-tooltip`) as HTMLElement
+      expect(tooltip_el.textContent).toBe(expected_text)
+    })
+
+    it(`tooltip structure: .tooltip-content span and display: inline-block`, () => {
+      const element = create_element()
+      element.title = `Test`
+      mock_bounds(element)
+      setup_tooltip(element, { delay: 0 })
+
+      trigger_tooltip(element)
+      const tooltip_el = document.querySelector(`.custom-tooltip`) as HTMLElement
+      expect(tooltip_el.style.display).toBe(`inline-block`)
+      const content_span = tooltip_el.querySelector(`.tooltip-content`)
+      expect(content_span?.tagName).toBe(`SPAN`)
+      expect(content_span?.textContent).toBe(`Test`)
+    })
   })
 })
 


### PR DESCRIPTION
- Add shrink-to-fit algorithm that eliminates excess whitespace from `text-wrap: balance`
  - Single-line tooltips: set exact width and prevent wrapping
  - Multi-line tooltips: binary search for minimum width that doesn't add line breaks
- Fix reactive content update to target inner `.tooltip-content` span instead of overwriting entire tooltip (which destroyed arrow elements)
- Move positioning into `requestAnimationFrame` so centering uses final dimensions after width adjustment
- Add guard for detached tooltip in rAF callback (user moved away quickly)
- Add fallback values to `--nav-item-padding` CSS custom property in Nav.svelte
- Add an optional HTML sanitization hook for tooltip content

## Demo

Added long word shrink-to-fit examples on the attachments demo page showcasing behavior with German compound words, medical terms, and other long words.