### PR TITLE
Fix live example CSS resolution during SSR

### DIFF
--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -782,14 +782,10 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
         let { top, left } = position_by_placement[chosen_placement]
 
         // Keep in viewport
-        left = Math.max(
-          min_padding,
-          Math.min(left, innerWidth - tooltip_rect.width - min_padding),
-        )
-        top = Math.max(
-          min_padding,
-          Math.min(top, innerHeight - tooltip_rect.height - min_padding),
-        )
+        const max_left = innerWidth - tooltip_rect.width - min_padding
+        left = Math.max(min_padding, Math.min(left, max_left))
+        const max_top = innerHeight - tooltip_rect.height - min_padding
+        top = Math.max(min_padding, Math.min(top, max_top))
 
         style.left = `${left + globalThis.scrollX}px`
         style.top = `${top + globalThis.scrollY}px`

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -2,7 +2,6 @@
 // @ts-expect-error no types available
 import ast from 'abstract-syntax-tree'
 import { Buffer } from 'node:buffer'
-import path from 'node:path'
 import process from 'node:process'
 import type { HmrContext, Plugin, ViteDevServer } from 'vite'
 import { EXAMPLE_MODULE_PREFIX } from './mdsvex-transform.ts'
@@ -32,9 +31,16 @@ interface AstNode {
   end?: number
 }
 
