### PR TITLE
Enrich snippet props and event callback payloads

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -708,18 +708,18 @@ These reflect internal component state:
 
 `MultiSelect.svelte` accepts the following named snippets:
 
-1. `#snippet option({ option, idx })`: Customize rendering of dropdown options. Receives as props an `option` and the zero-indexed position (`idx`) it has in the dropdown.
+1. `#snippet option({ option, idx, selected, active, disabled })`: Customize rendering of dropdown options. Receives the `option`, its zero-indexed position (`idx`) in the dropdown, whether it is `selected`, `active` (keyboard-highlighted), and `disabled`.
 1. `#snippet selectedItem({ option, idx })`: Customize rendering of selected items. Receives as props an `option` and the zero-indexed position (`idx`) it has in the list of selected items.
 1. `#snippet children({ option, idx, type })`: Convenience snippet that applies to both dropdown options AND selected items. Use this when you want the same custom rendering for both. Takes precedence if `option` or `selectedItem` are not provided. `type` is `'selected'` when rendering a selected pill and `'option'` when rendering a dropdown item, allowing conditional styling/content by context.
 1. `#snippet spinner()`: Custom spinner component to display when in `loading` state. Receives no props.
 1. `#snippet disabledIcon()`: Custom icon to display inside the input when in `disabled` state. Receives no props. Use an empty `{#snippet disabledIcon()}{/snippet}` to remove the default disabled icon.
