### PR TITLE
Block option creation during loadOptions debounce window

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1364,7 +1364,7 @@
     } catch (error) {
       console.error(`MultiSelect: loadOptions error:`, error)
     } finally {
-      load_options_last_search = search
+      if (open) load_options_last_search = search
       load_options_loading = false
     }
   }

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -409,6 +409,14 @@
   let load_options_last_search: string | null = $state(null)
   let debounce_timer: ReturnType<typeof setTimeout> | null = null
 
+  // True when loadOptions is configured and results for the current search haven't
+  // arrived yet (either debouncing or actively fetching). Prevents premature user
+  // messages and option creation while search is pending.
+  let load_options_pending = $derived(
+    Boolean(load_options_config) &&
+      (load_options_loading || (open && (load_options_last_search ?? ``) !== searchText)),
+  )
+
   let effective_options = $derived(
     loadOptions ? loaded_options : (options ?? []),
   )
@@ -886,14 +894,19 @@
     } else input?.focus()
   }
 
+  const can_show_create_msg = $derived(
+    !!allowUserOptions && !!resolved_create_msg && !load_options_pending,
+  )
+  const can_show_no_match_msg = $derived(
+    navigable_options.length === 0 && !!noMatchingOptionsMsg && !load_options_pending,
+  )
+
   // Check if a user message (create option, duplicate warning, no match) is visible
   const has_user_msg = $derived(
     searchText.length > 0 &&
-      Boolean(
-        (allowUserOptions && resolved_create_msg && !load_options_loading) ||
-          (duplicates !== true && is_label_selected(searchText)) ||
-          (navigable_options.length === 0 && noMatchingOptionsMsg && !load_options_loading),
-      ),
+      (can_show_create_msg ||
+        (duplicates !== true && is_label_selected(searchText)) ||
+        can_show_no_match_msg),
   )
 
   // Handle arrow key navigation through options (uses navigable_options to skip collapsed groups)
@@ -912,8 +925,7 @@
 
     // toggle user message when no options match but user can create
     if (
-      allowUserOptions &&
-      !load_options_loading &&
+      can_show_create_msg &&
       navigable_options.length === 0 &&
       searchText.length > 0
     ) {
@@ -1025,7 +1037,7 @@
         if (selected_keys_set.has(key(activeOption))) {
           if (can_remove) remove(activeOption, event)
         } else add(activeOption, event) // add() handles resetFilterOnAdd internally when successful
-      } else if (allowUserOptions && searchText.length > 0) {
+      } else if (allowUserOptions && searchText.length > 0 && !load_options_pending) {
         // user entered text but no options match, so if allowUserOptions is truthy, we create new option
         add(searchText as Option, event)
       } else {
@@ -1349,10 +1361,10 @@
       const result = await load_options_config.fetch({ search, offset, limit })
       loaded_options = reset ? result.options : [...loaded_options, ...result.options]
       load_options_has_more = result.hasMore
-      load_options_last_search = search
     } catch (error) {
       console.error(`MultiSelect: loadOptions error:`, error)
     } finally {
+      load_options_last_search = search
       load_options_loading = false
     }
   }
@@ -1536,7 +1548,7 @@
       aria-expanded={open}
       aria-controls={listbox_id}
       aria-activedescendant={active_option_id}
-      aria-busy={loading || load_options_loading || null}
+      aria-busy={loading || load_options_pending || null}
       aria-invalid={invalid ? `true` : null}
       ondrop={() => false}
       onmouseup={open_dropdown}