+// Normalize a module ID to absolute path for consistent lookups.
+// Can't use path.posix.join because it treats /src/... as already absolute.
+function to_absolute(id: string, cwd: string): string {
+  if (id.startsWith(cwd)) return id
+  return id.startsWith(`/`) ? `${cwd}${id}` : `${cwd}/${id}`
+}
+
 export default function live_examples_plugin(
   options: { extensions?: string[] } = {},
-): Plugin {
+): Plugin[] {
   const { extensions = [`.svelte.md`, `.md`, `.svx`] } = options
 
   // Extracted examples as individual virtual files (id -> svelte source)
@@ -43,40 +49,38 @@ export default function live_examples_plugin(
   const parent_to_virtual = new Map<string, Set<string>>()
 
   let vite_server: ViteDevServer | undefined
+  const cwd = process.cwd().replace(/\\/g, `/`)
 
-  return {
+  // Pre-enforce plugin ensures resolveId runs before vite-plugin-svelte's
+  // load-compiled-css:resolveId, so CSS derived modules get the same absolute
+  // path as the main component (needed for module graph CSS cache lookup).
+  const resolve_plugin: Plugin = {
+    name: `live-examples-resolve`,
+    enforce: `pre`,
+    resolveId(id: string) {
+      if (id.includes(EXAMPLE_MODULE_PREFIX)) {
+        return to_absolute(id, cwd)
+      }
+    },
+  }
+
+  const main_plugin: Plugin = {
     name: `live-examples-plugin`,
 
     configureServer(server) {
       vite_server = server
     },
 
-    resolveId(id: string) {
-      if (id.includes(EXAMPLE_MODULE_PREFIX)) {
-        // Force absolute path (dev uses relative, prod uses absolute)
-        // Use posix.join to ensure forward slashes on all platforms (Vite normalizes to /)
-        const cwd = process.cwd().replace(/\\/g, `/`)
-        return id.includes(cwd) ? id : path.posix.join(cwd, id)
-      }
-    },
-
     load(id: string) {
       if (id.includes(EXAMPLE_MODULE_PREFIX)) {
-        // Strip query parameters - Vite requests derived modules (styles, etc.) with queries
-        // like ?inline&svelte&type=style&lang.css but we store the base path
         const [base_id, query = ``] = id.split(`?`)
+
+        // Skip derived module requests (CSS, scripts) - let vite-plugin-svelte handle them.
+        // Must check BEFORE virtual_files lookup to avoid returning Svelte source for CSS.
+        if (/type=(style|script|module)/.test(query)) return
+
         const src = virtual_files.get(base_id)
         if (src) return src
-
-        // Virtual file not found - can happen during SSR/parallel builds when derived
-        // modules (styles, scripts) are requested before parent markdown is transformed.
-        // For derived module requests, return empty content to avoid crashes.
-        if (
-          query.includes(`type=style`) || query.includes(`type=script`) ||
-          query.includes(`type=module`)
-        ) {
-          return ``
-        }
 
         // For main component requests in production, fail the build
         const msg = `Example src not found for ${id}`
@@ -100,9 +104,9 @@ export default function live_examples_plugin(
       const is_markdown = extensions.some((ext) => base_id.endsWith(ext))
       if (!is_example_module && !is_markdown) return
 
-      // Skip derived modules (styles, etc.) - only process the main markdown file
-      // Vite creates derived modules like ?svelte&type=style&lang.css for style blocks
-      if (id.includes(`?svelte&type=`)) return { code, map: { mappings: `` } }
+      // Skip derived modules (styles, etc.) - only process the main markdown file.
+      // Match both ?svelte&type= and ?inline&svelte&type= (SSR adds ?inline prefix)
+      if (id.includes(`svelte&type=`)) return { code, map: { mappings: `` } }
 
       if (is_markdown) {
         // Use AST for precise node location, collect edits to apply at end
@@ -213,4 +217,6 @@ export default function live_examples_plugin(
       return [...additional_modules, ...ctx.modules]
     },
   }
+
+  return [resolve_plugin, main_plugin]
 }

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -34,7 +34,7 @@ interface AstNode {
 // Normalize a module ID to absolute path for consistent lookups.
 // Can't use path.posix.join because it treats /src/... as already absolute.
 function to_absolute(id: string, cwd: string): string {
-  if (id.startsWith(cwd)) return id
+  if (id.startsWith(`${cwd}/`) || id === cwd) return id
   return id.startsWith(`/`) ? `${cwd}${id}` : `${cwd}/${id}`
 }
 

--- a/tests/vitest/live-examples/index.test.ts
+++ b/tests/vitest/live-examples/index.test.ts
@@ -49,19 +49,6 @@ describe(`sveltePreprocess wrapper`, () => {
       [handler]?.(args)
   }
 
-  test(`returns preprocessor group with all handlers`, () => {
-    const preprocessor = sveltePreprocess()
-    expect(typeof preprocessor.markup).toBe(`function`)
-    expect(typeof preprocessor.script).toBe(`function`)
-    expect(typeof preprocessor.style).toBe(`function`)
-  })
-
-  // All handlers behave identically - test one handler per extension, trust the pattern
-  test.each([`.md`, `.mdx`, `.svx`])(`skips %s files`, async (ext) => {
-    const result = await call_handler(`markup`, `/project/page${ext}`)
-    expect(result?.code).toBe(`test`)
-  })
-
   test.each([`markup`, `script`, `style`] as const)(
     `%s processes .svelte files`,
     async (handler) => {
@@ -135,8 +122,10 @@ describe(`mdsvex_transform`, () => {
 })
 
 describe(`vite_plugin`, () => {
-  test(`creates plugin with correct name`, () => {
-    const plugin = vite_plugin()
-    expect(plugin.name).toBe(`live-examples-plugin`)
+  test(`returns resolve and main plugins`, () => {
+    const plugins = vite_plugin()
+    expect(plugins).toHaveLength(2)
+    expect(plugins[0].name).toBe(`live-examples-resolve`)
+    expect(plugins[1].name).toBe(`live-examples-plugin`)
   })
 })

--- a/tests/vitest/live-examples/vite-plugin.test.ts
+++ b/tests/vitest/live-examples/vite-plugin.test.ts
@@ -1,16 +1,14 @@
 // Tests for vite-plugin.ts - the Vite plugin for virtual module resolution
-import { EXAMPLE_MODULE_PREFIX } from '$lib/live-examples/vite-plugin'
-import vite_plugin from '$lib/live-examples/vite-plugin'
+import vite_plugin, { EXAMPLE_MODULE_PREFIX } from '$lib/live-examples/vite-plugin'
 import { Buffer } from 'node:buffer'
 import process from 'node:process'
 import { describe, expect, test, vi } from 'vitest'
 
-// Local helper for tests (same as in vite-plugin.ts)
 const to_base64 = (src: string): string => Buffer.from(src, `utf-8`).toString(`base64`)
 
-// Plugin interface for testing
 interface TestPlugin {
   name: string
+  enforce?: string
   resolveId?: (id: string) => string | undefined
   load?: (id: string) => string | undefined
   transform?: (
@@ -23,26 +21,35 @@ interface TestPlugin {
   ) => unknown[]
 }
 
-// Helpers
-const get_plugin = (options = {}): TestPlugin =>
-  vite_plugin(options) as unknown as TestPlugin
+// Merge resolve (enforce:'pre') and main plugins into one for testing
+const get_plugin = (options = {}): TestPlugin => {
+  const [resolve, main] = vite_plugin(options) as unknown as TestPlugin[]
+  return { ...main, resolveId: resolve.resolveId, enforce: resolve.enforce }
+}
 
 const create_mock_context = () => ({ warn: vi.fn(), error: vi.fn() })
 
 describe(`plugin initialization`, () => {
-  test(`creates plugin with correct name`, () => {
-    const plugin = get_plugin()
-    expect(plugin.name).toBe(`live-examples-plugin`)
+  test(`returns two plugins: resolve (pre) and main`, () => {
+    const [resolve, main] = vite_plugin() as unknown as TestPlugin[]
+    expect(resolve.name).toBe(`live-examples-resolve`)
+    expect(resolve.enforce).toBe(`pre`)
+    expect(main.name).toBe(`live-examples-plugin`)
   })
 })
 
 describe(`resolveId`, () => {
   const plugin = get_plugin()
 
-  test(`resolves example module paths to absolute`, () => {
-    const resolved = plugin.resolveId?.(`${EXAMPLE_MODULE_PREFIX}0.svelte`)
+  test.each([
+    [`relative`, `${EXAMPLE_MODULE_PREFIX}0.svelte`],
+    [`root-relative`, `/src/file.md${EXAMPLE_MODULE_PREFIX}0.svelte`],
+  ])(`resolves %s paths to absolute without double slashes`, (_, id) => {
+    const cwd = process.cwd().replace(/\\/g, `/`)
+    const resolved = plugin.resolveId?.(id)
     expect(resolved).toContain(EXAMPLE_MODULE_PREFIX)
-    expect(resolved).toMatch(/^\//)
+    expect(resolved?.startsWith(cwd)).toBe(true)
+    expect(resolved).not.toContain(`//`)
   })
 
   test(`preserves already absolute paths`, () => {
@@ -63,11 +70,14 @@ describe(`load`, () => {
     [`style`, `?inline&svelte&type=style&lang.css`],
     [`script`, `?svelte&type=script`],
     [`module`, `?type=module`],
-  ])(`returns empty string for %s module requests when file not found`, (_, query) => {
-    const ctx = create_mock_context()
-    expect(plugin.load?.call(ctx, `${base_id}${query}`)).toBe(``)
-    expect(ctx.warn).not.toHaveBeenCalled()
-  })
+  ])(
+    `returns undefined for %s derived module requests (defers to vite-plugin-svelte)`,
+    (_, query) => {
+      const ctx = create_mock_context()
+      expect(plugin.load?.call(ctx, `${base_id}${query}`)).toBeUndefined()
+      expect(ctx.warn).not.toHaveBeenCalled()
+    },
+  )
 
   test(`returns error component for main component requests when file not found`, () => {
     const ctx = create_mock_context()
@@ -81,16 +91,34 @@ describe(`load`, () => {
     expect(plugin.load?.call(create_mock_context(), `/path/to/regular.md`))
       .toBeUndefined()
   })
+
+  test(`returns undefined for CSS query even when virtual file exists`, () => {
+    const plugin = get_plugin()
+    const ctx = create_mock_context()
+    const id = `/path/to/file.md`
+
+    const code = `const props = { __live_example_src: "${to_base64(`<div>Test</div>`)}" }`
+    plugin.transform?.call(ctx, code, id)
+
+    const virtual_id = `${id}${EXAMPLE_MODULE_PREFIX}0.svelte`
+    expect(plugin.load?.call(ctx, `${virtual_id}?inline&svelte&type=style&lang.css`))
+      .toBeUndefined()
+  })
 })
 
 describe(`transform`, () => {
   const plugin = get_plugin()
   const ctx = create_mock_context()
 
-  test(`skips derived modules`, () => {
-    const code = `some code`
-    const result = plugin.transform?.call(ctx, code, `/file.md?svelte&type=style`)
-    expect(result).toEqual({ code, map: { mappings: `` } })
+  test.each([
+    [`?svelte&type=style`, `standard`],
+    [`?inline&svelte&type=style&lang.css`, `SSR with ?inline prefix`],
+  ])(`skips derived modules with query %s (%s)`, (query) => {
+    const code = `const props = { __live_example_src: "${to_base64(`<div>Test</div>`)}" }`
+    const result = plugin.transform?.call(ctx, code, `/file.md${query}`) as {
+      code: string
+    }
+    expect(result.code).toBe(code)
   })
 
   test(`returns original code when AST parsing fails`, () => {
@@ -143,11 +171,6 @@ describe(`transform`, () => {
       expect(result.code).toContain(`${id}${EXAMPLE_MODULE_PREFIX}${idx}.svelte`)
     }
   })
-})
-
-describe(`edge cases`, () => {
-  const plugin = get_plugin()
-  const ctx = create_mock_context()
 
   test.each([``, `const x = 1;`])(
     `returns unchanged for code without markers: %s`,
@@ -162,7 +185,56 @@ describe(`edge cases`, () => {
   test(`correctly decodes base64 with unicode`, () => {
     const original = `<div>Hello 世界 🌍</div>`
     const code = `const props = { __live_example_src: "${to_base64(original)}" }`
-    expect(plugin.transform?.call(ctx, code, `/file.md`)).toBeDefined()
+    const plugin = get_plugin()
+    const ctx = create_mock_context()
+    const id = `/path/to/file.md`
+    plugin.transform?.call(ctx, code, id)
+    expect(plugin.load?.call(ctx, `${id}${EXAMPLE_MODULE_PREFIX}0.svelte`)).toBe(original)
+  })
+
+  test(`updates cached virtual file on re-transform`, () => {
+    const plugin = get_plugin()
+    const ctx = create_mock_context()
+    const id = `/path/to/file.md`
+    const virtual_id = `${id}${EXAMPLE_MODULE_PREFIX}0.svelte`
+
+    const make_code = (src: string) =>
+      `const props = { __live_example_src: "${to_base64(src)}" }`
+
+    plugin.transform?.call(ctx, make_code(`<div>First</div>`), id)
+    expect(plugin.load?.call(ctx, virtual_id)).toBe(`<div>First</div>`)
+
+    plugin.transform?.call(ctx, make_code(`<div>Second</div>`), id)
+    expect(plugin.load?.call(ctx, virtual_id)).toBe(`<div>Second</div>`)
+  })
+
+  // Note: The remark transform always generates sequential indices (0, 1, 2...) for live
+  // examples. Non-live examples (TypeScript, etc.) don't generate __live_example_src props
+  // or imports, so they don't create gaps. The vite plugin's enumeration index matches
+  // the import path index because both are sequential.
+  test(`props and imports have matching indices and virtual files are loadable`, () => {
+    const plugin = get_plugin()
+    const ctx = create_mock_context()
+    const id = `/path/to/file.md`
+
+    const content0 = `<div>First</div>`
+    const content1 = `<div>Second</div>`
+    const code = `
+      import A from "${EXAMPLE_MODULE_PREFIX}0.svelte";
+      import B from "${EXAMPLE_MODULE_PREFIX}1.svelte";
+      const props0 = { __live_example_src: "${to_base64(content0)}" };
+      const props1 = { __live_example_src: "${to_base64(content1)}" };
+    `
+    const result = plugin.transform?.call(ctx, code, id) as { code: string }
+
+    const virtual_id0 = `${id}${EXAMPLE_MODULE_PREFIX}0.svelte`
+    const virtual_id1 = `${id}${EXAMPLE_MODULE_PREFIX}1.svelte`
+    expect(result.code).toContain(virtual_id0)
+    expect(result.code).toContain(virtual_id1)
+    expect(result.code).not.toContain(`__live_example_src`)
+
+    expect(plugin.load?.call(ctx, virtual_id0)).toBe(content0)
+    expect(plugin.load?.call(ctx, virtual_id1)).toBe(content1)
   })
 })
 
@@ -189,89 +261,20 @@ describe(`vite-specific hooks`, () => {
     expect(result).toContain(ctx.modules[0])
     if (!is_markdown) expect(result).toEqual(ctx.modules)
   })
-})
 
-describe(`handleHotUpdate Windows path normalization`, () => {
-  test(`normalizes backslashes to forward slashes for Map lookup`, () => {
+  test(`handleHotUpdate normalizes backslashes for Windows paths`, () => {
     const plugin = get_plugin()
     const ctx = create_mock_context()
-    // Transform with forward-slash path (how Vite stores IDs)
     const unix_path = `/path/to/file.md`
     const code = `const props = { __live_example_src: "${to_base64(`<div>Test</div>`)}" }`
     plugin.transform?.call(ctx, code, unix_path)
 
-    // HMR context uses Windows backslashes
-    const windows_path = `\\path\\to\\file.md`
     const mock_module = { id: `virtual` }
     const hmr_ctx = {
-      file: windows_path,
+      file: `\\path\\to\\file.md`,
       server: { moduleGraph: { getModuleById: vi.fn().mockReturnValue(mock_module) } },
       modules: [],
     }
-    const result = plugin.handleHotUpdate?.(hmr_ctx)
-
-    // Should find the virtual module despite path separator difference
-    expect(result).toContain(mock_module)
-  })
-})
-
-describe(`virtual file caching`, () => {
-  test(`caches and updates virtual files`, () => {
-    const plugin = get_plugin()
-    const ctx = create_mock_context()
-    const id = `/path/to/file.md`
-
-    // First transform
-    const code1 = `const props = { __live_example_src: "${
-      to_base64(`<div>First</div>`)
-    }" }`
-    plugin.transform?.call(ctx, code1, id)
-
-    // Second transform with different content
-    const code2 = `const props = { __live_example_src: "${
-      to_base64(`<div>Second</div>`)
-    }" }`
-    expect(plugin.transform?.call(ctx, code2, id)).toBeDefined()
-  })
-})
-
-describe(`index alignment`, () => {
-  // Note: The remark transform always generates sequential indices (0, 1, 2...) for live
-  // examples. Non-live examples (TypeScript, etc.) don't generate __live_example_src props
-  // or imports, so they don't create gaps. The vite plugin's enumeration index matches
-  // the import path index because both are sequential.
-  test(`props and imports have matching indices and virtual files are loadable`, () => {
-    const plugin = get_plugin()
-    const ctx = create_mock_context()
-    const id = `/path/to/file.md`
-
-    // Expected content for each example
-    const content0 = `<div>First</div>`
-    const content1 = `<div>Second</div>`
-
-    // Realistic output: 2 live examples with sequential indices 0, 1
-    // (any non-live examples in between don't affect numbering)
-    const code = `
-      import A from "${EXAMPLE_MODULE_PREFIX}0.svelte";
-      import B from "${EXAMPLE_MODULE_PREFIX}1.svelte";
-      const props0 = { __live_example_src: "${to_base64(content0)}" };
-      const props1 = { __live_example_src: "${to_base64(content1)}" };
-    `
-    const result = plugin.transform?.call(ctx, code, id) as { code: string }
-
-    // Import paths are rewritten to absolute virtual file IDs
-    const virtual_id0 = `${id}${EXAMPLE_MODULE_PREFIX}0.svelte`
-    const virtual_id1 = `${id}${EXAMPLE_MODULE_PREFIX}1.svelte`
-    expect(result.code).toContain(virtual_id0)
-    expect(result.code).toContain(virtual_id1)
-
-    // __live_example_src props are removed
-    expect(result.code).not.toContain(`__live_example_src`)
-
-    // Verify virtual files are stored and loadable with matching content
-    // This catches index mismatch bugs where transform rewrites imports
-    // but stores content under different indices
-    expect(plugin.load?.call(ctx, virtual_id0)).toBe(content0)
-    expect(plugin.load?.call(ctx, virtual_id1)).toBe(content1)
+    expect(plugin.handleHotUpdate?.(hmr_ctx)).toContain(mock_module)
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'vitest/config'
 import live_examples from './src/lib/live-examples/vite-plugin.ts'
 
 export default defineConfig({
-  plugins: [sveltekit(), live_examples()],
+  plugins: [sveltekit(), ...live_examples()],
 
   test: {
     include: [`tests/vitest/**/*.test.ts`],


### PR DESCRIPTION
- **Split vite plugin into two** — an `enforce: 'pre'` resolve plugin that runs `resolveId` before `vite-plugin-svelte`'s `load-compiled-css`, and the main plugin for load/transform/HMR. This ensures CSS derived modules resolve to the same absolute path as the main component.
- **Fix path normalization** — replaced `path.posix.join(cwd, id)` with `to_absolute()` using string concatenation, since `path.posix.join` ignores `cwd` when `id` is root-relative (starts with `/`).
- **Fix load hook ordering** — check derived module queries (`type=style/script/module`) *before* `virtual_files.get()` and return `undefined` (not `''`) to properly defer to `vite-plugin-svelte` instead of returning Svelte source for CSS requests.
- **Broaden transform derived module check** — match `svelte&type=` instead of `?svelte&type=` to also catch SSR's `?inline&svelte&type=` pattern.

## Root cause

Example 16 ("Multiple Plots in 2x2 Grid Layout") is the only live example with a `<style>` block. During SSR, Vite strips the project root from CSS virtual module imports (making them root-relative) and adds `?inline`. Two bugs conspired: `path.posix.join` not prepending `cwd` to root-relative paths, and plugin ordering letting `load-compiled-css` intercept the CSS request before our `resolveId`.