### PR TITLE
Add left/right arrow key navigation between selected items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test-results
 coverage
 
 package-lock.json
+.vite-hooks/

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -276,6 +276,7 @@
 
   let wiggle = $state(false) // controls wiggle animation when user tries to exceed maxSelect
   let ignore_hover = $state(false) // ignore mouseover during keyboard navigation to prevent scroll-triggered hover
+  let highlighted_idx: number | null = $state(null) // index of highlighted selected item for arrow key navigation
 
   // Track last selection action for aria-live announcements
   let last_action = $state<
@@ -807,6 +808,7 @@
   function remove(option_to_drop: Option, event: Event) {
     event.stopPropagation()
     if (selected.length === 0) return
+    highlighted_idx = null
 
     const idx = selected.findIndex((opt) => key(opt) === key(option_to_drop))
     let option_removed = selected[idx]
@@ -993,6 +995,10 @@
       }
     }
 
+    // Clear selected-item highlight for any key except arrow/backspace navigation
+    if (highlighted_idx !== null && ![`ArrowLeft`, `ArrowRight`, `Backspace`].includes(event.key))
+      highlighted_idx = null
+
     // on escape or tab out of input: close options dropdown and reset search text
     if (event.key === `Escape` || event.key === `Tab`) {
       event.stopPropagation()
@@ -1015,19 +1021,33 @@
         // in which case enter means open it
         open_dropdown(event)
       }
+    } // on left/right arrow keys: navigate between selected items
+    else if (event.key === `ArrowLeft` && selected.length > 0 && !searchText) {
+      event.preventDefault()
+      highlighted_idx = highlighted_idx === null
+        ? selected.length - 1
+        : Math.max(0, highlighted_idx - 1)
+    } else if (event.key === `ArrowRight` && highlighted_idx !== null) {
+      event.preventDefault()
+      highlighted_idx = highlighted_idx < selected.length - 1
+        ? highlighted_idx + 1
+        : null
     } // on up/down arrow keys: update active option
     else if (event.key === `ArrowDown` || event.key === `ArrowUp`) {
       event.stopPropagation()
       event.preventDefault()
       await handle_arrow_navigation(event.key === `ArrowUp` ? -1 : 1)
-    } // on backspace key: remove last selected option
+    } // on backspace key: remove highlighted or last selected option
     else if (event.key === `Backspace` && selected.length > 0 && !searchText) {
       event.stopPropagation()
       if (can_remove) {
-        const last_option = selected.at(-1)
-        if (last_option) remove(last_option, event)
+        const prev_highlighted = highlighted_idx
+        const target = prev_highlighted === null ? selected.at(-1) : selected[prev_highlighted]
+        if (target) remove(target, event)
+        if (prev_highlighted !== null) {
+          highlighted_idx = selected.length === 0 ? null : Math.min(prev_highlighted, selected.length - 1)
+        }
       }
-      // Don't prevent default, allow normal backspace behavior if not removing
     } // make first matching option active on any keypress (if none of the above special cases match)
     else if (navigable_options.length > 0 && activeIndex === null) {
       // Don't stop propagation or prevent default here, allow normal character input
@@ -1037,6 +1057,7 @@
 
   function remove_all(event: Event) {
     event.stopPropagation()
+    highlighted_idx = null
 
     // Keep the first minSelect items, remove the rest
     let removed_options: Option[] = []
@@ -1176,6 +1197,7 @@
     }
     selected = new_selected
     drag_idx = null
+    highlighted_idx = null
     onreorder?.({ options: new_selected, previous })
     onchange?.({ options: new_selected, type: `reorder` })
   }
@@ -1199,6 +1221,7 @@
   }
 
   const handle_input_focus: FocusEventHandler<HTMLInputElement> = (event) => {
+    highlighted_idx = null
     open_dropdown(event)
     onfocus?.(event)
   }
@@ -1441,6 +1464,7 @@
         .join(` `) || null}
       <li
         class={liSelectedClass}
+        class:highlighted={highlighted_idx === idx}
         role="option"
         aria-selected="true"
         animate:flip={selectedFlipParams}
@@ -1899,6 +1923,9 @@
         light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15))
       )
     );