@@ -1783,11 +1795,9 @@
         {/if}
       {/each}
       {#if searchText}
-        {@const is_dupe = duplicates !== true && is_label_selected(searchText) && `dupe`}
-        {@const can_create = Boolean(allowUserOptions && resolved_create_msg && !load_options_loading) && `create`}
-        {@const no_match =
-        Boolean(navigable_options?.length === 0 && noMatchingOptionsMsg && !load_options_loading) &&
-        `no-match`}
+        {@const is_dupe = duplicates !== true && is_label_selected(searchText) ? `dupe` : false}
+        {@const can_create = can_show_create_msg ? `create` : false}
+        {@const no_match = can_show_no_match_msg ? `no-match` : false}
         {@const msgType = is_dupe || can_create || no_match}
         {@const msg = msgType && {
         dupe: duplicateOptionMsg,
@@ -2040,7 +2050,7 @@
     border: var(--sms-options-border, 1px solid light-dark(lightgray, #555));
     border-width: var(--sms-options-border-width);
     border-radius: var(--sms-options-border-radius, 1ex);
-    padding: var(--sms-options-padding);
+    padding: var(--sms-options-padding, 0);
     margin: var(--sms-options-margin, 6pt 0 0 0);
   }
   :where(ul.options.hidden) {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-await-in-loop
 import { readFileSync } from 'node:fs'
 import { mount, tick } from 'svelte'
-import { describe, expect, test, vi } from 'vite-plus/test'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vite-plus/test'
 
 import type { Option, OptionStyle } from '$lib'
 import MultiSelect from '$lib'
@@ -3610,6 +3610,141 @@ test(`createOptionMsg shows immediately with static options`, async () => {
   expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
     `Create this option`,
   )
+})
+
+// https://github.com/janosh/svelte-multiselect/pull/403#issuecomment-4106385445
+describe(`load_options_pending`, () => {
+  type load_options_result = { options: string[]; hasMore: boolean }
+
+  function create_deferred_fetch() {
+    const fetch_resolvers: ((result: load_options_result) => void)[] = []
+    const fetch_fn = vi.fn(
+      () =>
+        new Promise<load_options_result>((resolve_fetch) =>
+          fetch_resolvers.push(resolve_fetch),
+        ),
+    )
+    return { fetch_fn, fetch_resolvers }
+  }
+
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  test(`Enter during debounce does not create unwanted option`, async () => {
+    const { fetch_fn, fetch_resolvers } = create_deferred_fetch()
+    const oncreate_spy = vi.fn()
+
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        loadOptions: { fetch: fetch_fn, debounceMs: 300 },
+        allowUserOptions: true,
+        createOptionMsg: `Create this option`,
+        open: true,
+        oncreate: oncreate_spy,
+      },
+    })
+    await vi.runAllTimersAsync()
+    fetch_resolvers[0]({ options: [`Apple`, `Banana`], hasMore: false })
+    await vi.runAllTimersAsync()
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.value = `Cherry`
+    input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+    await tick()
+
+    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
+
+    // Enter during debounce window should NOT create an option
+    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
+    await tick()
+    expect(oncreate_spy).not.toHaveBeenCalled()
+    expect(document.querySelector(`.user-msg`)).toBeNull()
+
+    // Let debounce fire and fetch complete
+    await vi.runAllTimersAsync()
+    fetch_resolvers[1]({ options: [], hasMore: false })
+    await vi.runAllTimersAsync()
+
+    expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
+      `Create this option`,
+    )
+
+    // Now Enter should create the option
+    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
+    await tick()
+    expect(oncreate_spy).toHaveBeenCalledTimes(1)
+  })
+
+  test(`fetch failure unblocks pending state`, async () => {
+    const fetch_fn = vi
+      .fn()
+      .mockResolvedValueOnce({ options: [`Apple`], hasMore: false })
+      .mockRejectedValue(new Error(`network error`))
+
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        loadOptions: { fetch: fetch_fn, debounceMs: 0 },
+        allowUserOptions: true,
+        createOptionMsg: `Create this option`,
+        open: true,
+      },
+    })
+    await vi.runAllTimersAsync()
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.value = `NewThing`
+    input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+    await vi.runAllTimersAsync()
+
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
+    expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
+      `Create this option`,
+    )
+  })
+
+  test(`onOpen: false — idle until user types, busy during debounce`, async () => {
+    const { fetch_fn, fetch_resolvers } = create_deferred_fetch()
+    const oncreate_spy = vi.fn()
+
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        loadOptions: { fetch: fetch_fn, onOpen: false, debounceMs: 200 },
+        allowUserOptions: true,
+        createOptionMsg: `Create this option`,
+        open: true,
+        oncreate: oncreate_spy,
+      },
+    })
+    await vi.runAllTimersAsync()
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    expect(fetch_fn).not.toHaveBeenCalled()
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
+
+    // Type triggers debounce — should become busy
+    input.value = `Rust`
+    input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+    await tick()
+    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
+
+    // Enter during debounce should NOT create option
+    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
+    await tick()
+    expect(oncreate_spy).not.toHaveBeenCalled()
+
+    // After debounce + fetch resolves, Enter works
+    await vi.runAllTimersAsync()
+    fetch_resolvers[0]({ options: [], hasMore: false })
+    await vi.runAllTimersAsync()
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
+
+    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
+    await tick()
+    expect(oncreate_spy).toHaveBeenCalledTimes(1)
+  })
 })
 
 // https://github.com/janosh/svelte-multiselect/issues/369

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-await-in-loop
 import { readFileSync } from 'node:fs'
 import { mount, tick } from 'svelte'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vite-plus/test'
