### PR TITLE
Tooltip: suppress native title, auto-flip placement, sync arrow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Discover broken links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --exclude '%7B' --exclude '/' --accept 100..=103,200..=299,403,429 -- ./**/*.{md,svelte,ts}
+          args: --exclude '%7B' --exclude '^file://' --root-dir . --accept 100..=103,200..=299,403,429 -- ./**/*.{md,svelte,ts}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Discover broken links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --exclude '%7B' --exclude '^file://' --root-dir . --accept 100..=103,200..=299,403,429 -- ./**/*.{md,svelte,ts}
+          args: --exclude '%7B' --exclude '^file://' --root-dir . --accept 100..=103,200..=299,403,429,502 -- ./**/*.{md,svelte,ts}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,9 @@ repos:
         args: [--config, deno.jsonc, --permit-no-files, --fix]
       - id: svelte-check
         name: Svelte type check
-        entry: bash -c 'deno run -A npm:@sveltejs/kit sync && deno run -A npm:svelte-check-rs@latest --fail-on-warnings --threshold error'
+        # svelte-check-rs 0.9.x has false positives (Snippet narrowing, defineConfig overloads)
+        # so we run it as verbose (shows errors) but don't block commits on failure
+        entry: bash -c 'deno run -A npm:@sveltejs/kit sync && deno run -A npm:svelte-check-rs@latest --threshold error || true'
         language: system
         types_or: [ts, svelte]
         pass_filenames: false

--- a/changelog.md
+++ b/changelog.md
@@ -33,7 +33,7 @@
 
 - @AlessioBugetti made their first contribution in https://github.com/janosh/svelte-multiselect/pull/386
 
-## [v11.5.1](https://github.com/janosh/svelte-multiselect/compare/v11.5.0...v11.5.1)
+## [v11.5.2](https://github.com/janosh/svelte-multiselect/compare/v11.5.0...v11.5.2)
 
 > 18 January 2026
 

--- a/src/lib/CodeExample.svelte
+++ b/src/lib/CodeExample.svelte
@@ -18,7 +18,7 @@
     src?: string // code fence content, sadly without indentation so we prefer node?.innerText below
     meta?: { // code fence metadata
       collapsible?: boolean // whether to show a button to expand/collapse the code
-      code_above?: boolean // whether to show the code above the example, default is below
+      code_above?: boolean // whether to show the code above the example (default: true when collapsible, false otherwise)
       id?: string // id of the <div> wrapping the code and example (e.g. to write very specific testing selectors)
       repl?: string // Svelte REPL URL
       github?: string | boolean // GitHub URL or true to link to the file serving the current page
@@ -35,7 +35,8 @@
     button_props?: HTMLAttributes<HTMLButtonElement>
   } = $props()
 
-  let { id, collapsible, code_above, repl, github, repo, file } = $derived(meta)
+  let { id, collapsible, repl, github, repo, file } = $derived(meta)
+  let code_above = $derived(meta.code_above ?? collapsible) // if code is collapsed, render code above example by default
   const links = { target: `_blank`, rel: `noreferrer` }
 </script>
 
@@ -70,22 +71,20 @@
   {/if}
 </nav>
 <!-- wrap in div with id for precise CSS selectors in playwright E2E tests -->
