### PR TITLE
Suppress user messages during async loading

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -889,6 +889,7 @@
   // Check if a user message (create option, duplicate warning, no match) is visible
   const has_user_msg = $derived(
     searchText.length > 0 &&
+      !load_options_loading &&
       Boolean(
         (allowUserOptions && resolved_create_msg) ||
           (duplicates !== true && is_label_selected(searchText)) ||
@@ -1783,9 +1784,9 @@
       {/each}
       {#if searchText}
         {@const is_dupe = duplicates !== true && is_label_selected(searchText) && `dupe`}
-        {@const can_create = Boolean(allowUserOptions && resolved_create_msg) && `create`}
+        {@const can_create = Boolean(allowUserOptions && resolved_create_msg && !load_options_loading) && `create`}
         {@const no_match =
-        Boolean(navigable_options?.length === 0 && noMatchingOptionsMsg) &&
+        Boolean(navigable_options?.length === 0 && noMatchingOptionsMsg && !load_options_loading) &&
         `no-match`}
         {@const msgType = is_dupe || can_create || no_match}
         {@const msg = msgType && {

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -914,6 +914,7 @@
     // toggle user message when no options match but user can create
     if (
       allowUserOptions &&
+      !load_options_loading &&
       navigable_options.length === 0 &&
       searchText.length > 0
     ) {

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -889,11 +889,10 @@
   // Check if a user message (create option, duplicate warning, no match) is visible
   const has_user_msg = $derived(
     searchText.length > 0 &&
-      !load_options_loading &&
       Boolean(
-        (allowUserOptions && resolved_create_msg) ||
+        (allowUserOptions && resolved_create_msg && !load_options_loading) ||
           (duplicates !== true && is_label_selected(searchText)) ||
-          (navigable_options.length === 0 && noMatchingOptionsMsg),
+          (navigable_options.length === 0 && noMatchingOptionsMsg && !load_options_loading),
       ),
   )
 

--- a/src/lib/ThemeToggle.svelte
+++ b/src/lib/ThemeToggle.svelte
@@ -68,13 +68,11 @@
   {title}
   aria-label={title}
   style:visibility={is_hydrated ? `visible` : `hidden`}
-  {@attach tooltip_opts !== false
-  ? tooltip({
+  {@attach tooltip_opts !== false && tooltip({
     placement: `bottom`,
     style: `font-size: 0.7rem; padding: 2pt 4pt;`,
     ...tooltip_opts,
-  })
-  : () => {}}
+  })}
   {...rest}
 >
   {#if is_hydrated}

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3514,43 +3514,83 @@ describe(`loadOptions feature`, () => {
 })
 
 // https://github.com/janosh/svelte-multiselect/discussions/401
-test(`createOptionMsg hidden while loadOptions is loading`, async () => {
-  vi.useFakeTimers()
-  try {
-    const resolvers: ((r: { options: string[]; hasMore: boolean }) => void)[] = []
-    const fetch_fn = vi.fn(
-      () =>
-        new Promise<{ options: string[]; hasMore: boolean }>((r) => resolvers.push(r)),
-    )
+// User messages during async loading: create/no-match suppressed, dupe allowed
+test.each([
+  {
+    name: `createOptionMsg hidden while loading, shown after`,
+    props: { allowUserOptions: true, createOptionMsg: `Create this option` },
+    initial_options: [`Existing`],
+    search: `new tag`,
+    while_loading: null,
+    after_resolve: `Create this option`,
+    resolve_with: [] as string[],
+  },
+  {
+    name: `duplicateOptionMsg shown during loading`,
+    props: { selected: [`Apple`], duplicateOptionMsg: `Already selected` },
+    initial_options: [`Apple`, `Banana`],
+    search: `Apple`,
+    while_loading: `Already selected`,
+    after_resolve: null,
+    resolve_with: null,
+  },
+  {
+    name: `noMatchingOptionsMsg hidden while loading, shown after`,
+    props: { noMatchingOptionsMsg: `No matches` },
+    initial_options: [`Apple`],
+    search: `xyz`,
+    while_loading: null,
+    after_resolve: `No matches`,
+    resolve_with: [] as string[],
+  },
+])(
+  `$name`,
+  async ({
+    props,
+    initial_options,
+    search,
+    while_loading,
+    after_resolve,
+    resolve_with,
+  }) => {
+    vi.useFakeTimers()
+    try {
+      const resolvers: ((r: { options: string[]; hasMore: boolean }) => void)[] = []
+      const fetch_fn = vi.fn(
+        () =>
+          new Promise<{ options: string[]; hasMore: boolean }>((r) => resolvers.push(r)),
+      )
 
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        loadOptions: { fetch: fetch_fn, debounceMs: 0 },
-        allowUserOptions: true,
-        createOptionMsg: `Create this option`,
-        open: true,
-      },
-    })
-    await vi.runAllTimersAsync()
-    resolvers[0]({ options: [`Existing`], hasMore: false })
-    await vi.runAllTimersAsync()
+      mount(MultiSelect, {
+        target: document.body,
+        props: { loadOptions: { fetch: fetch_fn, debounceMs: 0 }, open: true, ...props },
+      })
+      await vi.runAllTimersAsync()
+      resolvers[0]({ options: [...initial_options], hasMore: false })
+      await vi.runAllTimersAsync()
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.value = `new tag`
-    input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
-    await vi.runAllTimersAsync()
-    expect(document.querySelector(`.user-msg`)).toBeNull()
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      input.value = search
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await vi.runAllTimersAsync()
+      expect(fetch_fn.mock.calls.length).toBeGreaterThanOrEqual(2)
 
-    resolvers[1]({ options: [], hasMore: false })
-    await vi.runAllTimersAsync()
-    expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
-      `Create this option`,
-    )
-  } finally {
-    vi.useRealTimers()
-  }
-})
+      const msg_during = document.querySelector(`.user-msg`)?.textContent?.trim()
+      if (while_loading) expect(msg_during).toBe(while_loading)
+      else expect(document.querySelector(`.user-msg`)).toBeNull()
+
+      if (resolve_with) {
+        resolvers[1]({ options: resolve_with, hasMore: false })
+        await vi.runAllTimersAsync()
+        expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
+          after_resolve,
+        )
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+  },
+)
 
 test(`createOptionMsg shows immediately with static options`, async () => {
   mount(MultiSelect, {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3516,36 +3516,40 @@ describe(`loadOptions feature`, () => {
 // https://github.com/janosh/svelte-multiselect/discussions/401
 test(`createOptionMsg hidden while loadOptions is loading`, async () => {
   vi.useFakeTimers()
-  const resolvers: ((r: { options: string[]; hasMore: boolean }) => void)[] = []
-  const fetch_fn = vi.fn(
-    () => new Promise<{ options: string[]; hasMore: boolean }>((r) => resolvers.push(r)),
-  )
+  try {
+    const resolvers: ((r: { options: string[]; hasMore: boolean }) => void)[] = []
+    const fetch_fn = vi.fn(
+      () =>
+        new Promise<{ options: string[]; hasMore: boolean }>((r) => resolvers.push(r)),
+    )
 
-  mount(MultiSelect, {
-    target: document.body,
-    props: {
-      loadOptions: { fetch: fetch_fn, debounceMs: 0 },
-      allowUserOptions: true,
-      createOptionMsg: `Create this option`,
-      open: true,
-    },
-  })
-  await vi.runAllTimersAsync()
-  resolvers[0]({ options: [`Existing`], hasMore: false })
-  await vi.runAllTimersAsync()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        loadOptions: { fetch: fetch_fn, debounceMs: 0 },
+        allowUserOptions: true,
+        createOptionMsg: `Create this option`,
+        open: true,
+      },
+    })
+    await vi.runAllTimersAsync()
+    resolvers[0]({ options: [`Existing`], hasMore: false })
+    await vi.runAllTimersAsync()
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-  input.value = `new tag`
-  input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
-  await vi.runAllTimersAsync()
-  expect(document.querySelector(`.user-msg`)).toBeNull()
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.value = `new tag`
+    input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+    await vi.runAllTimersAsync()
+    expect(document.querySelector(`.user-msg`)).toBeNull()
 
-  resolvers[1]({ options: [], hasMore: false })
-  await vi.runAllTimersAsync()
-  expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
-    `Create this option`,
-  )
-  vi.useRealTimers()
+    resolvers[1]({ options: [], hasMore: false })
+    await vi.runAllTimersAsync()
+    expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
+      `Create this option`,
+    )
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 test(`createOptionMsg shows immediately with static options`, async () => {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3513,6 +3513,61 @@ describe(`loadOptions feature`, () => {
   })
 })
 
+// https://github.com/janosh/svelte-multiselect/discussions/401
+test(`createOptionMsg hidden while loadOptions is loading`, async () => {
+  vi.useFakeTimers()
+  const resolvers: ((r: { options: string[]; hasMore: boolean }) => void)[] = []
+  const fetch_fn = vi.fn(
+    () => new Promise<{ options: string[]; hasMore: boolean }>((r) => resolvers.push(r)),
+  )
+
+  mount(MultiSelect, {
+    target: document.body,
+    props: {
+      loadOptions: { fetch: fetch_fn, debounceMs: 0 },
+      allowUserOptions: true,
+      createOptionMsg: `Create this option`,
+      open: true,
+    },
+  })
+  await vi.runAllTimersAsync()
+  resolvers[0]({ options: [`Existing`], hasMore: false })
+  await vi.runAllTimersAsync()
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.value = `new tag`
+  input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+  await vi.runAllTimersAsync()
+  expect(document.querySelector(`.user-msg`)).toBeNull()
+
+  resolvers[1]({ options: [], hasMore: false })
+  await vi.runAllTimersAsync()
+  expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
+    `Create this option`,
+  )
+  vi.useRealTimers()
+})
+
+test(`createOptionMsg shows immediately with static options`, async () => {
+  mount(MultiSelect, {
+    target: document.body,
+    props: {
+      options: [`Apple`, `Banana`],
+      allowUserOptions: true,
+      createOptionMsg: `Create this option`,
+      open: true,
+    },
+  })
+  await tick()
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.value = `Cherry`
+  input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+  await tick()
+  expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
+    `Create this option`,
+  )
+})
+
 // https://github.com/janosh/svelte-multiselect/issues/369
 describe(`binding update event count`, () => {
   test(`onchange fires 0 times on init and exactly once per selection`, async () => {

--- a/tests/vitest/live-examples/vite-plugin.test.ts
+++ b/tests/vitest/live-examples/vite-plugin.test.ts
@@ -276,15 +276,16 @@ describe(`pending_hmr_file lifecycle`, () => {
     const ctx = create_mock_context()
     const id = `/path/to/file.md`
     const hot_send = vi.fn()
-    plugin.configureServer?.(create_mock_server(hot_send))
-    return { plugin, ctx, id, hot_send }
+    const server = create_mock_server(hot_send)
+    plugin.configureServer?.(server)
+    return { plugin, ctx, id, hot_send, server }
   }
 
   test(`stale flag cleared after no-change transform — no spurious reload`, () => {
-    const { plugin, ctx, id, hot_send } = setup_hmr()
+    const { plugin, ctx, id, hot_send, server } = setup_hmr()
 
     plugin.transform?.call(ctx, make_code(`<div>V1</div>`), id)
-    plugin.handleHotUpdate?.({ file: id, server: {}, modules: [] })
+    plugin.handleHotUpdate?.({ file: id, server, modules: [] })
 
     // re-transform with identical examples — fix clears pending_hmr_file
     plugin.transform?.call(ctx, make_code(`<div>V1</div>`), id)
@@ -298,10 +299,10 @@ describe(`pending_hmr_file lifecycle`, () => {
   })
 
   test(`triggers full-reload when examples actually change during HMR`, () => {
-    const { plugin, ctx, id, hot_send } = setup_hmr()
+    const { plugin, ctx, id, hot_send, server } = setup_hmr()
 
     plugin.transform?.call(ctx, make_code(`<div>V1</div>`), id)
-    plugin.handleHotUpdate?.({ file: id, server: {}, modules: [] })
+    plugin.handleHotUpdate?.({ file: id, server, modules: [] })
     plugin.transform?.call(ctx, make_code(`<div>V2</div>`), id)
     vi.advanceTimersByTime(500)
 


### PR DESCRIPTION
- Suppress `createOptionMsg` ("Create this option...") and `noMatchingOptionsMsg` ("No matching options") while `loadOptions` is still fetching results. Previously these flashed prematurely before search results arrived ([discussion #401](https://github.com/janosh/svelte-multiselect/discussions/401)).
- Sync `has_user_msg` derived value with the same `!load_options_loading` guard so keyboard navigation doesn't count a phantom user-message slot during loading.
- Fix `ThemeToggle` `@attach` returning `() => {}` instead of `false` when tooltip is disabled.
- Pass proper mock server in vite-plugin HMR tests instead of `{}`.