-1. `#snippet expandIcon({ open })`: Allows setting a custom icon to indicate to users that the Multiselect text input field is expandable into a dropdown list. `open` is `true` if the dropdown is visible and `false` if hidden.
-1. `#snippet removeIcon()`: Custom icon to display as remove button. Will be used both by buttons to remove individual selected options and the 'remove all' button that clears all options at once. Receives no props.
+1. `#snippet expandIcon({ open, disabled })`: Allows setting a custom icon to indicate to users that the Multiselect text input field is expandable into a dropdown list. `open` is `true` if the dropdown is visible and `false` if hidden. `disabled` reflects the component's disabled state.
+1. `#snippet removeIcon({ option, isRemoveAll })`: Custom icon to display as remove button. Used both by per-option remove buttons (`isRemoveAll: false`, `option` is the item being removed) and the 'remove all' button (`isRemoveAll: true`, `option` is `undefined`).
 1. `#snippet userMsg({ searchText, msgType, msg })`: Displayed like a dropdown item when the list is empty and user is allowed to create custom options based on text input (or if the user's text input clashes with an existing option). Receives props:
    - `searchText`: The text user typed into search input.
    - `msgType: false | 'create' | 'dupe' | 'no-match'`: `'dupe'` means user input is a duplicate of an existing option. `'create'` means user is allowed to convert their input into a new option not previously in the dropdown. `'no-match'` means user input doesn't match any dropdown items and users are not allowed to create new options. `false` means none of the above.
    - `msg`: Will be `duplicateOptionMsg` or `createOptionMsg` (see [props](#🔣-props)) based on whether user input is a duplicate or can be created as new option. Note this snippet replaces the default UI for displaying these messages so the snippet needs to render them instead (unless purposely not showing a message).
-1. `#snippet afterInput({ selected, disabled, invalid, id, placeholder, open, required })`: Placed after the search input. For arbitrary content like icons or temporary messages. Can serve as a more dynamic, more customizable alternative to the `placeholder` prop.
+1. `#snippet afterInput({ selected, disabled, invalid, id, placeholder, open, required, searchText })`: Placed after the search input. For arbitrary content like icons or temporary messages. Can serve as a more dynamic, more customizable alternative to the `placeholder` prop.
 
 Example using several snippets:
 
@@ -738,7 +738,7 @@ Example using several snippets:
   {#snippet spinner()}
     <CustomSpinner />
   {/snippet}
-  {#snippet removeIcon()}
+  {#snippet removeIcon({ option, isRemoveAll })}
     <strong>X</strong>
   {/snippet}
 </MultiSelect>
@@ -749,10 +749,10 @@ Example using several snippets:
 `MultiSelect.svelte` provides the following event callback props:
 
 1. ```ts
-   onadd={({ option }) => console.log(option)}
+   onadd={({ option, selected }) => console.log(option, selected)}
    ```
 
-   Triggers when a new option is selected. The newly selected option is provided as `option`.
+   Triggers when a new option is selected. `option` is the newly selected option, `selected` is the updated array of all selected options.
 
 1. ```ts
    oncreate={({ option }) => console.log(option)}
@@ -761,10 +761,10 @@ Example using several snippets:
    Triggers when a user creates a new option (when `allowUserOptions` is enabled). The created option is provided as `option`.
 
 1. ```ts
-   onremove={({ option }) => console.log(option)}
+   onremove={({ option, selected }) => console.log(option, selected)}
    ```
 
-   Triggers when a single selected option is removed. The removed option is provided as `option`.
+   Triggers when a single selected option is removed. `option` is the removed option, `selected` is the updated array of remaining selected options.
 
 1. ```ts
    onremoveAll={({ options }) => console.log(options)}
@@ -779,10 +779,10 @@ Example using several snippets:
    Triggers when the "Select All" option is clicked (requires `selectAllOption` to be enabled). The `options` payload contains the options that were added.
 
 1. ```ts
-   onreorder={({ options }) => console.log(options)}
+   onreorder={({ options, previous }) => console.log(options, previous)}
    ```
 
-   Triggers when selected options are reordered via drag-and-drop (enabled by default when `sortSelected` is false). The `options` payload is the newly ordered array of selected options.
+   Triggers when selected options are reordered via drag-and-drop (enabled by default when `sortSelected` is false). `options` is the newly ordered array, `previous` is the array before reordering.
 
 1. ```ts
    onchange={({ type, option, options }) => console.log(type, option ?? options)}
@@ -803,10 +803,10 @@ Example using several snippets:
    Triggers when the dropdown list of options disappears. `event` is the DOM's `FocusEvent`, `KeyboardEvent` or `ClickEvent` that triggered the close.
 
 1. ```ts
-   onsearch={({ searchText, matchingCount }) => console.log(searchText, matchingCount)}
+   onsearch={({ searchText, matchingOptions }) => console.log(searchText, matchingOptions.length)}
    ```
 
-   Triggers (debounced, 150ms) when the search text changes. Useful for analytics or loading remote options. `searchText` is the current input value, `matchingCount` is the number of options that match.
+   Triggers (debounced, 150ms) when the search text changes. Useful for analytics or loading remote options. `searchText` is the current input value, `matchingOptions` is the array of options matching the search.
 
 1. ```ts
    onmaxreached={({ selected, maxSelect, attemptedOption }) => console.log(attemptedOption)}

--- a/readme.md
+++ b/readme.md
@@ -738,8 +738,8 @@ Example using several snippets:
   {#snippet spinner()}
     <CustomSpinner />
   {/snippet}
-  {#snippet removeIcon({ option, isRemoveAll })}
-    <strong>X</strong>
+  {#snippet removeIcon({ isRemoveAll })}
+    <strong>{isRemoveAll ? `Clear` : `X`}</strong>
   {/snippet}
 </MultiSelect>
 ```

--- a/src/lib/CopyButton.svelte
+++ b/src/lib/CopyButton.svelte
@@ -38,7 +38,9 @@
     skip_selector?: string | null
     as?: string
     labels?: Record<State, { icon: IconName; text: string }>
-    children?: Snippet<[{ state: State; icon: IconName; text: string }]>
+    children?: Snippet<
+      [{ state: State; icon: IconName; text: string; disabled: boolean }]
+    >
   } = $props()
 
   let reset_timeout: ReturnType<typeof setTimeout> | null = null
@@ -149,7 +151,7 @@
     {...rest}
   >
     {#if children}
-      {@render children({ state, icon, text })}
+      {@render children({ state, icon, text, disabled })}
     {:else}
       <span>
         <Icon {icon} />

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -387,10 +387,7 @@
 
     search_debounce_timer = setTimeout(() => {
       // Optional chaining in case onsearch is removed while timer is pending
-      onsearch?.({
-        searchText: current_search,
-        matchingCount: matchingOptions.length,
-      })
+      onsearch?.({ searchText: current_search, matchingOptions })
     }, 150)
     return () => {
       if (search_debounce_timer) clearTimeout(search_debounce_timer)
@@ -806,7 +803,7 @@
       clear_validity()
       handle_dropdown_after_select(event)
       last_action = { type: `add`, label: `${utils.get_label(option_to_add)}` }
-      onadd?.({ option: option_to_add })
+      onadd?.({ option: option_to_add, selected })
       onchange?.({ option: option_to_add, type: `add` })
     }
   }
@@ -842,7 +839,7 @@
     selected = selected.filter((_, remove_idx) => remove_idx !== idx)
     clear_validity()
     last_action = { type: `remove`, label: `${utils.get_label(option_removed)}` }
-    onremove?.({ option: option_removed })
+    onremove?.({ option: option_removed, selected })
     onchange?.({ option: option_removed, type: `remove` })
   }
 
@@ -1173,6 +1170,7 @@
     if (!event.dataTransfer) return
     event.dataTransfer.dropEffect = `move`
     const start_idx = parseInt(event.dataTransfer.getData(`text/plain`))
+    const previous = [...selected]
     const new_selected = [...selected]
 
     if (start_idx < target_idx) {
@@ -1184,7 +1182,7 @@
     }
     selected = new_selected
     drag_idx = null
-    onreorder?.({ options: new_selected })
+    onreorder?.({ options: new_selected, previous })
     onchange?.({ options: new_selected, type: `reorder` })
   }
 
@@ -1427,7 +1425,7 @@
   />
   <span class="expand-icon">
     {#if expandIcon}
-      {@render expandIcon({ open })}
+      {@render expandIcon({ open, disabled })}
     {:else}
       <Icon
         icon="ChevronExpand"
@@ -1478,7 +1476,7 @@
             class="remove"
           >
             {#if removeIcon}
-              {@render removeIcon()}
+              {@render removeIcon({ option, isRemoveAll: false })}
             {:else}
               <Icon icon="Cross" style="width: 15px" />
             {/if}
@@ -1528,6 +1526,7 @@
         placeholder: placeholder_text,
         open,
         required,
+        searchText,
       })}
   </ul>
   {#if loading}
@@ -1565,7 +1564,7 @@
         onkeydown={if_enter_or_space(remove_all)}
       >
         {#if removeIcon}
-          {@render removeIcon()}
+          {@render removeIcon({ isRemoveAll: true })}
         {:else}
           <Icon icon="Cross" style="width: 15px" />
         {/if}
@@ -1727,7 +1726,13 @@
                   />
                 {/if}
                 {#if option}
-                  {@render option({ option: option_item, idx: flat_idx })}
+                  {@render option({
+          option: option_item,
+          idx: flat_idx,
+          selected,
+          active,
+          disabled: disabled ?? false,
+        })}
                 {:else if children}
                   {@render children({ option: option_item, idx: flat_idx, type: `option` })}
                 {:else if parseLabelsAsHtml}

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -39,7 +39,7 @@
     routes: NavRoute[]
     children?: Snippet<[{ is_open: boolean; panel_id: string; routes: NavRoute[] }]>
     item?: Snippet<[ItemSnippetParams]>
-    link?: Snippet<[{ href: string; label: string }]>
+    link?: Snippet<[{ href: string; label: string; isActive: boolean }]>
     menu_props?: HTMLAttributes<HTMLDivElement>
     link_props?: HTMLAttributes<HTMLAnchorElement>
     page?: Page
@@ -277,7 +277,11 @@
       {@attach item_tooltip}
     >{@html formatted.label}</span>
   {:else if link}
-    {@render link({ href: parsed_route.href, label: formatted.label })}
+    {@render link({
+    href: parsed_route.href,
+    label: formatted.label,
+    isActive: is_current(parsed_route.href) === `page`,
+  })}
   {:else}
     <a
       href={parsed_route.href}
@@ -434,7 +438,11 @@
               {@const child_formatted = format_label(child_href, true)}
               {@const child_tooltip = get_tooltip({ href: child_href })}
               {#if link}
-                {@render link({ href: child_href, label: child_formatted.label })}
+                {@render link({
+            href: child_href,
+            label: child_formatted.label,
+            isActive: is_current(child_href) === `page`,
+          })}
               {:else}
                 <a
                   href={child_href}

--- a/src/lib/PrevNext.svelte
+++ b/src/lib/PrevNext.svelte
@@ -27,10 +27,12 @@
     onkeyup?:
       | ((obj: { prev: Item; next: Item }) => Record<string, string | undefined>)
       | null
-    prev_snippet?: Snippet<[{ item: Item }]>
-    children?: Snippet<[{ kind: `prev` | `next`; item: Item }]>
+    prev_snippet?: Snippet<[{ item: Item; index: number | null; total: number }]>
+    children?: Snippet<
+      [{ kind: `prev` | `next`; item: Item; index: number | null; total: number }]
+    >
     between?: Snippet<[]>
-    next_snippet?: Snippet<[{ item: Item }]>
+    next_snippet?: Snippet<[{ item: Item; index: number | null; total: number }]>
     min_items?: number
     link_props?: HTMLAttributes<HTMLAnchorElement>
   } = $props()
@@ -44,6 +46,8 @@
 
   // Calculate prev/next items with wraparound
   let idx = $derived(items_arr.findIndex(([key]) => key === current))
+  let index = $derived(idx >= 0 ? idx : null)
+  let total = $derived(items_arr.length)
   let prev = $derived(items_arr[idx - 1] ?? items_arr[items_arr.length - 1])
   let next = $derived(items_arr[idx + 1] ?? items_arr[0])
 
@@ -94,9 +98,9 @@
     -->
     {#if prev?.length >= 2}
       {#if prev_snippet}
-        {@render prev_snippet({ item: prev })}
+        {@render prev_snippet({ item: prev, index, total })}
       {:else if children}
-        {@render children({ kind: `prev`, item: prev })}
+        {@render children({ kind: `prev`, item: prev, index, total })}
       {:else}
         <div>
           {#if titles.prev}<span>{@html titles.prev}</span>{/if}
@@ -109,9 +113,9 @@
     {@render between?.()}
     {#if next?.length >= 2}
       {#if next_snippet}
-        {@render next_snippet({ item: next })}
+        {@render next_snippet({ item: next, index, total })}
       {:else if children}
-        {@render children({ kind: `next`, item: next })}
+        {@render children({ kind: `next`, item: next, index, total })}
       {:else}
         <div>
           {#if titles.next}<span>{@html titles.next}</span>{/if}

--- a/src/lib/PrevNext.svelte
+++ b/src/lib/PrevNext.svelte
@@ -46,6 +46,7 @@
 
   // Calculate prev/next items with wraparound
   let idx = $derived(items_arr.findIndex(([key]) => key === current))
+  // position of `current` in items (not the prev/next item), null if not found
   let index = $derived(idx >= 0 ? idx : null)
   let total = $derived(items_arr.length)
   let prev = $derived(items_arr[idx - 1] ?? items_arr[items_arr.length - 1])

--- a/src/lib/Toggle.svelte
+++ b/src/lib/Toggle.svelte
@@ -11,7 +11,7 @@
   }: HTMLAttributes<HTMLLabelElement> & {
     checked?: boolean // whether the toggle is on or off
     onkeydown?: (event: KeyboardEvent) => void
-    children?: Snippet<[]>
+    children?: Snippet<[{ checked: boolean }]>
     input_props?: HTMLAttributes<HTMLInputElement>
   } = $props()
 
@@ -27,7 +27,7 @@
 </script>
 
 <label {...rest}>
-  {@render children?.()}
+  {@render children?.({ checked })}
   <input
     type="checkbox"
     bind:checked

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,12 +29,12 @@ export type PlaceholderConfig = {
 
 // custom events created by MultiSelect
 export interface MultiSelectEvents<T extends Option = Option> {
-  onadd?: (data: { option: T }) => unknown
+  onadd?: (data: { option: T; selected: T[] }) => unknown
   oncreate?: (data: { option: T }) => unknown // fires when users entered custom text from which new option is created
-  onremove?: (data: { option: T }) => unknown
+  onremove?: (data: { option: T; selected: T[] }) => unknown
   onremoveAll?: (data: { options: T[] }) => unknown
   onselectAll?: (data: { options: T[] }) => unknown // fires when select all is triggered
-  onreorder?: (data: { options: T[] }) => unknown // fires when selected options are reordered via drag-and-drop
+  onreorder?: (data: { options: T[]; previous: T[] }) => unknown // fires when selected options are reordered via drag-and-drop
   onchange?: (data: {
     option?: T
     options?: T[]
@@ -46,7 +46,7 @@ export interface MultiSelectEvents<T extends Option = Option> {
   oncollapseAll?: (data: { groups: string[] }) => unknown // fires when all groups are collapsed
   onexpandAll?: (data: { groups: string[] }) => unknown // fires when all groups are expanded
   // Additional events for user feedback and analytics
-  onsearch?: (data: { searchText: string; matchingCount: number }) => unknown // fires (debounced) when search text changes
+  onsearch?: (data: { searchText: string; matchingOptions: T[] }) => unknown // fires (debounced) when search text changes
   onmaxreached?: (
     data: { selected: T[]; maxSelect: number; attemptedOption: T },
   ) => unknown // fires when user tries to exceed maxSelect
@@ -86,7 +86,14 @@ export type LoadOptions<T extends Option = Option> =
 
 type AfterInputProps = Pick<
   MultiSelectProps,
-  `selected` | `disabled` | `invalid` | `id` | `placeholder` | `open` | `required`
+  | `selected`
+  | `disabled`
+  | `invalid`
+  | `id`
+  | `placeholder`
+  | `open`
+  | `required`
+  | `searchText`
 >
 type UserMsgProps = {
   searchText: string
@@ -107,16 +114,20 @@ export type GroupedOptions<T extends Option = Option> = {
 }
 
 export interface MultiSelectSnippets<T extends Option = Option> {
-  expandIcon?: Snippet<[{ open: boolean }]>
+  expandIcon?: Snippet<[{ open: boolean; disabled: boolean }]>
   selectedItem?: Snippet<[{ option: T; idx: number }]>
   children?: Snippet<[{ option: T; idx: number; type: `option` | `selected` }]>
-  removeIcon?: Snippet
+  removeIcon?: Snippet<
+    [{ option: T; isRemoveAll: false } | { option?: undefined; isRemoveAll: true }]
+  >
   afterInput?: Snippet<[AfterInputProps]>
   spinner?: Snippet
   disabledIcon?: Snippet
-  option?: Snippet<[{ option: T; idx: number }]>
+  option?: Snippet<
+    [{ option: T; idx: number; selected: boolean; active: boolean; disabled: boolean }]
+  >
   userMsg?: Snippet<[UserMsgProps]>
-  groupHeader?: Snippet<[GroupHeaderProps<T>]> // custom group header rendering
+  groupHeader?: Snippet<[GroupHeaderProps<T>]>
 }
 
 export interface PortalParams {

--- a/src/routes/(demos)/events/+page.md
+++ b/src/routes/(demos)/events/+page.md
@@ -191,19 +191,23 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
 
 #### Custom Events
 
-| Event          | Description                                      | Data Structure                                                          |
-| -------------- | ------------------------------------------------ | ----------------------------------------------------------------------- |
-| `onadd`        | Fired when an option is added to selection       | `{ option: T }`                                                         |
-| `onremove`     | Fired when an option is removed from selection   | `{ option: T }`                                                         |
-| `onremoveAll`  | Fired when all options are removed               | `{ options: T[] }`                                                      |
-| `onchange`     | Fired for any selection change                   | `{ option?: T, options?: T[], type: 'add' \| 'remove' \| 'removeAll' }` |
-| `oncreate`     | Fired when user creates a custom option          | `{ option: T }`                                                         |
-| `onopen`       | Fired when dropdown opens                        | `{ event: Event }`                                                      |
-| `onclose`      | Fired when dropdown closes                       | `{ event: Event }`                                                      |
-| `onsearch`     | Fired (debounced 150ms) when search text changes | `{ searchText: string, matchingCount: number }`                         |
-| `onmaxreached` | Fired when user tries to exceed maxSelect        | `{ selected: T[], maxSelect: number, attemptedOption: T }`              |
-| `onduplicate`  | Fired when user tries to add duplicate           | `{ option: T }`                                                         |
-| `onactivate`   | Fired on keyboard navigation through options     | `{ option: T \| null, index: number \| null }`                          |
+| Event           | Description                                      | Data Structure                                                                                      |
+| --------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `onadd`         | Fired when an option is added to selection       | `{ option: T, selected: T[] }`                                                                      |
+| `onremove`      | Fired when an option is removed from selection   | `{ option: T, selected: T[] }`                                                                      |
+| `onremoveAll`   | Fired when all options are removed               | `{ options: T[] }`                                                                                  |
+| `onselectAll`   | Fired when select all is triggered               | `{ options: T[] }`                                                                                  |
+| `onreorder`     | Fired when selected options are reordered        | `{ options: T[], previous: T[] }`                                                                   |
+| `onchange`      | Fired for any selection change                   | `{ option?: T, options?: T[], type: 'add' \| 'remove' \| 'removeAll' \| 'selectAll' \| 'reorder' }` |
+| `oncreate`      | Fired when user creates a custom option          | `{ option: T }`                                                                                     |
+| `onopen`        | Fired when dropdown opens                        | `{ event: Event }`                                                                                  |
+| `onclose`       | Fired when dropdown closes                       | `{ event: Event }`                                                                                  |
+| `onsearch`      | Fired (debounced 150ms) when search text changes | `{ searchText: string, matchingOptions: T[] }`                                                      |
+| `onmaxreached`  | Fired when user tries to exceed maxSelect        | `{ selected: T[], maxSelect: number, attemptedOption: T }`                                          |
+| `onduplicate`   | Fired when user tries to add duplicate           | `{ option: T }`                                                                                     |
+| `onactivate`    | Fired on keyboard navigation through options     | `{ option: T \| null, index: number \| null }`                                                      |
+| `oncollapseAll` | Fired when all groups are collapsed              | `{ groups: string[] }`                                                                              |
+| `onexpandAll`   | Fired when all groups are expanded               | `{ groups: string[] }`                                                                              |
 
 #### Native DOM Events
 

--- a/src/routes/(demos)/nav/+page.md
+++ b/src/routes/(demos)/nav/+page.md
@@ -150,7 +150,7 @@ Use the `link` snippet to customize how all links render:
 </script>
 
 <Nav {routes} {page}>
-  {#snippet link({ href, label })}
+  {#snippet link({ href, label, isActive })}
     <a {href} onclick={(event: MouseEvent) => event.preventDefault()}>🔗 {label}</a>
   {/snippet}
 </Nav>

--- a/src/routes/(demos)/nav/+page.md
+++ b/src/routes/(demos)/nav/+page.md
@@ -151,7 +151,11 @@ Use the `link` snippet to customize how all links render:
 
 <Nav {routes} {page}>
   {#snippet link({ href, label, isActive })}
-    <a {href} onclick={(event: MouseEvent) => event.preventDefault()}>🔗 {label}</a>
+    <a
+      {href}
+      style:font-weight={isActive ? `bold` : `normal`}
+      onclick={(event: MouseEvent) => event.preventDefault()}
+    >🔗 {label}</a>
   {/snippet}
 </Nav>
 ```

--- a/src/routes/(demos)/snippets/+page.md
+++ b/src/routes/(demos)/snippets/+page.md
@@ -25,10 +25,14 @@
     <LanguageSnippet {option} />
   {/snippet}
   {#snippet expandIcon({ open, disabled })}
-    <Icon icon={open ? 'Collapse' : 'Expand'} />
+    <Icon icon={open ? 'Collapse' : 'Expand'} style={disabled ? `opacity: 0.5` : ``} />
   {/snippet}
-  {#snippet removeIcon({ option, isRemoveAll })}
-    <MinusIcon width="1em" />
+  {#snippet removeIcon({ isRemoveAll })}
+    {#if isRemoveAll}
+      <span style="font-size: 0.8em">Clear all</span>
+    {:else}
+      <MinusIcon width="1em" />
+    {/if}
   {/snippet}
 </MultiSelect>
 ```
@@ -60,22 +64,16 @@
   {#snippet selectedItem({ option })}
     <LanguageSnippet {option} />
   {/snippet}
-  {#snippet option({ option, idx, selected, active, disabled })}
-    <LanguageSnippet {option} />
+  {#snippet option({ option, selected })}
+    <LanguageSnippet {option} style={selected ? `opacity: 0.6` : ``} />
   {/snippet}
   {#snippet expandIcon({ open: expandOpen, disabled })}
-    <button
-      onclick={() => (open = false)}
-      onkeyup={(event: KeyboardEvent) => {
-        event.preventDefault()
-        if ([`Enter`, `Space`].includes(event.code)) open = !open
-      }}
-    >
+    <button {disabled}>
       <Icon icon={expandOpen ? `Collapse` : `Expand`} />
     </button>
   {/snippet}
-  {#snippet removeIcon({ option, isRemoveAll })}
-    <span style="width: 2ex">x</span>
+  {#snippet removeIcon({ option: opt, isRemoveAll })}
+    <span style="width: 2ex">{isRemoveAll ? `✕✕` : `✕`}</span>
   {/snippet}
 </MultiSelect>
 ```

--- a/src/routes/(demos)/snippets/+page.md
+++ b/src/routes/(demos)/snippets/+page.md
@@ -24,10 +24,10 @@
   {#snippet children({ option })}
     <LanguageSnippet {option} />
   {/snippet}
-  {#snippet expandIcon({ open })}
+  {#snippet expandIcon({ open, disabled })}
     <Icon icon={open ? 'Collapse' : 'Expand'} />
   {/snippet}
-  {#snippet removeIcon()}
+  {#snippet removeIcon({ option, isRemoveAll })}
     <MinusIcon width="1em" />
   {/snippet}
 </MultiSelect>
@@ -60,10 +60,10 @@
   {#snippet selectedItem({ option })}
     <LanguageSnippet {option} />
   {/snippet}
-  {#snippet option({ option })}
+  {#snippet option({ option, idx, selected, active, disabled })}
     <LanguageSnippet {option} />
   {/snippet}
-  {#snippet expandIcon({ open: expandOpen })}
+  {#snippet expandIcon({ open: expandOpen, disabled })}
     <button
       onclick={() => (open = false)}
       onkeyup={(event: KeyboardEvent) => {
@@ -74,7 +74,7 @@
       <Icon icon={expandOpen ? `Collapse` : `Expand`} />
     </button>
   {/snippet}
-  {#snippet removeIcon()}
+  {#snippet removeIcon({ option, isRemoveAll })}
     <span style="width: 2ex">x</span>
   {/snippet}
 </MultiSelect>

--- a/src/routes/(demos)/snippets/+page.md
+++ b/src/routes/(demos)/snippets/+page.md
@@ -25,7 +25,7 @@
     <LanguageSnippet {option} />
   {/snippet}
   {#snippet expandIcon({ open, disabled })}
-    <Icon icon={open ? 'Collapse' : 'Expand'} style={disabled ? `opacity: 0.5` : ``} />
+    <Icon icon={open ? 'Collapse' : 'Expand'} style={disabled ? `opacity: 0.5` : null} />
   {/snippet}
   {#snippet removeIcon({ isRemoveAll })}
     {#if isRemoveAll}
@@ -73,7 +73,9 @@
     </button>
   {/snippet}
   {#snippet removeIcon({ option: opt, isRemoveAll })}
-    <span style="width: 2ex">{isRemoveAll ? `✕✕` : `✕`}</span>
+    <span style="width: 2ex" title={isRemoveAll ? `Remove all` : `Remove ${opt}`}>{
+      isRemoveAll ? `✕✕` : `✕`
+    }</span>
   {/snippet}
 </MultiSelect>
 ```

--- a/src/site/Examples.md
+++ b/src/site/Examples.md
@@ -187,7 +187,7 @@ value = {JSON.stringify(value) || `null`}
     }
   }}
 >
-  {#snippet option({ idx, option })}
+  {#snippet option({ idx, option, selected, active, disabled })}
     <RepoSnippet {idx} {option} />
   {/snippet}
 </MultiSelect>

--- a/src/site/Examples.md
+++ b/src/site/Examples.md
@@ -187,8 +187,8 @@ value = {JSON.stringify(value) || `null`}
     }
   }}
 >
-  {#snippet option({ idx, option, selected, active, disabled })}
-    <RepoSnippet {idx} {option} />
+  {#snippet option({ idx, option, selected })}
+    <RepoSnippet {idx} {option} style={selected ? `opacity: 0.5` : ``} />
   {/snippet}
 </MultiSelect>
 {#if show_confetti}

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -987,13 +987,14 @@ test.describe(`snippets`, () => {
       `unexpected number of custom remove icon snippets rendered`,
     ).toHaveCount(3)
 
-    const remove_all_svg_locator = page.locator(
-      `#languages-1 button.remove-all > svg`,
+    const remove_all_label = page.locator(
+      `#languages-1 button.remove-all > span`,
     )
     await expect(
-      remove_all_svg_locator,
-      `custom remove-all icon snippet is not rendered`,
+      remove_all_label,
+      `custom remove-all snippet is not rendered`,
     ).toHaveCount(1)
+    await expect(remove_all_label).toHaveText(`Clear all`)
   })
 })
 

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -949,7 +949,7 @@ test.describe(`maxSelect`, () => {
 })
 
 test.describe(`snippets`, () => {
-  test(`renders removeIcon snippet for individual remove buttons and the remove-all button`, async ({ page }) => {
+  test(`renders custom removeIcon snippets with per-item icons and Clear all label`, async ({ page }) => {
     await page.goto(`/snippets`, { waitUntil: `networkidle` })
 
     // Use .expand-icon wrapper class for robust selection that doesn't depend on exact sibling order

--- a/tests/vitest/CopyButton.test.ts
+++ b/tests/vitest/CopyButton.test.ts
@@ -3,6 +3,7 @@ import type { ComponentProps } from 'svelte'
 import { mount, tick, unmount } from 'svelte'
 import { beforeEach, expect, test, vi } from 'vitest'
 import TestCopyButtonGlobalUpdate from './TestCopyButtonGlobalUpdate.svelte'
+import TestCopyButtonSnippet from './TestCopyButtonSnippet.svelte'
 
 const mock_write_text = vi.fn()
 vi.stubGlobal(`navigator`, { clipboard: { writeText: mock_write_text } })
@@ -12,10 +13,6 @@ const default_labels = {
   success: { icon: `Check`, text: `success` },
   error: { icon: `Alert`, text: `error` },
 } as const
-const empty_children_snippet = (() => ``) as unknown as NonNullable<
-  ComponentProps<typeof CopyButton>[`children`]
->
-
 const mount_copy_button = (
   props: Partial<ComponentProps<typeof CopyButton>> = {},
 ) => {
@@ -127,11 +124,20 @@ test(`renders default icon and ready label`, () => {
   expect(copy_button.textContent).toContain(`ready`)
 })
 
-test(`custom children render without default content wrapper`, () => {
-  const { copy_button } = mount_copy_button({ children: empty_children_snippet })
-  expect(copy_button.textContent).toBe(``)
-  expect(copy_button.querySelector(`svg`)).toBeNull()
-})
+test.each([true, false])(
+  `custom children snippet renders and receives disabled=%s`,
+  (disabled) => {
+    mount(TestCopyButtonSnippet, {
+      target: document.body,
+      props: { content: `test`, disabled },
+    })
+    const copy_button = document.body.querySelector(`[data-sms-copy]`) as HTMLElement
+    expect(copy_button.querySelector(`svg`)).toBeNull()
+    const snippet = copy_button.querySelector(`.copy-snippet`) as HTMLElement
+    expect(snippet.dataset.disabled).toBe(`${disabled}`)
+    expect(snippet.dataset.state).toBe(`ready`)
+  },
+)
 
 test(`disabled=true blocks copy and preserves ready state`, async () => {
   const { copy_button } = mount_copy_button({

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -11,6 +11,8 @@ import { get_label, get_style } from '$lib/utils'
 import { doc_query, type Test2WayBindProps } from './index'
 import Test2WayBind from './Test2WayBind.svelte'
 import TestChildrenSnippet from './TestChildrenSnippet.svelte'
+import TestMultiSelectSnippets from './TestMultiSelectSnippets.svelte'
+import TestOptionSnippet from './TestOptionSnippet.svelte'
 
 const mouseover = new MouseEvent(`mouseover`, { bubbles: true })
 const input_event = new InputEvent(`input`, { bubbles: true })
@@ -750,6 +752,105 @@ test(`children snippet receives type='selected' for pills and type='option' for 
   for (const span of option_spans) {
     expect(span.dataset.type).toBe(`option`)
   }
+})
+
+test(`option snippet receives selected, active, and disabled booleans`, async () => {
+  mount(TestOptionSnippet, {
+    target: document.body,
+    props: {
+      options: [
+        { label: `Enabled`, value: 1 },
+        { label: `Disabled`, value: 2, disabled: true },
+      ],
+      selected: [{ label: `Enabled`, value: 1 }],
+      keepSelectedInDropdown: `plain`,
+    },
+  })
+
+  // open dropdown
+  doc_query(`div.multiselect`).dispatchEvent(
+    new MouseEvent(`mouseup`, { bubbles: true }),
+  )
+  await tick()
+
+  const option_spans = [
+    ...document.querySelectorAll<HTMLElement>(`ul.options span.option-snippet`),
+  ]
+  expect(option_spans).toHaveLength(2)
+
+  // first option is selected (keepSelectedInDropdown shows it)
+  expect(option_spans[0].dataset.selected).toBe(`true`)
+  expect(option_spans[0].dataset.disabled).toBe(`false`)
+
+  // second option is disabled
+  expect(option_spans[1].dataset.selected).toBe(`false`)
+  expect(option_spans[1].dataset.disabled).toBe(`true`)
+})
+
+test(`expandIcon snippet receives open and disabled`, () => {
+  mount(TestMultiSelectSnippets, {
+    target: document.body,
+    props: { options: [1, 2, 3], disabled: true },
+  })
+
+  const expand = doc_query<HTMLElement>(`.expand-snippet`)
+  expect(expand.dataset.disabled).toBe(`true`)
+  expect(expand.dataset.open).toBe(`false`)
+})
+
+test(`expandIcon open toggles to true when dropdown opens`, async () => {
+  mount(TestMultiSelectSnippets, {
+    target: document.body,
+    props: { options: [1, 2, 3] },
+  })
+
+  const expand = doc_query<HTMLElement>(`.expand-snippet`)
+  expect(expand.dataset.open).toBe(`false`)
+
+  doc_query(`div.multiselect`).dispatchEvent(
+    new MouseEvent(`mouseup`, { bubbles: true }),
+  )
+  await tick()
+  expect(expand.dataset.open).toBe(`true`)
+})
+
+test(`removeIcon snippet receives option for per-item and remove_all flag`, async () => {
+  mount(TestMultiSelectSnippets, {
+    target: document.body,
+    props: { options: [1, 2, 3], selected: [1, 2] },
+  })
+  await tick()
+
+  const remove_spans = [
+    ...document.querySelectorAll<HTMLElement>(`.remove-snippet`),
+  ]
+  expect(remove_spans).toHaveLength(3)
+
+  // first 2 are per-option removes
+  expect(remove_spans[0].dataset.isRemoveAll).toBe(`false`)
+  expect(remove_spans[0].dataset.option).toBe(`1`)
+  expect(remove_spans[1].dataset.isRemoveAll).toBe(`false`)
+  expect(remove_spans[1].dataset.option).toBe(`2`)
+  // last is the remove-all button
+  expect(remove_spans[2].dataset.isRemoveAll).toBe(`true`)
+  expect(remove_spans[2].dataset.option).toBeUndefined()
+})
+
+test(`afterInput snippet receives searchText`, async () => {
+  mount(TestMultiSelectSnippets, {
+    target: document.body,
+    props: { options: [1, 2, 3] },
+  })
+
+  const after_input = doc_query<HTMLElement>(`.after-input-snippet`)
+  expect(after_input.dataset.searchText).toBe(``)
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.value = `test`
+  input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+  await tick()
+
+  expect(after_input.dataset.searchText).toBe(`test`)
 })
 
 test(`filters dropdown to show only matching options when entering text`, async () => {
@@ -1557,7 +1658,7 @@ test(`drag-drop reordering fires onreorder and onchange events`, async () => {
 
   // verify onreorder was called with the new order
   expect(onreorder_spy).toHaveBeenCalledTimes(1)
-  expect(onreorder_spy).toHaveBeenCalledWith({ options: [2, 1, 3] })
+  expect(onreorder_spy).toHaveBeenCalledWith({ options: [2, 1, 3], previous: [1, 2, 3] })
 
   // verify onchange was called with type 'reorder'
   expect(onchange_spy).toHaveBeenCalledTimes(1)
@@ -1797,9 +1898,52 @@ test.each([
     expect(onadd_spy).toHaveBeenCalledTimes(1)
     expect(onadd_spy).toHaveBeenCalledWith({
       option: expected_created_option,
+      selected: [expected_created_option],
     })
   },
 )
+
+test(`onadd selected accumulates and onremove selected reflects removal`, async () => {
+  const onadd_spy = vi.fn()
+  const onremove_spy = vi.fn()
+
+  mount(MultiSelect, {
+    target: document.body,
+    props: { options: [1, 2, 3], onadd: onadd_spy, onremove: onremove_spy },
+  })
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.focus()
+  await tick()
+  doc_query(`ul.options li`).click()
+  await tick()
+  expect(onadd_spy).toHaveBeenLastCalledWith({ option: 1, selected: [1] })
+
+  input.focus()
+  await tick()
+  doc_query(`ul.options li`).click()
+  await tick()
+  expect(onadd_spy).toHaveBeenLastCalledWith({ option: 2, selected: [1, 2] })
+
+  doc_query(`ul.selected button.remove`).click()
+  expect(onremove_spy).toHaveBeenCalledWith({ option: 1, selected: [2] })
+})
+
+test(`onadd selected reflects replacement when maxSelect=1`, async () => {
+  const onadd_spy = vi.fn()
+  mount(MultiSelect, {
+    target: document.body,
+    props: { options: [1, 2, 3], maxSelect: 1, selected: [1], onadd: onadd_spy },
+  })
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.focus()
+  await tick()
+  doc_query(`ul.options li`).click()
+  await tick()
+
+  expect(onadd_spy).toHaveBeenCalledWith({ option: 2, selected: [2] })
+})
 
 test.each(
   [
@@ -4659,7 +4803,7 @@ describe(`onsearch event`, () => {
     expect(onsearch_spy).toHaveBeenCalledTimes(1)
     expect(onsearch_spy).toHaveBeenCalledWith({
       searchText: `1`,
-      matchingCount: 2, // matches "1" and "10"
+      matchingOptions: [1, 10],
     })
 
     // Clear the search - should also fire
@@ -4670,7 +4814,7 @@ describe(`onsearch event`, () => {
     expect(onsearch_spy).toHaveBeenCalledTimes(2)
     expect(onsearch_spy).toHaveBeenNthCalledWith(2, {
       searchText: ``,
-      matchingCount: 6, // all options match empty search
+      matchingOptions: [1, 2, 3, 10, 20, 30],
     })
 
     vi.useRealTimers()
@@ -4728,13 +4872,13 @@ describe(`onsearch event`, () => {
     expect(onsearch_spy).toHaveBeenCalledTimes(1)
     expect(onsearch_spy).toHaveBeenCalledWith({
       searchText: `ap`,
-      matchingCount: 2, // matches "apple" and "apricot"
+      matchingOptions: [`apple`, `apricot`],
     })
 
     vi.useRealTimers()
   })
 
-  test(`matchingCount is 0 when no options match`, async () => {
+  test(`matchingOptions is empty when no options match`, async () => {
     vi.useFakeTimers()
     const onsearch_spy = vi.fn()
 
@@ -4747,14 +4891,13 @@ describe(`onsearch event`, () => {
     input.focus()
     await tick()
 
-    // Type something that matches nothing
     input.value = `xyz`
     input.dispatchEvent(input_event)
     await vi.advanceTimersByTimeAsync(200)
 
     expect(onsearch_spy).toHaveBeenCalledWith({
       searchText: `xyz`,
-      matchingCount: 0,
+      matchingOptions: [],
     })
 
     vi.useRealTimers()

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -781,10 +781,23 @@ test(`option snippet receives selected, active, and disabled booleans`, async ()
   // first option is selected (keepSelectedInDropdown shows it)
   expect(option_spans[0].dataset.selected).toBe(`true`)
   expect(option_spans[0].dataset.disabled).toBe(`false`)
+  expect(option_spans[0].dataset.active).toBe(`false`)
 
   // second option is disabled
   expect(option_spans[1].dataset.selected).toBe(`false`)
   expect(option_spans[1].dataset.disabled).toBe(`true`)
+  expect(option_spans[1].dataset.active).toBe(`false`)
+
+  // hover first option to activate it
+  doc_query(`ul.options > li`).dispatchEvent(
+    new MouseEvent(`mouseover`, { bubbles: true }),
+  )
+  await tick()
+  const updated_spans = [
+    ...document.querySelectorAll<HTMLElement>(`ul.options span.option-snippet`),
+  ]
+  expect(updated_spans[0].dataset.active).toBe(`true`)
+  expect(updated_spans[1].dataset.active).toBe(`false`)
 })
 
 test(`expandIcon snippet receives open and disabled`, () => {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -827,7 +827,7 @@ test(`expandIcon open toggles to true when dropdown opens`, async () => {
   expect(expand.dataset.open).toBe(`true`)
 })
 
-test(`removeIcon snippet receives option for per-item and remove_all flag`, async () => {
+test(`removeIcon snippet receives option for per-item and isRemoveAll flag`, async () => {
   mount(TestMultiSelectSnippets, {
     target: document.body,
     props: { options: [1, 2, 3], selected: [1, 2] },
@@ -1939,7 +1939,8 @@ test(`onadd selected accumulates and onremove selected reflects removal`, async 
   expect(onadd_spy).toHaveBeenLastCalledWith({ option: 2, selected: [1, 2] })
 
   doc_query(`ul.selected button.remove`).click()
-  expect(onremove_spy).toHaveBeenCalledWith({ option: 1, selected: [2] })
+  expect(onremove_spy).toHaveBeenCalledTimes(1)
+  expect(onremove_spy).toHaveBeenLastCalledWith({ option: 1, selected: [2] })
 })
 
 test(`onadd selected reflects replacement when maxSelect=1`, async () => {

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -4,6 +4,7 @@ import type { Page } from '@sveltejs/kit'
 import { mount, tick } from 'svelte'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { doc_query } from './index'
+import TestNavLinkSnippet from './TestNavLinkSnippet.svelte'
 
 vi.mock(`$app/state`, () => ({ page: { url: { pathname: `/` } } }))
 
@@ -444,6 +445,26 @@ describe(`Nav`, () => {
     expect(dropdown2.classList.contains(`active`)).toBe(
       !is_active && pathname === `/other`,
     )
+  })
+
+  test(`link snippet receives is_active for current and non-current routes`, () => {
+    const mock_page = { url: { pathname: `/about` } } as Page
+    mount(TestNavLinkSnippet, {
+      target: document.body,
+      props: { routes: [`/`, `/about`, `/contact`], page: mock_page },
+    })
+
+    const links = [...document.querySelectorAll<HTMLElement>(`.link-snippet`)]
+    expect(links).toHaveLength(3)
+
+    expect(links[0].dataset.isActive).toBe(`false`)
+    expect(links[0].getAttribute(`href`)).toBe(`/`)
+
+    expect(links[1].dataset.isActive).toBe(`true`)
+    expect(links[1].getAttribute(`href`)).toBe(`/about`)
+
+    expect(links[2].dataset.isActive).toBe(`false`)
+    expect(links[2].getAttribute(`href`)).toBe(`/contact`)
   })
 
   test(`dropdown accessibility: role and aria-label attributes`, () => {

--- a/tests/vitest/PrevNext.test.ts
+++ b/tests/vitest/PrevNext.test.ts
@@ -161,7 +161,7 @@ describe(`PrevNext`, () => {
     })
 
     const snippets = [
-      ...document.querySelectorAll<HTMLElement>(`.prevnext-snippet`),
+      ...target.querySelectorAll<HTMLElement>(`.prevnext-snippet`),
     ]
     expect(snippets).toHaveLength(2)
 
@@ -183,7 +183,7 @@ describe(`PrevNext`, () => {
     })
 
     const snippets = [
-      ...document.querySelectorAll<HTMLElement>(`.prevnext-snippet`),
+      ...target.querySelectorAll<HTMLElement>(`.prevnext-snippet`),
     ]
     expect(snippets).toHaveLength(2)
     expect(snippets[0].dataset.index).toBeUndefined()

--- a/tests/vitest/PrevNext.test.ts
+++ b/tests/vitest/PrevNext.test.ts
@@ -156,7 +156,7 @@ describe(`PrevNext`, () => {
 
   test(`children snippet receives index and total`, () => {
     mount(TestPrevNextSnippet, {
-      target: document.body,
+      target,
       props: { items, current: `page2` },
     })
 
@@ -176,9 +176,9 @@ describe(`PrevNext`, () => {
     expect(snippets[1].dataset.total).toBe(`4`)
   })
 
-  test(`children snippet passes index=null when current is invalid`, () => {
+  test(`children snippet passes index=undefined when current is invalid`, () => {
     mount(TestPrevNextSnippet, {
-      target: document.body,
+      target,
       props: { items, current: `nonexistent`, log: `silent` },
     })
 

--- a/tests/vitest/PrevNext.test.ts
+++ b/tests/vitest/PrevNext.test.ts
@@ -1,6 +1,7 @@
 import { PrevNext } from '$lib'
 import { mount } from 'svelte'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import TestPrevNextSnippet from './TestPrevNextSnippet.svelte'
 
 const items = [`page1`, `page2`, `page3`, `page4`]
 
@@ -151,6 +152,43 @@ describe(`PrevNext`, () => {
 
     globalThis.dispatchEvent(new KeyboardEvent(`keyup`, { key: `PageDown` }))
     expect(replaceStateSpy).toHaveBeenCalledWith({}, ``, `page3`)
+  })
+
+  test(`children snippet receives index and total`, () => {
+    mount(TestPrevNextSnippet, {
+      target: document.body,
+      props: { items, current: `page2` },
+    })
+
+    const snippets = [
+      ...document.querySelectorAll<HTMLElement>(`.prevnext-snippet`),
+    ]
+    expect(snippets).toHaveLength(2)
+
+    // prev snippet gets current page index and total count
+    expect(snippets[0].dataset.kind).toBe(`prev`)
+    expect(snippets[0].dataset.index).toBe(`1`)
+    expect(snippets[0].dataset.total).toBe(`4`)
+
+    // next snippet gets same index/total (it's the current page position)
+    expect(snippets[1].dataset.kind).toBe(`next`)
+    expect(snippets[1].dataset.index).toBe(`1`)
+    expect(snippets[1].dataset.total).toBe(`4`)
+  })
+
+  test(`children snippet passes index=null when current is invalid`, () => {
+    mount(TestPrevNextSnippet, {
+      target: document.body,
+      props: { items, current: `nonexistent`, log: `silent` },
+    })
+
+    const snippets = [
+      ...document.querySelectorAll<HTMLElement>(`.prevnext-snippet`),
+    ]
+    expect(snippets).toHaveLength(2)
+    expect(snippets[0].dataset.index).toBeUndefined()
+    expect(snippets[1].dataset.index).toBeUndefined()
+    expect(snippets[0].dataset.total).toBe(`4`)
   })
 
   test(`link_props and default attributes applied to links`, () => {

--- a/tests/vitest/TestCopyButtonSnippet.svelte
+++ b/tests/vitest/TestCopyButtonSnippet.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { CopyButton } from '$lib'
+  import type { ComponentProps } from 'svelte'
+
+  let { ...rest }: ComponentProps<typeof CopyButton> = $props()
+</script>
+
+<CopyButton {...rest}>
+  {#snippet children({ state, disabled })}
+    <span class="copy-snippet" data-state={state} data-disabled={disabled}>{state}</span>
+  {/snippet}
+</CopyButton>

--- a/tests/vitest/TestMultiSelectSnippets.svelte
+++ b/tests/vitest/TestMultiSelectSnippets.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import MultiSelect from '$lib'
+  import type { MultiSelectProps } from '$lib/types'
+
+  let { ...rest }: MultiSelectProps = $props()
+</script>
+
+<MultiSelect {...rest}>
+  {#snippet expandIcon({ open, disabled })}
+    <span class="expand-snippet" data-open={open} data-disabled={disabled}>▼</span>
+  {/snippet}
+  {#snippet removeIcon({ option, isRemoveAll })}
+    <span class="remove-snippet" data-option={option} data-is-remove-all={isRemoveAll}
+    >✕</span>
+  {/snippet}
+  {#snippet afterInput({ searchText })}
+    <span class="after-input-snippet" data-search-text={searchText}>after</span>
+  {/snippet}
+  {#snippet groupHeader({ group, options, collapsed })}
+    <span
+      class="group-header-snippet"
+      data-group={group}
+      data-count={options.length}
+      data-collapsed={collapsed}
+    >{group}</span>
+  {/snippet}
+</MultiSelect>

--- a/tests/vitest/TestNavLinkSnippet.svelte
+++ b/tests/vitest/TestNavLinkSnippet.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Nav } from '$lib'
+  import type { ComponentProps } from 'svelte'
+
+  let { ...rest }: ComponentProps<typeof Nav> = $props()
+</script>
+
+<Nav {...rest}>
+  {#snippet link({ href, label, isActive })}
+    <a class="link-snippet" {href} data-is-active={isActive}>{label}</a>
+  {/snippet}
+</Nav>

--- a/tests/vitest/TestOptionSnippet.svelte
+++ b/tests/vitest/TestOptionSnippet.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import MultiSelect from '$lib'
+  import type { MultiSelectProps } from '$lib/types'
+
+  let { ...rest }: MultiSelectProps = $props()
+</script>
+
+<MultiSelect {...rest}>
+  {#snippet option({ option, idx, selected, active, disabled })}
+    <span
+      class="option-snippet"
+      data-selected={selected}
+      data-active={active}
+      data-disabled={disabled}
+      data-idx={idx}
+    >{option}</span>
+  {/snippet}
+</MultiSelect>

--- a/tests/vitest/TestPrevNextSnippet.svelte
+++ b/tests/vitest/TestPrevNextSnippet.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { PrevNext } from '$lib'
+  import type { ComponentProps } from 'svelte'
+
+  let { ...rest }: ComponentProps<typeof PrevNext> = $props()
+</script>
+
+<PrevNext {...rest}>
+  {#snippet children({ kind, item, index, total })}
+    <span
+      class="prevnext-snippet"
+      data-kind={kind}
+      data-index={index}
+      data-total={total}
+    >{item[0]}</span>
+  {/snippet}
+</PrevNext>

--- a/tests/vitest/TestToggleSnippet.svelte
+++ b/tests/vitest/TestToggleSnippet.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Toggle } from '$lib'
+  import type { ComponentProps } from 'svelte'
+
+  let { ...rest }: ComponentProps<typeof Toggle> = $props()
+</script>
+
+<Toggle {...rest}>
+  {#snippet children({ checked })}
+    <span class="toggle-snippet" data-checked={checked}>label</span>
+  {/snippet}
+</Toggle>

--- a/tests/vitest/Toggle.test.ts
+++ b/tests/vitest/Toggle.test.ts
@@ -1,6 +1,7 @@
 import { Toggle } from '$lib'
-import { mount } from 'svelte'
+import { mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
+import TestToggleSnippet from './TestToggleSnippet.svelte'
 
 describe(`Toggle`, () => {
   const get_input = () =>
@@ -106,6 +107,21 @@ describe(`Toggle`, () => {
     expect(document.body.querySelector(`label`)).toBeTruthy()
     expect(document.body.querySelector(`input[type="checkbox"]`)).toBeTruthy()
     expect(document.body.querySelector(`span`)).toBeTruthy()
+  })
+
+  test(`children snippet receives checked state and updates on toggle`, async () => {
+    mount(TestToggleSnippet, { target: document.body, props: { checked: false } })
+
+    const snippet = document.body.querySelector(`.toggle-snippet`) as HTMLElement
+    expect(snippet.dataset.checked).toBe(`false`)
+
+    get_input().click()
+    await tick()
+    expect(snippet.dataset.checked).toBe(`true`)
+
+    get_input().click()
+    await tick()
+    expect(snippet.dataset.checked).toBe(`false`)
   })
 
   test(`two-way binding works`, () => {


### PR DESCRIPTION
## Breaking changes

- **Event callbacks**: `onadd`/`onremove` now include `selected` array, `onreorder` includes `previous` snapshot, `onsearch` replaces `matchingCount` number with full `matchingOptions` array
- **Snippet props**: `expandIcon` gets `disabled`, `removeIcon` gets `{option, isRemoveAll}` discriminated union, `option` snippet gets `selected`/`active`/`disabled` booleans, `afterInput` gets `searchText`, `Toggle` children get `checked`, `CopyButton` children get `disabled`, `Nav` link gets `isActive`, `PrevNext` snippets get `index`/`total`

## Documentation

- Updated readme, demo pages, and events reference table (added missing `onselectAll`, `onreorder`, `oncollapseAll`, `onexpandAll` rows; fixed incomplete `onchange` type union)