### PR TITLE
Fix tooltip background not inheriting page theme

### DIFF
--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -426,7 +426,7 @@ export const highlight_matches = (ops: HighlightOptions) => (node: HTMLElement) 
   }
 
   // iterate over all text nodes and find matches
-  const ranges = text_nodes.map((el) => {
+  const find_ranges = (el: Node): Range[] => {
     const text = el.textContent?.toLowerCase()
     if (!text) return []
 
@@ -477,7 +477,8 @@ export const highlight_matches = (ops: HighlightOptions) => (node: HTMLElement) 
       range.setEnd(el, index + search.length)
       return range
     })
-  })
+  }
+  const ranges = text_nodes.map(find_ranges)
 
   // create Highlight object from ranges and add to registry
   CSS.highlights.set(css_class, new Highlight(...ranges.flat()))
@@ -853,10 +854,10 @@ export const tooltip =
           tooltip_el.id = tooltip_id
           tooltip_el.setAttribute(`role`, `tooltip`)
           element.setAttribute(`aria-describedby`, tooltip_id)
-          // Apply base styles
+          // light-dark() inherits the page's color-scheme (defaults to light if unset)
           tooltip_el.style.cssText = `
           position: absolute; z-index: 9999; opacity: 0; display: inline-block;
-          background: var(--tooltip-bg, light-dark(#f5f5f7, #2a2a2e)); color: var(--text-color, light-dark(#222, #eee)); border: var(--tooltip-border, none);
+          background-color: var(--tooltip-bg, light-dark(#f5f5f7, #2a2a2e)); color: var(--text-color, light-dark(#222, #eee)); border: var(--tooltip-border, none);
           padding: var(--tooltip-padding, 6px 10px); border-radius: var(--tooltip-radius, 5pt); font-size: var(--tooltip-font-size, 0.8rem); line-height: 1.4;
           max-width: var(--tooltip-max-width, 280px); overflow-wrap: break-word; text-wrap: balance; pointer-events: none;
           filter: var(--tooltip-shadow, drop-shadow(0 2px 8px rgba(0,0,0,0.25))); transition: opacity 0.15s ease-out;

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -203,6 +203,62 @@ describe(`tooltip`, () => {
     }
   }
 
+  // Intercepts all cssText assignments and setProperty calls on new elements.
+  // Needed because happy-dom drops var()/light-dark() from parsed style values.
+  const capture_style_writes = () => {
+    const css_texts: string[] = []
+    const set_prop_values: string[] = []
+    const orig_css = Object.getOwnPropertyDescriptor(
+      CSSStyleDeclaration.prototype,
+      `cssText`,
+    )
+    Object.defineProperty(CSSStyleDeclaration.prototype, `cssText`, {
+      configurable: true,
+      enumerable: orig_css?.enumerable,
+      get() {
+        return orig_css?.get?.call(this) ?? ``
+      },
+      set(value: string) {
+        css_texts.push(value)
+        orig_css?.set?.call(this, value)
+      },
+    })
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- wrapping DOM method for test interception
+    const real_create = Reflect.get(document, `createElement`) as (
+      ...args: unknown[]
+    ) => HTMLElement
+    const patched_styles: {
+      el: HTMLElement
+      orig: CSSStyleDeclaration[`setProperty`]
+    }[] = []
+    Reflect.set(document, `createElement`, (...args: unknown[]) => {
+      const el = real_create.apply(document, args)
+      const orig_set = el.style.setProperty.bind(el.style)
+      patched_styles.push({ el, orig: orig_set })
+      el.style.setProperty = (prop: string, val: string | null, priority?: string) => {
+        if (val) set_prop_values.push(`${prop}: ${val}`)
+        return orig_set(prop, val, priority)
+      }
+      return el
+    })
+    return {
+      css_texts,
+      set_prop_values,
+      restore: () => {
+        for (const { el, orig } of patched_styles) el.style.setProperty = orig
+        Reflect.set(document, `createElement`, real_create)
+        if (orig_css) {
+          Object.defineProperty(CSSStyleDeclaration.prototype, `cssText`, orig_css)
+        } else {
+          Reflect.deleteProperty(CSSStyleDeclaration.prototype, `cssText`)
+        }
+      },
+    }
+  }
+
+  const find_tooltip_css = (css_texts: string[]) =>
+    css_texts.find((text) => text.includes(`z-index`) && text.includes(`9999`))
+
   // Shared helper for triggering tooltip display (requires vi.useFakeTimers())
   const trigger_tooltip = (element: HTMLElement) => {
     element.dispatchEvent(new MouseEvent(`mouseenter`, { bubbles: true }))
@@ -744,6 +800,65 @@ describe(`tooltip`, () => {
       const content_span = tooltip_el?.querySelector(`.tooltip-content`)
       expect(content_span?.tagName).toBe(`SPAN`)
       expect(content_span?.textContent).toBe(`Test`)
+    })
+
+    it(`tooltip uses theme-aware light-dark() defaults`, () => {
+      // Regression: commit 9bfac33 broke tooltip bg by using light-dark() on a page
+      // without color-scheme. The tooltip must NOT set color-scheme itself (that would
+      // override the page's theme); instead it inherits the page's value so
+      // light-dark(#f5f5f7, #2a2a2e) resolves to light bg (#f5f5f7) in light mode
+      // and dark bg (#2a2a2e) in dark mode — standard polarity matching the page.
+      // We check via css_texts (cssText spy) and set_prop_values (setProperty spy)
+      // because happy-dom strips var()/light-dark() from parsed style values.
+      const { css_texts, set_prop_values, restore } = capture_style_writes()
+      try {
+        const element = create_element()
+        element.title = `bg test`
+        mock_bounds(element)
+        setup_tooltip(element, { delay: 0 })
+        trigger_tooltip(element)
+      } finally {
+        restore()
+      }
+
+      const tooltip_css = find_tooltip_css(css_texts)
+      expect(tooltip_css).toBeDefined()
+      expect(tooltip_css).not.toContain(`color-scheme`)
+      expect(tooltip_css).toMatch(/background-color:.*light-dark\(\s*#f5f5f7,\s*#2a2a2e/)
+      expect(tooltip_css).toMatch(/\bcolor:.*light-dark\(\s*#222,\s*#eee/)
+
+      // Arrow border color must use matching light-dark() values
+      const arrow_borders = set_prop_values.filter(
+        (entry) =>
+          entry.startsWith(`border-`) &&
+          entry.includes(`solid`) &&
+          !entry.includes(`transparent`),
+      )
+      expect(arrow_borders.length).toBeGreaterThan(0)
+      for (const entry of arrow_borders) {
+        expect(entry).toMatch(/light-dark\(\s*#f5f5f7,\s*#2a2a2e/)
+      }
+    })
+
+    it(`custom --tooltip-bg overrides default background`, () => {
+      const { css_texts, restore } = capture_style_writes()
+      try {
+        const element = create_element()
+        element.title = `custom bg`
+        element.style.setProperty(`--tooltip-bg`, `red`)
+        mock_bounds(element)
+        setup_tooltip(element, { delay: 0 })
+        trigger_tooltip(element)
+      } finally {
+        restore()
+      }
+
+      const tooltip_el = document.querySelector<HTMLElement>(`.custom-tooltip`)
+      expect(tooltip_el).toBeInstanceOf(HTMLElement)
+      expect(tooltip_el?.style.getPropertyValue(`--tooltip-bg`)).toBe(`red`)
+      // background-color must consume the var, not be hard-coded
+      const tooltip_css = find_tooltip_css(css_texts)
+      expect(tooltip_css).toContain(`var(--tooltip-bg,`)
     })
   })
 })

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -203,54 +203,43 @@ describe(`tooltip`, () => {
     }
   }
 
-  // Intercepts all cssText assignments and setProperty calls on new elements.
-  // Needed because happy-dom drops var()/light-dark() from parsed style values.
+  // Intercepts cssText assignments and setProperty calls at the prototype level.
+  // Needed because happy-dom strips var()/light-dark() from parsed style values.
   const capture_style_writes = () => {
     const css_texts: string[] = []
     const set_prop_values: string[] = []
-    const orig_css = Object.getOwnPropertyDescriptor(
+    const orig_css_desc = Object.getOwnPropertyDescriptor(
       CSSStyleDeclaration.prototype,
       `cssText`,
     )
     Object.defineProperty(CSSStyleDeclaration.prototype, `cssText`, {
       configurable: true,
-      enumerable: orig_css?.enumerable,
+      enumerable: orig_css_desc?.enumerable,
       get() {
-        return orig_css?.get?.call(this) ?? ``
+        return orig_css_desc?.get?.call(this) ?? ``
       },
       set(value: string) {
         css_texts.push(value)
-        orig_css?.set?.call(this, value)
+        orig_css_desc?.set?.call(this, value)
       },
     })
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- wrapping DOM method for test interception
-    const real_create = Reflect.get(document, `createElement`) as (
-      ...args: unknown[]
-    ) => HTMLElement
-    const patched_styles: {
-      el: HTMLElement
-      orig: CSSStyleDeclaration[`setProperty`]
-    }[] = []
-    Reflect.set(document, `createElement`, (...args: unknown[]) => {
-      const el = real_create.apply(document, args)
-      const orig_set = el.style.setProperty.bind(el.style)
-      patched_styles.push({ el, orig: orig_set })
-      el.style.setProperty = (prop: string, val: string | null, priority?: string) => {
-        if (val) set_prop_values.push(`${prop}: ${val}`)
-        return orig_set(prop, val, priority)
-      }
-      return el
-    })
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- storing for prototype swap, called with .call(this)
+    const orig_set_prop = CSSStyleDeclaration.prototype.setProperty
+    CSSStyleDeclaration.prototype.setProperty = function (
+      prop: string,
+      val: string | null,
+      priority?: string,
+    ) {
+      if (val) set_prop_values.push(`${prop}: ${val}`)
+      return orig_set_prop.call(this, prop, val, priority)
+    }
     return {
       css_texts,
       set_prop_values,
       restore: () => {
-        for (const { el, orig } of patched_styles) el.style.setProperty = orig
-        Reflect.set(document, `createElement`, real_create)
-        if (orig_css) {
-          Object.defineProperty(CSSStyleDeclaration.prototype, `cssText`, orig_css)
-        } else {
-          Reflect.deleteProperty(CSSStyleDeclaration.prototype, `cssText`)
+        CSSStyleDeclaration.prototype.setProperty = orig_set_prop
+        if (orig_css_desc) {
+          Object.defineProperty(CSSStyleDeclaration.prototype, `cssText`, orig_css_desc)
         }
       },
     }
@@ -803,13 +792,9 @@ describe(`tooltip`, () => {
     })
 
     it(`tooltip uses theme-aware light-dark() defaults`, () => {
-      // Regression: commit 9bfac33 broke tooltip bg by using light-dark() on a page
-      // without color-scheme. The tooltip must NOT set color-scheme itself (that would
-      // override the page's theme); instead it inherits the page's value so
-      // light-dark(#f5f5f7, #2a2a2e) resolves to light bg (#f5f5f7) in light mode
-      // and dark bg (#2a2a2e) in dark mode — standard polarity matching the page.
-      // We check via css_texts (cssText spy) and set_prop_values (setProperty spy)
-      // because happy-dom strips var()/light-dark() from parsed style values.
+      // Regression test for commit 9bfac33: tooltip must not set color-scheme (would
+      // override page theme). Asserts via raw cssText/setProperty spies because
+      // happy-dom strips var()/light-dark() from parsed style values.
       const { css_texts, set_prop_values, restore } = capture_style_writes()
       try {
         const element = create_element()
@@ -827,7 +812,6 @@ describe(`tooltip`, () => {
       expect(tooltip_css).toMatch(/background-color:.*light-dark\(\s*#f5f5f7,\s*#2a2a2e/)
       expect(tooltip_css).toMatch(/\bcolor:.*light-dark\(\s*#222,\s*#eee/)
 
-      // Arrow border color must use matching light-dark() values
       const arrow_borders = set_prop_values.filter(
         (entry) =>
           entry.startsWith(`border-`) &&
@@ -856,7 +840,6 @@ describe(`tooltip`, () => {
       const tooltip_el = document.querySelector<HTMLElement>(`.custom-tooltip`)
       expect(tooltip_el).toBeInstanceOf(HTMLElement)
       expect(tooltip_el?.style.getPropertyValue(`--tooltip-bg`)).toBe(`red`)
-      // background-color must consume the var, not be hard-coded
       const tooltip_css = find_tooltip_css(css_texts)
       expect(tooltip_css).toContain(`var(--tooltip-bg,`)
     })


### PR DESCRIPTION
- Use `background-color` instead of `background` shorthand to avoid resetting other background sub-properties consumers may set
- Tooltip inherits `color-scheme` from the page (does NOT set its own), so `light-dark(#f5f5f7, #2a2a2e)` follows the active theme — light bg in light mode, dark bg in dark mode
- Add regression tests verifying theme-aware `light-dark()` defaults for tooltip bg, text color, and arrow color, plus `--tooltip-bg` CSS var override