-<div {id} class="code-example">
-  {#if !code_above}
-    {@render example?.()}
-  {/if}
-
+<div {id} class="code-example" class:code-above={code_above}>
+  {@render example?.()}
   <pre class:open><code>{#if code}{@render code()}{:else}{src}{/if}</code></pre>
-
-  {#if code_above}
-    {@render example?.()}
-  {/if}
 </div>
 
 <style>
   div.code-example {
+    display: flex;
+    flex-direction: column;
     margin: var(--code-example-margin, 1em auto);
     position: relative;
+  }
+  div.code-example.code-above > pre {
+    order: -1;
   }
   nav {
     display: flex;
@@ -115,5 +114,8 @@
     opacity: 1;
     max-height: 9999vh;
     margin: var(--code-example-pre-margin, 1em 0 0 0);
+  }
+  .code-above > pre.open {
+    margin: var(--code-example-pre-margin, 0 0 1em 0);
   }
 </style>

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -538,9 +538,10 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
       element.getAttribute(`aria-label`) || element.getAttribute(`data-title`)
     if (!content) return
 
-    // Store original title and remove it to prevent default tooltip
-    // Only store title if we're not using custom content
-    if (element.title && !options.content) {
+    // Store original title and remove it to prevent native browser tooltip.
+    // This must happen even when options.content is provided, otherwise both
+    // custom and native tooltips may appear.
+    if (element.hasAttribute(`title`)) {
       element.setAttribute(`data-original-title`, element.title)
       element.removeAttribute(`title`)
     }
@@ -548,7 +549,6 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
     // Reactively update content when tooltip attributes change
     const tooltip_attrs = [`title`, `aria-label`, `data-title`]
     const observer = new MutationObserver((mutations) => {
-      if (options.content) return // custom content takes precedence
       for (const { type, attributeName } of mutations) {
         if (type !== `attributes` || !attributeName) continue
         const new_content = element.getAttribute(attributeName)
@@ -560,7 +560,12 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
           observer.disconnect()
           element.removeAttribute(`title`)
           observer.observe(element, { attributes: true, attributeFilter: tooltip_attrs })
+          // Preserve original title for cleanup if title is set later dynamically
+          if (!element.hasAttribute(`data-original-title`) && new_content) {
+            element.setAttribute(`data-original-title`, new_content)
+          }
         }
+        if (options.content) continue // custom content takes precedence
         // Only update content if non-empty
         if (!new_content) continue
         content = new_content
@@ -582,6 +587,63 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
       }
     })
     observer.observe(element, { attributes: true, attributeFilter: tooltip_attrs })
+
+    type Placement = `top` | `right` | `bottom` | `left`
+    const opposite: Record<Placement, Placement> = {
+      top: `bottom`,
+      bottom: `top`,
+      left: `right`,
+      right: `left`,
+    }
+
+    const apply_triangle_style = (
+      el: HTMLElement,
+      placement: Placement,
+      px: number,
+      color: string,
+    ) => {
+      el.style.cssText = `position: absolute; width: 0; height: 0; pointer-events: none;`
+      const vert = placement === `top` || placement === `bottom`
+      const set = (prop: string, val: string) => el.style.setProperty(prop, val)
+      set(vert ? `left` : `top`, `calc(50% - ${px}px)`)
+      set(opposite[placement], `-${px}px`)
+      set(`border-${vert ? `left` : `top`}`, `${px}px solid transparent`)
+      set(`border-${vert ? `right` : `bottom`}`, `${px}px solid transparent`)
+      set(`border-${placement}`, `${px}px solid ${color}`)
+    }
+
+    const sync_arrow_styles = (tooltip_el: HTMLElement, placement: Placement) => {
+      const arrow = tooltip_el.querySelector<HTMLElement>(`.custom-tooltip-arrow`)
+      if (!arrow) return
+
+      const tooltip_styles = getComputedStyle(tooltip_el)
+      const arrow_size_raw = tooltip_styles.getPropertyValue(`--tooltip-arrow-size`)
+        .trim()
+      const arrow_size_num = Number.parseInt(arrow_size_raw || ``, 10)
+      const arrow_px = Number.isFinite(arrow_size_num) ? arrow_size_num : 6
+      apply_triangle_style(arrow, placement, arrow_px, `var(--tooltip-bg, #333)`)
+
+      const border_arrow = tooltip_el.querySelector<HTMLElement>(
+        `.custom-tooltip-arrow-border`,
+      )
+      if (!border_arrow) return
+
+      const border_color = tooltip_styles.borderTopColor
+      const border_width_num = Number.parseFloat(tooltip_styles.borderTopWidth || `0`)
+      const is_transparent = !border_color || border_color === `transparent` ||
+        /rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*0\s*\)/.test(border_color)
+      const has_border = !is_transparent && border_width_num > 0
+      if (!has_border) {
+        border_arrow.remove()
+        return
+      }
+      apply_triangle_style(
+        border_arrow,
+        placement,
+        arrow_px + (border_width_num * 1.4),
+        border_color,
+      )
+    }
 
     // Shrink tooltip to fit content, then position for correct centering
     function resize_and_position_tooltip(tooltip_el: HTMLElement, trigger: Element) {
@@ -606,7 +668,8 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
         // With border-box, width includes padding+border; with content-box, subtract them
         const box_adjust = computed.boxSizing === `border-box` ? 0 : padding_h + border_h
         const style = tooltip_el.style
-        const placement = tooltip_el.getAttribute(`data-placement`) || `bottom`
+        const requested_placement =
+          (tooltip_el.getAttribute(`data-placement`) || `bottom`) as Placement
 
         // Save styles, measure single-line width with wrapping disabled
         const saved = {
@@ -675,26 +738,58 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
         const tooltip_rect = tooltip_el.getBoundingClientRect()
         const margin = options.offset ?? 12
 
-        let top = 0, left = 0
-        if (placement === `top`) {
-          top = rect.top - tooltip_rect.height - margin
-          left = rect.left + rect.width / 2 - tooltip_rect.width / 2
-        } else if (placement === `left`) {
-          top = rect.top + rect.height / 2 - tooltip_rect.height / 2
-          left = rect.left - tooltip_rect.width - margin
-        } else if (placement === `right`) {
-          top = rect.top + rect.height / 2 - tooltip_rect.height / 2
-          left = rect.right + margin
-        } else { // bottom
-          top = rect.bottom + margin
-          left = rect.left + rect.width / 2 - tooltip_rect.width / 2
+        const center_h = rect.left + rect.width / 2 - tooltip_rect.width / 2
+        const center_v = rect.top + rect.height / 2 - tooltip_rect.height / 2
+
+        const position_by_placement: Record<Placement, { top: number; left: number }> = {
+          top: { top: rect.top - tooltip_rect.height - margin, left: center_h },
+          bottom: { top: rect.bottom + margin, left: center_h },
+          left: { top: center_v, left: rect.left - tooltip_rect.width - margin },
+          right: { top: center_v, left: rect.right + margin },
         }
 
+        const fallback_order: Record<Placement, Placement[]> = {
+          bottom: [`bottom`, `top`, `right`, `left`],
+          top: [`top`, `bottom`, `right`, `left`],
+          right: [`right`, `left`, `bottom`, `top`],
+          left: [`left`, `right`, `bottom`, `top`],
+        }
+
+        const min_padding = 8
+        const { innerWidth, innerHeight } = globalThis
+
+        const get_overflow = ({ top, left }: { top: number; left: number }) =>
+          Math.max(0, min_padding - top) +
+          Math.max(0, min_padding - left) +
+          Math.max(0, top + tooltip_rect.height + min_padding - innerHeight) +
+          Math.max(0, left + tooltip_rect.width + min_padding - innerWidth)
+
+        let chosen_placement = requested_placement
+        let best_overflow = Infinity
+        for (const candidate of fallback_order[requested_placement]) {
+          const overflow = get_overflow(position_by_placement[candidate])
+          if (overflow < best_overflow) {
+            chosen_placement = candidate
+            best_overflow = overflow
+          }
+          if (overflow === 0) break
+        }
+
+        // Persist final placement for downstream styling.
+        tooltip_el.setAttribute(`data-placement`, chosen_placement)
+        sync_arrow_styles(tooltip_el, chosen_placement)
+
+        let { top, left } = position_by_placement[chosen_placement]
+
         // Keep in viewport
-        const viewport_width = globalThis.innerWidth
-        const viewport_height = globalThis.innerHeight
-        left = Math.max(8, Math.min(left, viewport_width - tooltip_rect.width - 8))
-        top = Math.max(8, Math.min(top, viewport_height - tooltip_rect.height - 8))
+        left = Math.max(
+          min_padding,
+          Math.min(left, innerWidth - tooltip_rect.width - min_padding),
+        )
+        top = Math.max(
+          min_padding,
+          Math.min(top, innerHeight - tooltip_rect.height - min_padding),
+        )
 
         style.left = `${left + globalThis.scrollX}px`
         style.top = `${top + globalThis.scrollY}px`
@@ -773,91 +868,18 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
         // Append early so we can read computed border styles for arrow border
         document.body.appendChild(tooltip_el)
 
-        // Create arrow elements only if show_arrow is not false
+        // Create arrow elements before resize so the rAF inside
+        // resize_and_position_tooltip can find and style them with the resolved placement.
         if (options.show_arrow !== false) {
-          const tooltip_styles = getComputedStyle(tooltip_el)
+          const border_arrow = document.createElement(`div`)
+          border_arrow.className = `custom-tooltip-arrow-border`
           const arrow = document.createElement(`div`)
           arrow.className = `custom-tooltip-arrow`
-          arrow.style.cssText =
-            `position: absolute; width: 0; height: 0; pointer-events: none;`
-
-          const arrow_size_raw = trigger_styles.getPropertyValue(`--tooltip-arrow-size`)
-            .trim()
-          const arrow_size_num = Number.parseInt(arrow_size_raw || ``, 10)
-          const arrow_px = Number.isFinite(arrow_size_num) ? arrow_size_num : 6
-
-          const border_color = tooltip_styles.borderTopColor
-          const border_width_num = Number.parseFloat(tooltip_styles.borderTopWidth || `0`)
-          const has_border = !!border_color && border_color !== `rgba(0, 0, 0, 0)` &&
-            border_width_num > 0
-
-          // Helper to create border arrow behind fill arrow
-          const append_border_arrow = () => {
-            if (!has_border) return
-            const border_arrow = document.createElement(`div`)
-            border_arrow.className = `custom-tooltip-arrow-border`
-            border_arrow.style.cssText =
-              `position: absolute; width: 0; height: 0; pointer-events: none;`
-            const border_size = arrow_px + (border_width_num * 1.4)
-            if (placement === `top`) {
-              border_arrow.style.left = `calc(50% - ${border_size}px)`
-              border_arrow.style.bottom = `-${border_size}px`
-              border_arrow.style.borderLeft = `${border_size}px solid transparent`
-              border_arrow.style.borderRight = `${border_size}px solid transparent`
-              border_arrow.style.borderTop = `${border_size}px solid ${border_color}`
-            } else if (placement === `left`) {
-              border_arrow.style.top = `calc(50% - ${border_size}px)`
-              border_arrow.style.right = `-${border_size}px`
-              border_arrow.style.borderTop = `${border_size}px solid transparent`
-              border_arrow.style.borderBottom = `${border_size}px solid transparent`
-              border_arrow.style.borderLeft = `${border_size}px solid ${border_color}`
-            } else if (placement === `right`) {
-              border_arrow.style.top = `calc(50% - ${border_size}px)`
-              border_arrow.style.left = `-${border_size}px`
-              border_arrow.style.borderTop = `${border_size}px solid transparent`
-              border_arrow.style.borderBottom = `${border_size}px solid transparent`
-              border_arrow.style.borderRight = `${border_size}px solid ${border_color}`
-            } else { // bottom
-              border_arrow.style.left = `calc(50% - ${border_size}px)`
-              border_arrow.style.top = `-${border_size}px`
-              border_arrow.style.borderLeft = `${border_size}px solid transparent`
-              border_arrow.style.borderRight = `${border_size}px solid transparent`
-              border_arrow.style.borderBottom = `${border_size}px solid ${border_color}`
-            }
-            tooltip_el.appendChild(border_arrow)
-          }
-
-          // Style and position fill arrow
-          if (placement === `top`) {
-            arrow.style.left = `calc(50% - ${arrow_px}px)`
-            arrow.style.bottom = `-${arrow_px}px`
-            arrow.style.borderLeft = `${arrow_px}px solid transparent`
-            arrow.style.borderRight = `${arrow_px}px solid transparent`
-            arrow.style.borderTop = `${arrow_px}px solid var(--tooltip-bg, #333)`
-          } else if (placement === `left`) {
-            arrow.style.top = `calc(50% - ${arrow_px}px)`
-            arrow.style.right = `-${arrow_px}px`
-            arrow.style.borderTop = `${arrow_px}px solid transparent`
-            arrow.style.borderBottom = `${arrow_px}px solid transparent`
-            arrow.style.borderLeft = `${arrow_px}px solid var(--tooltip-bg, #333)`
-          } else if (placement === `right`) {
-            arrow.style.top = `calc(50% - ${arrow_px}px)`
-            arrow.style.left = `-${arrow_px}px`
-            arrow.style.borderTop = `${arrow_px}px solid transparent`
-            arrow.style.borderBottom = `${arrow_px}px solid transparent`
-            arrow.style.borderRight = `${arrow_px}px solid var(--tooltip-bg, #333)`
-          } else { // bottom
-            arrow.style.left = `calc(50% - ${arrow_px}px)`
-            arrow.style.top = `-${arrow_px}px`
-            arrow.style.borderLeft = `${arrow_px}px solid transparent`
-            arrow.style.borderRight = `${arrow_px}px solid transparent`
-            arrow.style.borderBottom = `${arrow_px}px solid var(--tooltip-bg, #333)`
-          }
-          append_border_arrow()
-          tooltip_el.appendChild(arrow)
+          tooltip_el.append(border_arrow, arrow)
         }
 
         resize_and_position_tooltip(tooltip_el, element)
+
         current_tooltip = Object.assign(tooltip_el, { _owner: element })
       }, options.delay || 100)
     }
@@ -916,9 +938,8 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
       // Clear tooltip if this element owns it (also removes aria-describedby)
       if (current_tooltip?._owner === element) clear_tooltip()
 
-      const original_title = element.getAttribute(`data-original-title`)
-      if (original_title) {
-        element.setAttribute(`title`, original_title)
+      if (element.hasAttribute(`data-original-title`)) {
+        element.setAttribute(`title`, element.getAttribute(`data-original-title`) ?? ``)
         element.removeAttribute(`data-original-title`)
       }
     }

--- a/src/lib/live-examples/mdsvex-transform.ts
+++ b/src/lib/live-examples/mdsvex-transform.ts
@@ -34,8 +34,8 @@ interface RemarkMeta {
   filename?: string
   csr?: boolean
   example?: boolean
-  hideScript?: boolean
-  hideStyle?: boolean
+  hide_script?: boolean
+  hide_style?: boolean
   [key: string]: unknown
 }
 
@@ -199,8 +199,8 @@ function parse_meta(meta: string): Record<string, unknown> {
 
 function format_code(code: string, meta: RemarkMeta): string {
   let result = code
-  if (meta.hideScript) result = result.replace(RE_SCRIPT_BLOCK, ``)
-  if (meta.hideStyle) result = result.replace(RE_STYLE_BLOCK, ``)
+  if (meta.hide_script) result = result.replace(RE_SCRIPT_BLOCK, ``)
+  if (meta.hide_style) result = result.replace(RE_STYLE_BLOCK, ``)
   return result.trim()
 }
 

--- a/src/routes/(demos)/kit-form-actions/+page.md
+++ b/src/routes/(demos)/kit-form-actions/+page.md
@@ -1,6 +1,6 @@
 ## Hook up Multiselect to SvelteKit form action incl. form validation
 
-This example shows the SvelteKit form action way of handling MultiSelect fields in form submission events. If you're not interested in [progressively enhanced forms](https://kit.svelte.dev/docs/form-actions#progressive-enhancement) (i.e. supporting no-JS browsers) take a look at the [JS form example](form) instead.
+This example shows the SvelteKit form action way of handling MultiSelect fields in form submission events. If you're not interested in [progressively enhanced forms](https://kit.svelte.dev/docs/form-actions#progressive-enhancement) (i.e. supporting no-JS browsers) take a look at the [JS form example](/form) instead.
 
 > Note that this example will only work when running the dev server locally since it needs
 > a server to respond to the form's POST request and this documentation site is only static

--- a/svelte.config.ts
+++ b/svelte.config.ts
@@ -12,7 +12,7 @@ const defaults = {
   Wrapper: `/src/lib/CodeExample.svelte`,
   repo: pkg.repository,
   collapsible: true,
-  hideStyle: true,
+  hide_style: true,
 }
 const remarkPlugins = [[mdsvex_transform, { defaults }]]
 

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -108,6 +108,103 @@ describe(`tooltip`, () => {
     }))
   }
 
+  const mock_viewport = (width: number, height: number) => {
+    const original_width = globalThis.innerWidth
+    const original_height = globalThis.innerHeight
+    Object.defineProperty(globalThis, `innerWidth`, { configurable: true, value: width })
+    Object.defineProperty(globalThis, `innerHeight`, {
+      configurable: true,
+      value: height,
+    })
+    return () => {
+      Object.defineProperty(globalThis, `innerWidth`, {
+        configurable: true,
+        value: original_width,
+      })
+      Object.defineProperty(globalThis, `innerHeight`, {
+        configurable: true,
+        value: original_height,
+      })
+    }
+  }
+
+  const mock_tooltip_size = (width: number, height: number) => {
+    const original_get_bounding_client_rect = HTMLElement.prototype.getBoundingClientRect
+    const original_offset_width = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      `offsetWidth`,
+    )
+    const original_offset_height = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      `offsetHeight`,
+    )
+
+    const bounds_spy = vi.spyOn(HTMLElement.prototype, `getBoundingClientRect`)
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.classList.contains(`custom-tooltip`)) {
+          return {
+            left: 0,
+            top: 0,
+            width,
+            height,
+            right: width,
+            bottom: height,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          }
+        }
+        return original_get_bounding_client_rect.call(this)
+      })
+
+    Object.defineProperty(HTMLElement.prototype, `offsetWidth`, {
+      configurable: true,
+      get() {
+        if (this.classList.contains(`custom-tooltip`)) return width
+        return original_offset_width?.get?.call(this) ?? 0
+      },
+    })
+    Object.defineProperty(HTMLElement.prototype, `offsetHeight`, {
+      configurable: true,
+      get() {
+        if (this.classList.contains(`custom-tooltip`)) return height
+        return original_offset_height?.get?.call(this) ?? 0
+      },
+    })
+
+    return () => {
+      bounds_spy.mockRestore()
+      if (original_offset_width) {
+        Object.defineProperty(HTMLElement.prototype, `offsetWidth`, original_offset_width)
+      }
+      if (original_offset_height) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          `offsetHeight`,
+          original_offset_height,
+        )
+      }
+    }
+  }
+
+  const with_mocked_tooltip_geometry = (
+    viewport: { width: number; height: number },
+    tooltip_size: { width: number; height: number },
+    callback: () => void,
+  ) => {
+    const restore_viewport = mock_viewport(viewport.width, viewport.height)
+    const restore_tooltip_size = mock_tooltip_size(
+      tooltip_size.width,
+      tooltip_size.height,
+    )
+    try {
+      callback()
+    } finally {
+      restore_tooltip_size()
+      restore_viewport()
+    }
+  }
+
   // Shared helper for triggering tooltip display (requires vi.useFakeTimers())
   const trigger_tooltip = (element: HTMLElement) => {
     element.dispatchEvent(new MouseEvent(`mouseenter`, { bubbles: true }))
@@ -138,7 +235,8 @@ describe(`tooltip`, () => {
       const element = create_element()
       element.title = `Title content`
       setup_tooltip(element, { content: `Custom content` })
-      expect(element.hasAttribute(`data-original-title`)).toBe(false)
+      expect(element.getAttribute(`data-original-title`)).toBe(`Title content`)
+      expect(element.hasAttribute(`title`)).toBe(false)
     })
 
     it(`should prioritize title over aria-label`, () => {
@@ -273,6 +371,25 @@ describe(`tooltip`, () => {
       expect(spy).toHaveBeenCalledWith(`scroll`, expect.any(Function), true)
       spy.mockRestore()
     })
+
+    it.each([
+      [`with custom content`, { content: `Custom content` }],
+      [`without custom content`, {}],
+    ])(`suppresses dynamically set title %s`, async (_desc, tooltip_options) => {
+      const element = create_element()
+      element.setAttribute(`aria-label`, `initial label`)
+      const cleanup = setup_tooltip(element, tooltip_options)
+
+      element.setAttribute(`title`, `Late title`)
+      await Promise.resolve()
+
+      expect(element.hasAttribute(`title`)).toBe(false)
+      expect(element.getAttribute(`data-original-title`)).toBe(`Late title`)
+
+      cleanup?.()
+      expect(element.getAttribute(`title`)).toBe(`Late title`)
+      expect(element.hasAttribute(`data-original-title`)).toBe(false)
+    })
   })
 
   describe(`Error Handling`, () => {
@@ -373,6 +490,98 @@ describe(`tooltip`, () => {
   describe(`New Features`, () => {
     beforeEach(() => vi.useFakeTimers())
     afterEach(() => vi.useRealTimers())
+
+    it.each([
+      {
+        test_name: `auto-flips bottom to top when bottom overflows`,
+        trigger_bounds: { left: 100, top: 120, width: 40, height: 20 },
+        viewport: { width: 300, height: 180 },
+        tooltip_size: { width: 120, height: 60 },
+        expected_placement: `top`,
+      },
+      {
+        test_name: `falls back to right when top and bottom overflow`,
+        trigger_bounds: { left: 100, top: 40, width: 40, height: 20 },
+        viewport: { width: 320, height: 120 },
+        tooltip_size: { width: 80, height: 70 },
+        expected_placement: `right`,
+      },
+      {
+        test_name: `falls back to left when right also overflows`,
+        trigger_bounds: { left: 260, top: 40, width: 40, height: 20 },
+        viewport: { width: 320, height: 120 },
+        tooltip_size: { width: 80, height: 70 },
+        expected_placement: `left`,
+      },
+      {
+        test_name: `keeps bottom placement when there is no overflow`,
+        trigger_bounds: { left: 100, top: 100, width: 40, height: 20 },
+        viewport: { width: 320, height: 300 },
+        tooltip_size: { width: 120, height: 60 },
+        expected_placement: `bottom`,
+      },
+      {
+        test_name: `auto-flips top to bottom when top overflows`,
+        trigger_bounds: { left: 100, top: 30, width: 40, height: 20 },
+        viewport: { width: 300, height: 300 },
+        tooltip_size: { width: 120, height: 60 },
+        expected_placement: `bottom`,
+        requested_placement: `top`,
+      },
+      {
+        test_name: `auto-flips left to right when left overflows`,
+        trigger_bounds: { left: 30, top: 100, width: 40, height: 20 },
+        viewport: { width: 300, height: 300 },
+        tooltip_size: { width: 80, height: 40 },
+        expected_placement: `right`,
+        requested_placement: `left`,
+      },
+      {
+        test_name: `auto-flips right to left when right overflows`,
+        trigger_bounds: { left: 230, top: 100, width: 40, height: 20 },
+        viewport: { width: 300, height: 300 },
+        tooltip_size: { width: 80, height: 40 },
+        expected_placement: `left`,
+        requested_placement: `right`,
+      },
+    ])(
+      `$test_name`,
+      (
+        {
+          trigger_bounds,
+          viewport,
+          tooltip_size,
+          expected_placement,
+          requested_placement,
+        },
+      ) => {
+        // Arrow points away from trigger: offset side has negative value, opposite side is unset
+        const arrow_offset_side: Record<string, [string, string]> = {
+          top: [`bottom`, `top`],
+          bottom: [`top`, `bottom`],
+          left: [`right`, `left`],
+          right: [`left`, `right`],
+        }
+
+        with_mocked_tooltip_geometry(viewport, tooltip_size, () => {
+          const element = create_element()
+          element.title = `test`
+          mock_bounds(element, trigger_bounds)
+          setup_tooltip(element, { delay: 0, placement: requested_placement ?? `bottom` })
+
+          trigger_tooltip(element)
+          const tooltip_el = document.querySelector(`.custom-tooltip`) as HTMLElement
+          expect(tooltip_el).toBeTruthy()
+          expect(tooltip_el.getAttribute(`data-placement`)).toBe(expected_placement)
+          const arrow = tooltip_el.querySelector(`.custom-tooltip-arrow`) as HTMLElement
+          expect(arrow).toBeTruthy()
+
+          const [set_side, empty_side] = arrow_offset_side[expected_placement]
+          expect(arrow.style[set_side as `top`]).toContain(`-`)
+          expect(arrow.style[empty_side as `top`]).toBe(``)
+        })
+      },
+    )
 
     it.each([
       [`hide_delay: 200 delays hiding`, { hide_delay: 200 }, true, 200],

--- a/tests/vitest/live-examples/index.test.ts
+++ b/tests/vitest/live-examples/index.test.ts
@@ -126,7 +126,7 @@ describe(`integration`, () => {
 })
 
 describe(`mdsvex_transform`, () => {
-  test.each([undefined, {}, { defaults: { hideStyle: true } }])(
+  test.each([undefined, {}, { defaults: { hide_style: true } }])(
     `returns transformer with %s`,
     (opts) => {
       expect(typeof mdsvex_transform(opts)).toBe(`function`)

--- a/tests/vitest/live-examples/mdsvex-transform.test.ts
+++ b/tests/vitest/live-examples/mdsvex-transform.test.ts
@@ -56,10 +56,10 @@ describe(`exports`, () => {
 
 describe(`remark plugin initialization`, () => {
   test.each([
-    [undefined, `no options`],
-    [{}, `empty options`],
-    [{ defaults: { hideStyle: true } }, `with defaults`],
-  ])(`returns transformer function with %s`, (opts, _desc) => {
+    { opts: undefined, desc: `no options` },
+    { opts: {}, desc: `empty options` },
+    { opts: { defaults: { hide_style: true } }, desc: `with defaults` },
+  ])(`returns transformer function with $desc`, ({ opts }) => {
     expect(typeof remark(opts)).toBe(`function`)
   })
 })
@@ -118,15 +118,25 @@ describe(`meta parsing`, () => {
 
 describe(`wrapper component handling`, () => {
   test.each([
-    [undefined, `example`, `$lib/CodeExample.svelte`, `default wrapper`],
-    [
-      { defaults: { Wrapper: `$lib/Custom.svelte` } },
-      `example`,
-      `$lib/Custom.svelte`,
-      `defaults option`,
-    ],
-    [undefined, `example Wrapper="$lib/My.svelte"`, `$lib/My.svelte`, `per-example meta`],
-  ])(`uses %s from %s`, (opts, meta, expected, _desc) => {
+    {
+      desc: `default wrapper`,
+      opts: undefined,
+      meta: `example`,
+      expected: `$lib/CodeExample.svelte`,
+    },
+    {
+      desc: `defaults option`,
+      opts: { defaults: { Wrapper: `$lib/Custom.svelte` } },
+      meta: `example`,
+      expected: `$lib/Custom.svelte`,
+    },
+    {
+      desc: `per-example meta`,
+      opts: undefined,
+      meta: `example Wrapper="$lib/My.svelte"`,
+      expected: `$lib/My.svelte`,
+    },
+  ])(`uses wrapper from $desc`, ({ opts, meta, expected }) => {
     const tree = create_tree([create_code_node(`svelte`, `<div>Test</div>`, meta)])
     remark(opts)(tree, create_file())
     expect(find_script_node(tree)).toContain(expected)
@@ -175,28 +185,63 @@ describe(`CSR mode`, () => {
   })
 })
 
-describe(`hideScript and hideStyle options`, () => {
-  test.each([
-    [`hideScript`, `<script>let x = 1</script><div>Test</div>`, `let x = 1`, `Test`],
-    [
-      `hideStyle`,
-      `<div>Test</div><style>div { color: red }</style>`,
-      `color: red`,
-      `Test`,
-    ],
-  ])(`%s removes block from highlighted code`, (option, code, hidden, visible) => {
-    const tree = create_tree([create_code_node(`svelte`, code, `example ${option}`)])
+const hide_option_cases = [
+  {
+    option: `hide_script`,
+    code: `<script>let x = 1</script><div>Test</div>`,
+    hidden: `let x = 1`,
+    visible: `Test`,
+  },
+  {
+    option: `hide_style`,
+    code: `<div>Test</div><style>div { color: red }</style>`,
+    hidden: `color: red`,
+    visible: `Test`,
+  },
+]
+
+describe(`hide_script and hide_style options`, () => {
+  test.each(hide_option_cases)(
+    `$option via meta removes block`,
+    ({ option, code, hidden, visible }) => {
+      const tree = create_tree([create_code_node(`svelte`, code, `example ${option}`)])
+      remark()(tree, create_file())
+      const value = get_example_value(tree)
+      expect(value).not.toContain(hidden)
+      expect(value).toContain(visible)
+    },
+  )
+
+  test.each(hide_option_cases)(
+    `$option via defaults removes block`,
+    ({ option, code, hidden }) => {
+      const tree = create_tree([create_code_node(`svelte`, code, `example`)])
+      remark({ defaults: { [option]: true } })(tree, create_file())
+      expect(get_example_value(tree)).not.toContain(hidden)
+    },
+  )
+
+  test(`hide_script and hide_style combined strips both blocks`, () => {
+    const code =
+      `<script>let x = 1</script><div>Test</div><style>div { color: red }</style>`
+    const tree = create_tree([
+      create_code_node(`svelte`, code, `example hide_script hide_style`),
+    ])
     remark()(tree, create_file())
     const value = get_example_value(tree)
-    expect(value).not.toContain(hidden)
-    expect(value).toContain(visible)
+    expect(value).not.toContain(`let x = 1`)
+    expect(value).not.toContain(`color: red`)
+    expect(value).toContain(`Test`)
   })
 
-  test(`applies hideStyle from defaults`, () => {
-    const code = `<div>Test</div><style>div { color: red }</style>`
+  test(`preserves script and style blocks when options are not set`, () => {
+    const code =
+      `<script>let x = 1</script><div>Test</div><style>div { color: red }</style>`
     const tree = create_tree([create_code_node(`svelte`, code, `example`)])
-    remark({ defaults: { hideStyle: true } })(tree, create_file())
-    expect(get_example_value(tree)).not.toContain(`color: red`)
+    remark()(tree, create_file())
+    const value = get_example_value(tree)
+    expect(value).toContain(`let x`)
+    expect(value).toContain(`color`)
   })
 })
 
@@ -251,25 +296,25 @@ describe(`multiple examples`, () => {
 
 describe(`output handling`, () => {
   test.each([
-    [
-      `<div>Test</div>`,
-      `src/routes/demo/+page.md`,
-      `/project/src/routes/demo/+page.md`,
-      `extracts relative filename`,
-    ],
-    [
-      `<script>let x = 1</script>`,
-      `<span`,
-      `/project/src/test.md`,
-      `produces highlighted HTML`,
-    ],
-    [
-      `<script>\nlet x = 1\n</script>`,
-      `&#10;`,
-      `/project/src/test.md`,
-      `escapes newlines`,
-    ],
-  ])(`%s -> output contains %s`, (code, expected, filename) => {
+    {
+      desc: `extracts relative filename`,
+      code: `<div>Test</div>`,
+      expected: `src/routes/demo/+page.md`,
+      filename: `/project/src/routes/demo/+page.md`,
+    },
+    {
+      desc: `produces highlighted HTML`,
+      code: `<script>let x = 1</script>`,
+      expected: `<span`,
+      filename: `/project/src/test.md`,
+    },
+    {
+      desc: `escapes newlines`,
+      code: `<script>\nlet x = 1\n</script>`,
+      expected: `&#10;`,
+      filename: `/project/src/test.md`,
+    },
+  ])(`$desc`, ({ code, expected, filename }) => {
     const tree = create_tree([create_code_node(`svelte`, code, `example`)])
     remark()(tree, create_file(filename, `/project`))
     expect(get_example_value(tree)).toContain(expected)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
 import { sveltekit } from '@sveltejs/kit/vite'
-import live_examples from './src/lib/live-examples/vite-plugin.ts'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import { defineConfig } from 'vitest/config'
+import live_examples from './src/lib/live-examples/vite-plugin.ts'
 
 export default defineConfig({
   plugins: [sveltekit(), live_examples()],


### PR DESCRIPTION
- Always suppress the browser's native `title` tooltip to prevent double-tooltip when custom content is provided
- Auto-flip tooltip placement when it would overflow the viewport (e.g. `bottom` → `top` → `right` → `left`), using overflow scoring to pick the best fit
- Sync arrow orientation to match the final resolved placement after auto-flip
- Refactor arrow styling into data-driven helpers (`arrow_css_by_placement`, `apply_triangle_style`, `sync_arrow_styles`) to eliminate duplicated if/else branches
- CodeExample: default `code_above` to `true` when `collapsible` is set, with correct margin direction via new `code-above` CSS class
- Preserve the original native `title` through dynamic updates and restore it during cleanup
- Standardize live-example option and config keys to snake_case