### PR TITLE
Simplify syntax highlighting with starry-night common bundle

### DIFF
--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -516,7 +516,7 @@
   }
   .menu > span > a {
     line-height: 1.3;
-    padding: var(--nav-item-padding, 2pt 6pt);
+    padding: var(--nav-item-padding, 1pt 4pt);
     text-decoration: none;
     color: inherit;
   }
@@ -576,7 +576,7 @@
   }
   .dropdown > div:first-child > a, .dropdown > div:first-child > span {
     line-height: 1.3;
-    padding: var(--nav-item-padding, 2pt 6pt);
+    padding: var(--nav-item-padding, 1pt 4pt);
     text-decoration: none;
     color: inherit;
     border-radius: var(--nav-border-radius) 0 0 var(--nav-border-radius);

--- a/src/lib/live-examples/index.ts
+++ b/src/lib/live-examples/index.ts
@@ -1,6 +1,6 @@
 // Live examples - transforms ```svelte example code blocks into rendered components
 // with syntax highlighting and live preview
-export { starry_night_highlighter } from './highlighter.ts'
+export { hast_to_html, starry_night, starry_night_highlighter } from './highlighter.ts'
 export {
   default as mdsvex_transform,
   EXAMPLE_COMPONENT_PREFIX,

--- a/tests/vitest/live-examples/highlighter.test.ts
+++ b/tests/vitest/live-examples/highlighter.test.ts
@@ -1,27 +1,159 @@
 // Tests for starry-night syntax highlighter
-import { starry_night_highlighter } from '$lib/live-examples/highlighter'
+import {
+  hast_to_html,
+  starry_night,
+  starry_night_highlighter,
+} from '$lib/live-examples/highlighter'
 import { describe, expect, test } from 'vitest'
 
+describe(`starry_night.flagToScope`, () => {
+  test.each([
+    `svelte`,
+    `html`,
+    `css`,
+    `js`,
+    `ts`,
+    `json`,
+    `python`,
+    `rust`,
+    `go`,
+    `yaml`,
+    `sql`,
+  ])(
+    `resolves %s`,
+    (lang) => expect(starry_night.flagToScope(lang)).toBeDefined(),
+  )
+
+  test.each([
+    [`js`, `javascript`],
+    [`ts`, `typescript`],
+    [`py`, `python`],
+    [`rs`, `rust`],
+    [`rb`, `ruby`],
+    [`yml`, `yaml`],
+    [`md`, `markdown`],
+    [`sh`, `bash`],
+    [`golang`, `go`],
+    [`kt`, `kotlin`],
+    [`pl`, `perl`],
+    [`cs`, `csharp`],
+    [`c++`, `cpp`],
+    [`objective-c`, `objc`],
+    [`vb`, `vbnet`],
+    [`gql`, `graphql`],
+    [`make`, `makefile`],
+  ])(`%s aliases %s`, (alias, canonical) => {
+    expect(starry_night.flagToScope(alias)).toBe(starry_night.flagToScope(canonical))
+  })
+})
+
+describe(`hast_to_html`, () => {
+  test.each([
+    [{ type: `text` as const, value: `hello` }, `hello`],
+    [{ type: `text` as const, value: `<script>` }, `&lt;script&gt;`],
+    [{ type: `text` as const, value: `a & b` }, `a &amp; b`],
+    [{ type: `root` as const, children: [] }, ``],
+    [
+      {
+        type: `root` as const,
+        children: [
+          { type: `text` as const, value: `a` },
+          { type: `text` as const, value: `b` },
+        ],
+      },
+      `ab`,
+    ],
+  ])(`converts %j`, (node, expected) => {
+    expect(hast_to_html(node)).toBe(expected)
+  })
+
+  test.each(
+    [
+      [[`pl-k`], `const`, `<span class="pl-k">const</span>`],
+      [[`pl-k`, `pl-s`], `x`, `<span class="pl-k pl-s">x</span>`],
+      [undefined, `x`, `<span>x</span>`],
+    ] as const,
+  )(`element with className=%j`, (className, text, expected) => {
+    const node = {
+      type: `element` as const,
+      tagName: `span`,
+      properties: className ? { className: [...className] } : undefined,
+      children: [{ type: `text` as const, value: text }],
+    }
+    expect(hast_to_html(node)).toBe(expected)
+  })
+})
+
 describe(`starry_night_highlighter`, () => {
-  describe(`supported languages`, () => {
-    test.each([
-      [`svelte`, `<div>test</div>`],
-      [`html`, `<div>test</div>`],
-      [`ts`, `const x: number = 1`],
-      [`typescript`, `const x: number = 1`],
-      [`js`, `const x = 1`],
-      [`javascript`, `const x = 1`],
-      [`css`, `.class { color: red; }`],
-      [`json`, `{"key": "value"}`],
-      [`shell`, `echo "hello"`],
-      [`bash`, `echo "hello"`],
-      [`sh`, `echo "hello"`],
-    ])(`highlights %s code`, (lang, code) => {
-      const result = starry_night_highlighter(code, lang)
-      expect(result).toMatch(
-        new RegExp(`^<pre class="highlight highlight-${lang}"><code>.*</code></pre>$`),
-      )
-    })
+  // All supported languages in one test.each - covers web, shell, config, programming, etc.
+  test.each([
+    // Web
+    [`svelte`, `<div>test</div>`],
+    [`html`, `<div>test</div>`],
+    [`ts`, `const x: number = 1`],
+    [`typescript`, `const x: number = 1`],
+    [`js`, `const x = 1`],
+    [`javascript`, `const x = 1`],
+    [`css`, `.class { color: red; }`],
+    [`less`, `@color: red;`],
+    [`scss`, `$color: red;`],
+    [`json`, `{"key": "value"}`],
+    [`graphql`, `query { user { name } }`],
+    [`gql`, `query { user { name } }`],
+    [`xml`, `<root><child/></root>`],
+    [`svg`, `<svg><circle/></svg>`],
+    [`php`, `<?php echo "hi"; ?>`],
+    // Shell & config
+    [`shell`, `echo "hello"`],
+    [`bash`, `echo "hello"`],
+    [`sh`, `echo "hello"`],
+    [`yaml`, `key: value`],
+    [`yml`, `key: value`],
+    [`ini`, `[section]\nkey=value`],
+    [`makefile`, `all:\n\techo hi`],
+    [`make`, `all:\n\techo hi`],
+    // Programming languages
+    [`python`, `def foo(): pass`],
+    [`py`, `def foo(): pass`],
+    [`rust`, `fn main() {}`],
+    [`rs`, `fn main() {}`],
+    [`go`, `func main() {}`],
+    [`golang`, `func main() {}`],
+    [`java`, `class Foo {}`],
+    [`kotlin`, `fun main() {}`],
+    [`kt`, `fun main() {}`],
+    [`swift`, `func main() {}`],
+    [`ruby`, `def foo; end`],
+    [`rb`, `def foo; end`],
+    [`perl`, `print "hi";`],
+    [`pl`, `print "hi";`],
+    [`lua`, `print("hi")`],
+    [`r`, `print("hi")`],
+    [`sql`, `SELECT * FROM users`],
+    [`c`, `int main() {}`],
+    [`cpp`, `int main() {}`],
+    [`c++`, `int main() {}`],
+    [`cs`, `class Foo {}`],
+    [`csharp`, `class Foo {}`],
+    [`objc`, `@interface Foo`],
+    [`objective-c`, `@interface Foo`],
+    [`vb`, `Module Foo`],
+    [`vbnet`, `Module Foo`],
+    // Other
+    [`diff`, `+added\n-removed`],
+    [`markdown`, `# Hello`],
+    [`md`, `# Hello`],
+  ])(`highlights %s code`, (lang, code) => {
+    const result = starry_night_highlighter(code, lang)
+    const escaped_lang = lang.replace(/[+]/g, `\\$&`)
+    expect(result).toMatch(
+      new RegExp(
+        `^<pre class="highlight highlight-${escaped_lang}"><code>.*</code></pre>$`,
+        `s`,
+      ),
+    )
+    // Verify actual syntax highlighting produces spans (not just wrapper)
+    expect(result).toContain(`<span class="pl-`)
   })
 
   describe(`case-insensitive language matching`, () => {
@@ -36,19 +168,13 @@ describe(`starry_night_highlighter`, () => {
   })
 
   describe(`unsupported languages`, () => {
-    test.each([`yaml`, `rust`, `python`, `unknown`])(
-      `returns escaped code for unsupported lang: %s`,
+    test.each([`unknown`, `cobol`, `fortran`, null, undefined])(
+      `returns escaped code for lang=%s`,
       (lang) => {
         const result = starry_night_highlighter(`test`, lang)
         expect(result).toBe(`<pre class="highlight"><code>test</code></pre>`)
       },
     )
-
-    test(`returns escaped code when no lang provided`, () => {
-      expect(starry_night_highlighter(`test`)).toBe(
-        `<pre class="highlight"><code>test</code></pre>`,
-      )
-    })
   })
 
   describe(`escaping`, () => {

--- a/tests/vitest/live-examples/index.test.ts
+++ b/tests/vitest/live-examples/index.test.ts
@@ -2,7 +2,9 @@
 import {
   EXAMPLE_COMPONENT_PREFIX,
   EXAMPLE_MODULE_PREFIX,
+  hast_to_html,
   mdsvex_transform,
+  starry_night,
   starry_night_highlighter,
   sveltePreprocess,
   vite_plugin,
@@ -28,6 +30,9 @@ describe(`module exports`, () => {
     expect(typeof vite_plugin).toBe(`function`)
     expect(typeof sveltePreprocess).toBe(`function`)
     expect(typeof starry_night_highlighter).toBe(`function`)
+    expect(typeof hast_to_html).toBe(`function`)
+    expect(typeof starry_night.flagToScope).toBe(`function`)
+    expect(starry_night.flagToScope(`svelte`)).toBe(`source.svelte`)
     expect(EXAMPLE_MODULE_PREFIX).toBe(`___live_example___`)
     expect(EXAMPLE_COMPONENT_PREFIX).toBe(`LiveExample___`)
   })

--- a/tests/vitest/live-examples/mdsvex-transform.test.ts
+++ b/tests/vitest/live-examples/mdsvex-transform.test.ts
@@ -3,8 +3,8 @@ import remark, {
   EXAMPLE_COMPONENT_PREFIX,
   EXAMPLE_MODULE_PREFIX,
 } from '$lib/live-examples/mdsvex-transform'
-import { describe, expect, test } from 'vitest'
 import { Buffer } from 'node:buffer'
+import { describe, expect, test } from 'vitest'
 
 // Minimal types for testing
 interface TestNode {
@@ -90,9 +90,9 @@ describe(`code block detection`, () => {
   )
 
   test(`ignores unsupported languages even with example meta`, () => {
-    const tree = create_tree([create_code_node(`python`, `print("hello")`, `example`)])
+    const tree = create_tree([create_code_node(`cobol`, `DISPLAY "hello"`, `example`)])
     remark()(tree, create_file())
-    expect(tree.children[0]).toMatchObject({ type: `code`, lang: `python` })
+    expect(tree.children[0]).toMatchObject({ type: `code`, lang: `cobol` })
   })
 })
 


### PR DESCRIPTION
- Use starry-night's `common` bundle (34 grammars) + Svelte instead of 7 individual imports
- Use built-in `flagToScope()` for language resolution instead of manual lookup table
- Export `starry_night` instance and `hast_to_html` for downstream use
- Reduce nav item vertical padding (2pt 6pt → 1pt 4pt)

## Why

The grammars are build-time only dependencies (used by mdsvex during Vite build), so there's no runtime cost. Using the `common` bundle gives users syntax highlighting for popular languages out of the box with zero configuration.

Using `flagToScope()` eliminates the need to maintain a manual language-to-scope mapping—starry-night already handles all aliases internally.