+  }
+  :where(div.multiselect > ul.selected > li).highlighted {
+    outline: 2px solid var(--sms-active-color, cornflowerblue);
   }
   :is(div.multiselect button) {
     border-radius: 50%;

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -815,12 +815,13 @@
   }
 
   // remove an option from selected list
-  function remove(option_to_drop: Option, event: Event) {
+  // at_idx overrides findIndex lookup so duplicates=true removes the correct occurrence
+  function remove(option_to_drop: Option, event: Event, at_idx?: number) {
     event.stopPropagation()
     if (selected.length === 0) return
     highlighted_idx = null
 
-    const idx = selected.findIndex((opt) => key(opt) === key(option_to_drop))
+    const idx = at_idx ?? selected.findIndex((opt) => key(opt) === key(option_to_drop))
     let option_removed = selected[idx]
 
     if (option_removed === undefined && allowUserOptions) {
@@ -1052,8 +1053,9 @@
       event.stopPropagation()
       if (can_remove) {
         const prev_highlighted = highlighted_idx
-        const target = prev_highlighted === null ? selected.at(-1) : selected[prev_highlighted]
-        if (target) remove(target, event)
+        const target_idx = prev_highlighted ?? selected.length - 1
+        const target = selected[target_idx]
+        if (target !== undefined) remove(target, event, target_idx)
         if (prev_highlighted !== null) {
           highlighted_idx = selected.length === 0 ? null : Math.min(prev_highlighted, selected.length - 1)
         }

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -278,6 +278,13 @@
   let ignore_hover = $state(false) // ignore mouseover during keyboard navigation to prevent scroll-triggered hover
   let highlighted_idx: number | null = $state(null) // index of highlighted selected item for arrow key navigation
 
+  // Clamp highlighted_idx when selected items change externally (undo/redo, parent prop, select_all)
+  $effect(() => {
+    if (highlighted_idx !== null && highlighted_idx >= selected.length) {
+      highlighted_idx = selected.length > 0 ? selected.length - 1 : null
+    }
+  })
+
   // Track last selection action for aria-live announcements
   let last_action = $state<
     { type: `add` | `remove` | `removeAll`; label: string } | null
@@ -703,11 +710,14 @@
     activeOption = navigable_options[activeIndex ?? -1] ?? null
   })
 
-  // Compute the ID of the currently active option for aria-activedescendant
+  // Compute the ID of the currently active element for aria-activedescendant
+  // (highlighted selected pill takes priority, then active dropdown option)
   const active_option_id = $derived(
-    activeIndex !== null && activeIndex < navigable_options.length
-      ? `${internal_id}-opt-${activeIndex}`
-      : undefined,
+    highlighted_idx === null
+      ? activeIndex !== null && activeIndex < navigable_options.length
+        ? `${internal_id}-opt-${activeIndex}`
+        : undefined
+      : `${internal_id}-selected-${highlighted_idx}`,
   )
 
   // Helper to check if removing an option would violate minSelect constraint
@@ -1463,6 +1473,7 @@
         .filter(Boolean)
         .join(` `) || null}
       <li
+        id="{internal_id}-selected-{idx}"
         class={liSelectedClass}
         class:highlighted={highlighted_idx === idx}
         role="option"

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -742,7 +742,7 @@ export const tooltip =
             // Get min-content (longest word) as lower bound
             Object.assign(style, {
               maxWidth: `none`,
-              wordWrap: `normal`,
+              overflowWrap: `normal`,
               width: `min-content`,
             })
             const min_width = tooltip_el.offsetWidth
@@ -858,7 +858,7 @@ export const tooltip =
           position: absolute; z-index: 9999; opacity: 0; display: inline-block;
           background: var(--tooltip-bg, light-dark(#f5f5f7, #2a2a2e)); color: var(--text-color, light-dark(#222, #eee)); border: var(--tooltip-border, none);
           padding: var(--tooltip-padding, 6px 10px); border-radius: var(--tooltip-radius, 5pt); font-size: var(--tooltip-font-size, 0.8rem); line-height: 1.4;
-          max-width: var(--tooltip-max-width, 280px); word-wrap: break-word; text-wrap: balance; pointer-events: none;
+          max-width: var(--tooltip-max-width, 280px); overflow-wrap: break-word; text-wrap: balance; pointer-events: none;
           filter: var(--tooltip-shadow, drop-shadow(0 2px 8px rgba(0,0,0,0.25))); transition: opacity 0.15s ease-out;
         `
 

--- a/src/routes/(demos)/events/+page.md
+++ b/src/routes/(demos)/events/+page.md
@@ -176,7 +176,7 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
     font-size: 0.8em;
     margin: 0;
     white-space: pre-wrap;
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
   }
   .no-events {
     color: light-dark(#666, #a0aec0);

--- a/src/routes/(demos)/events/+page.md
+++ b/src/routes/(demos)/events/+page.md
@@ -176,7 +176,7 @@ This demo showcases all the events that `<MultiSelect>` emits. Each emitted even
     font-size: 0.8em;
     margin: 0;
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: break-word;
   }
   .no-events {
     color: light-dark(#666, #a0aec0);

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1696,6 +1696,19 @@ describe(`arrow key navigation between selected items`, () => {
     expect(is_highlighted(0)).toBe(true)
   })
 
+  test(`Backspace with duplicates removes correct occurrence`, async () => {
+    // with duplicates=true, selected can have repeated values
+    // backspace on highlighted idx 2 (second "Red") must remove idx 2, not idx 0
+    const input = setup([`Red`, `Blue`, `Red`], { duplicates: true })
+    input.dispatchEvent(press(`ArrowLeft`)) // idx 2 (second Red)
+    input.dispatchEvent(press(`Backspace`))
+    await tick()
+    expect(selected_items().length).toBe(2)
+    // first Red (idx 0) should survive, Blue (idx 1) should survive
+    expect(selected_items()[0]?.textContent).toContain(`Red`)
+    expect(selected_items()[1]?.textContent).toContain(`Blue`)
+  })
+
   test(`re-focusing input clears highlight`, async () => {
     const input = setup()
     input.dispatchEvent(press(`ArrowLeft`))

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1706,6 +1706,74 @@ describe(`arrow key navigation between selected items`, () => {
     await tick()
     expect(highlighted().length).toBe(0)
   })
+
+  test(`external selected shrink clamps highlighted_idx`, async () => {
+    const props = $state<MultiSelectProps>({
+      options,
+      selected: [`Red`, `Green`, `Blue`],
+    })
+    mount(MultiSelect, { target: document.body, props })
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    // highlight idx 2 (Blue)
+    input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(is_highlighted(2)).toBe(true)
+    // externally shrink to 2 items — idx 2 is out of bounds
+    props.selected = [`Red`, `Green`]
+    await tick()
+    expect(selected_items().length).toBe(2)
+    // $effect should clamp to last valid index (1)
+    expect(is_highlighted(1)).toBe(true)
+  })
+
+  test(`external selected clear nullifies highlighted_idx`, async () => {
+    const props = $state<MultiSelectProps>({
+      options,
+      selected: [`Red`, `Green`, `Blue`],
+    })
+    mount(MultiSelect, { target: document.body, props })
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(highlighted().length).toBe(1)
+    props.selected = []
+    await tick()
+    expect(highlighted().length).toBe(0)
+  })
+
+  test(`highlighted pill gets aria-activedescendant on input`, async () => {
+    const input = setup()
+    expect(input.getAttribute(`aria-activedescendant`)).toBeFalsy()
+    input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    const active_id = input.getAttribute(`aria-activedescendant`)
+    expect(active_id).toBeTruthy()
+    // the id should match the highlighted <li>'s id
+    const highlighted_li = document.querySelector(`ul.selected > li.highlighted`)
+    expect(highlighted_li?.id).toBe(active_id)
+  })
+
+  test(`aria-activedescendant clears when highlight clears`, async () => {
+    const input = setup()
+    input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(input.getAttribute(`aria-activedescendant`)).toBeTruthy()
+    input.dispatchEvent(press(`Escape`))
+    await tick()
+    // should revert to null/undefined (no active dropdown option either since dropdown closed)
+    expect(input.getAttribute(`aria-activedescendant`)).toBeFalsy()
+  })
+
+  test(`each selected <li> has a stable id`, () => {
+    setup()
+    const items = selected_items()
+    for (let idx = 0; idx < items.length; idx++) {
+      expect(items[idx]?.id).toMatch(/-selected-\d+$/)
+    }
+    // ids should be unique
+    const ids = [...items].map((li) => li.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
 })
 
 test(`remove all button does not remove items when minSelect constraint would be violated`, async () => {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1525,6 +1525,189 @@ test(`backspace does not remove items when minSelect would be violated`, () => {
   expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`Red`)
 })
 
+describe(`arrow key navigation between selected items`, () => {
+  const options = [`Red`, `Green`, `Blue`]
+  const press = (key: string) => new KeyboardEvent(`keydown`, { key, bubbles: true })
+  const highlighted = () => document.querySelectorAll(`ul.selected > li.highlighted`)
+  const selected_items = () => document.querySelectorAll(`ul.selected > li`)
+  const is_highlighted = (idx: number) =>
+    selected_items()[idx]?.classList.contains(`highlighted`)
+
+  function setup(
+    selected = [`Red`, `Green`, `Blue`],
+    extra_props: Record<string, unknown> = {},
+  ) {
+    mount(MultiSelect, {
+      target: document.body,
+      props: { options, selected, ...extra_props },
+    })
+    return doc_query<HTMLInputElement>(`input[autocomplete]`)
+  }
+
+  test(`ArrowLeft highlights last selected item`, async () => {
+    const input = setup()
+    input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(is_highlighted(2)).toBe(true)
+  })
+
+  test(`repeated ArrowLeft moves highlight leftward and stops at 0`, async () => {
+    const input = setup()
+    for (let step = 0; step < 4; step++) input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(is_highlighted(0)).toBe(true)
+    expect(is_highlighted(1)).toBe(false)
+  })
+
+  test(`ArrowRight moves highlight rightward, then clears`, async () => {
+    const input = setup()
+    input.dispatchEvent(press(`ArrowLeft`)) // idx 2
+    input.dispatchEvent(press(`ArrowLeft`)) // idx 1
+    input.dispatchEvent(press(`ArrowRight`)) // idx 2
+    await tick()
+    expect(is_highlighted(2)).toBe(true)
+    input.dispatchEvent(press(`ArrowRight`)) // clears
+    await tick()
+    expect(highlighted().length).toBe(0)
+  })
+
+  test(`Backspace removes highlighted item and highlight stays at same index`, async () => {
+    const input = setup()
+    input.dispatchEvent(press(`ArrowLeft`)) // Blue (idx 2)
+    input.dispatchEvent(press(`ArrowLeft`)) // Green (idx 1)
+    input.dispatchEvent(press(`Backspace`))
+    await tick()
+    expect(selected_items().length).toBe(2)
+    expect(selected_items()[0]?.textContent).toContain(`Red`)
+    expect(selected_items()[1]?.textContent).toContain(`Blue`)
+    // highlight should stay at idx 1 (Blue), not jump to idx 0 (Red)
+    expect(is_highlighted(1)).toBe(true)
+    expect(is_highlighted(0)).toBe(false)
+  })
+
+  test(`ArrowLeft does nothing when input has text`, async () => {
+    const input = setup()
+    input.value = `R`
+    input.dispatchEvent(new Event(`input`, { bubbles: true }))
+    await tick()
+    input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(highlighted().length).toBe(0)
+  })
+
+  test(`ArrowLeft is no-op with no selected items`, async () => {
+    const input = setup([])
+    input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(highlighted().length).toBe(0)
+  })
+
+  test(`ArrowRight is no-op without prior highlight`, async () => {
+    const input = setup()
+    input.dispatchEvent(press(`ArrowRight`))
+    await tick()
+    expect(highlighted().length).toBe(0)
+  })
+
+  test(`Backspace without highlight removes last item`, async () => {
+    const input = setup()
+    input.dispatchEvent(press(`Backspace`))
+    await tick()
+    const text = doc_query(`ul.selected`).textContent?.trim()
+    expect(text).toContain(`Red`)
+    expect(text).toContain(`Green`)
+    expect(text).not.toContain(`Blue`)
+  })
+
+  test(`Backspace on highlighted first item keeps highlight in bounds`, async () => {
+    const input = setup()
+    for (let step = 0; step < 3; step++) input.dispatchEvent(press(`ArrowLeft`))
+    input.dispatchEvent(press(`Backspace`))
+    await tick()
+    expect(selected_items().length).toBe(2)
+    expect(is_highlighted(0)).toBe(true)
+    expect(selected_items()[0]?.textContent).toContain(`Green`)
+  })
+
+  test(`Backspace on single highlighted item clears highlight`, async () => {
+    const input = setup([`Red`])
+    input.dispatchEvent(press(`ArrowLeft`))
+    input.dispatchEvent(press(`Backspace`))
+    await tick()
+    expect(selected_items().length).toBe(0)
+    expect(highlighted().length).toBe(0)
+  })
+
+  test.each([`Escape`, `ArrowDown`, `ArrowUp`, `Tab`, `Enter`, `a`])(
+    `%s clears highlight`,
+    async (key) => {
+      const input = setup()
+      input.dispatchEvent(press(`ArrowLeft`))
+      await tick()
+      expect(highlighted().length).toBe(1)
+      input.dispatchEvent(press(key))
+      await tick()
+      expect(highlighted().length).toBe(0)
+    },
+  )
+
+  test(`clicking X button clears highlight`, async () => {
+    const input = setup()
+    // highlight idx 1 (Green) so removing the last item leaves a valid stale index
+    input.dispatchEvent(press(`ArrowLeft`))
+    input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(is_highlighted(1)).toBe(true)
+    // click X on last item (Blue) — selected becomes [Red, Green], stale idx 1 still valid
+    ;[...document.querySelectorAll<HTMLElement>(`ul.selected li button.remove`)]
+      .at(-1)
+      ?.click()
+    await tick()
+    expect(highlighted().length).toBe(0)
+  })
+
+  test(`remove-all button clears highlight`, async () => {
+    // minSelect=1 so one item survives remove-all, exposing stale highlighted_idx
+    const input = setup([`Red`, `Green`, `Blue`], { minSelect: 1 })
+    // highlight idx 0 (Red) — this item will survive remove-all
+    for (let step = 0; step < 3; step++) input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(is_highlighted(0)).toBe(true)
+    doc_query<HTMLElement>(`button.remove-all`).click()
+    await tick()
+    expect(selected_items().length).toBe(1)
+    expect(highlighted().length).toBe(0)
+  })
+
+  test(`consecutive Backspace removals track highlight correctly`, async () => {
+    const input = setup()
+    input.dispatchEvent(press(`ArrowLeft`)) // idx 2 (Blue)
+    input.dispatchEvent(press(`ArrowLeft`)) // idx 1 (Green)
+    input.dispatchEvent(press(`ArrowLeft`)) // idx 0 (Red)
+    input.dispatchEvent(press(`Backspace`)) // remove Red, highlight stays at 0
+    await tick()
+    expect(selected_items().length).toBe(2)
+    expect(selected_items()[0]?.textContent).toContain(`Green`)
+    expect(is_highlighted(0)).toBe(true)
+    input.dispatchEvent(press(`Backspace`)) // remove Green, highlight stays at 0
+    await tick()
+    expect(selected_items().length).toBe(1)
+    expect(selected_items()[0]?.textContent).toContain(`Blue`)
+    expect(is_highlighted(0)).toBe(true)
+  })
+
+  test(`re-focusing input clears highlight`, async () => {
+    const input = setup()
+    input.dispatchEvent(press(`ArrowLeft`))
+    await tick()
+    expect(highlighted().length).toBe(1)
+    input.blur()
+    input.focus()
+    await tick()
+    expect(highlighted().length).toBe(0)
+  })
+})
+
 test(`remove all button does not remove items when minSelect constraint would be violated`, async () => {
   // Test that remove all button also respects minSelect
   const options = [`Red`, `Green`, `Yellow`]


### PR DESCRIPTION
- ArrowLeft/Right keys navigate between selected items when the input is empty, highlighting them with an outline
- Backspace removes the highlighted item (previously always removed the last one)
- Highlight clears on typing, Escape, ArrowDown/Up, focus, and drag-drop reorder
- Fixes last missed `wordWrap` -> `overflowWrap` CSS deprecation in tooltip and events demo
- Drive `aria-activedescendant` from the highlighted item and give selected pills stable unique IDs