+import { beforeEach, describe, expect, test, vi } from 'vite-plus/test'
 
 import type { Option, OptionStyle } from '$lib'
 import MultiSelect from '$lib'
@@ -3628,7 +3628,6 @@ describe(`load_options_pending`, () => {
   }
 
   beforeEach(() => vi.useFakeTimers())
-  afterEach(() => vi.useRealTimers())
 
   test(`Enter during debounce does not create unwanted option`, async () => {
     const { fetch_fn, fetch_resolvers } = create_deferred_fetch()

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3745,6 +3745,47 @@ describe(`load_options_pending`, () => {
     await tick()
     expect(oncreate_spy).toHaveBeenCalledTimes(1)
   })
+
+  test(`late fetch response after close does not corrupt next open`, async () => {
+    const { fetch_fn, fetch_resolvers } = create_deferred_fetch()
+
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        loadOptions: { fetch: fetch_fn, debounceMs: 0 },
+        open: true,
+      },
+    })
+    await vi.runAllTimersAsync()
+    fetch_resolvers[0]({ options: [`Apple`], hasMore: false })
+    await vi.runAllTimersAsync()
+    expect(fetch_fn).toHaveBeenCalledTimes(1)
+
+    // Type to trigger a second fetch, then close before it resolves
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.value = `Rust`
+    input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+    await vi.runAllTimersAsync()
+    expect(fetch_fn).toHaveBeenCalledTimes(2)
+
+    // Close dropdown while fetch is in-flight
+    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
+    await tick()
+
+    // Late fetch resolves after close
+    fetch_resolvers[1]({ options: [`Rust Lang`], hasMore: false })
+    await vi.runAllTimersAsync()
+
+    // Reopen — should trigger fresh load immediately (is_first_load path)
+    // not a debounced stale-search-change load
+    doc_query(`div.multiselect`).dispatchEvent(
+      new MouseEvent(`mouseup`, { bubbles: true }),
+    )
+    await tick()
+    // Fresh load fires immediately; stale path would debounce (not yet called)
+    expect(fetch_fn).toHaveBeenCalledTimes(3)
+    expect(fetch_fn).toHaveBeenLastCalledWith({ search: ``, offset: 0, limit: 50 })
+  })
 })
 
 // https://github.com/janosh/svelte-multiselect/issues/369

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -1225,7 +1225,6 @@ describe(`Nav`, () => {
   // Regression: dropdown panel mouseleave should not close when mouse moves to trigger
   describe(`dropdown panel mouseleave relatedTarget`, () => {
     beforeEach(() => vi.useFakeTimers())
-    afterEach(() => vi.useRealTimers())
 
     // Open dropdown and enter the panel, returning elements for assertions
     const open_and_enter_panel = async () => {

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -7,7 +7,7 @@ import {
   sortable,
   tooltip,
 } from '$lib/attachments'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 describe(`get_html_sort_value`, () => {
   const create_element = (tag = `div`) => document.createElement(tag)
@@ -404,7 +404,6 @@ describe(`tooltip`, () => {
   describe(`Reactive Content and Scroll Behavior`, () => {
     // MutationObserver callbacks don't fire in happy-dom, so we test setup/cleanup/ownership.
     beforeEach(() => vi.useFakeTimers())
-    afterEach(() => vi.useRealTimers())
 
     it(`tracks tooltip ownership via _owner property`, () => {
       const element = create_element()
@@ -488,7 +487,6 @@ describe(`tooltip`, () => {
 
   describe(`New Features`, () => {
     beforeEach(() => vi.useFakeTimers())
-    afterEach(() => vi.useRealTimers())
 
     it.each([
       {

--- a/tests/vitest/index.test.ts
+++ b/tests/vitest/index.test.ts
@@ -4,7 +4,7 @@ import DefaultExport, {
   scroll_into_view_if_needed_polyfill,
 } from '$lib'
 import MultiSelect from '$lib/MultiSelect.svelte'
-import { afterEach, describe, expect, test, vi } from 'vite-plus/test'
+import { describe, expect, test, vi } from 'vite-plus/test'
 
 test(`default export from index.ts is same as component file`, () => {
   expect(DefaultExport).toBe(MultiSelect)
@@ -59,11 +59,6 @@ describe(`scroll_into_view_if_needed_polyfill`, () => {
     }
     vi.stubGlobal(`IntersectionObserver`, MockObserver)
   }
-
-  afterEach(() => {
-    mock = { callback: null, disconnect: vi.fn(), observe: vi.fn(), instance: undefined }
-    vi.unstubAllGlobals()
-  })
 
   test(`creates observer and observes element`, () => {
     create_mock_observer()

--- a/tests/vitest/live-examples/vite-plugin.test.ts
+++ b/tests/vitest/live-examples/vite-plugin.test.ts
@@ -2,7 +2,7 @@
 import vite_plugin, { EXAMPLE_MODULE_PREFIX } from '$lib/live-examples/vite-plugin'
 import { Buffer } from 'node:buffer'
 import process from 'node:process'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vite-plus/test'
+import { beforeEach, describe, expect, test, vi } from 'vite-plus/test'
 
 const to_base64 = (src: string): string => Buffer.from(src, `utf-8`).toString(`base64`)
 const make_code = (src: string): string =>
@@ -269,7 +269,6 @@ describe(`vite-specific hooks`, () => {
 
 describe(`pending_hmr_file lifecycle`, () => {
   beforeEach(() => vi.useFakeTimers())
-  afterEach(() => vi.useRealTimers())
 
   const setup_hmr = () => {
     const plugin = get_plugin()


### PR DESCRIPTION
- Fixes [#403 comment](https://github.com/janosh/svelte-multiselect/pull/403#issuecomment-4106385445): pressing Enter during the `loadOptions` debounce window (before the fetch even starts) created unwanted user options because only `load_options_loading` (true during fetch) was guarded, not the debounce delay.
- Introduces `load_options_pending` derived covering both debounce delay and in-flight fetch. Replaces bare `!load_options_loading` guards in `has_user_msg`, arrow navigation, Enter key handler, template, and `aria-busy`.
- Extracts `can_show_create_msg` / `can_show_no_match_msg` deriveds to DRY up repeated conditions across `has_user_msg`, arrow navigation, and template.
- Moves `load_options_last_search` to `finally` block so fetch failures don't leave the component stuck in pending state.
- Uses `?? ''` in `load_options_pending` so `onOpen: false` doesn't falsely report busy before the user types.
- Adds regression tests for debounce-window Enter suppression (both `onOpen: true` and `false`), fetch failure recovery, and `aria-busy` transitions.
- Add a default padding fallback to avoid layout issues.