### PR TITLE
Add parse_paste prop, fix shortcut defaults and select-all UX

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -745,7 +745,9 @@
   }
 
   // add an option to selected list
-  function add(option_to_add: Option, event: Event) {
+  // from_paste: when true, skip option reconstruction so parse_paste() objects
+  // are preserved as-is (extra fields like value/group/metadata aren't stripped)
+  function add(option_to_add: Option, event: Event, from_paste = false) {
     event.stopPropagation()
     if (maxSelect !== null && selected.length >= maxSelect) wiggle = true
     if (
@@ -781,21 +783,22 @@
         // this has the side-effect of not allowing to user to add the same
         // custom option twice in append mode
         [true, `append`].includes(allowUserOptions) &&
-        searchText.length > 0
+        (searchText.length > 0 || from_paste)
       ) {
-        // user entered text but no options match, so if allowUserOptions = true | 'append', we create
-        // a new option from the user-entered text
-        if (typeof effective_options[0] === `object`) {
-          // if 1st option is an object, we create new option as object to keep type homogeneity
-          option_to_add = { label: searchText } as Option
-        } else if (
-          [`number`, `undefined`].includes(typeof effective_options[0]) &&
-          !isNaN(Number(searchText))
-        ) {
-          // create new option as number if it parses to a number and 1st option is also number or missing
-          option_to_add = Number(searchText) as Option
-        } else {
-          option_to_add = searchText as Option // else create custom option as string
+        // Reconstruct option for type homogeneity, but preserve object options
+        // from parse_paste as-is so extra fields (value/group/metadata) aren't stripped
+        if (!(from_paste && typeof option_to_add === `object`)) {
+          const label_text = from_paste ? `${utils.get_label(option_to_add)}` : searchText
+          if (typeof effective_options[0] === `object`) {
+            option_to_add = { label: label_text } as Option
+          } else if (
+            [`number`, `undefined`].includes(typeof effective_options[0]) &&
+            !isNaN(Number(label_text))
+          ) {
+            option_to_add = Number(label_text) as Option
+          } else {
+            option_to_add = label_text as Option
+          }
         }
         // Fire oncreate event for all user-created options, regardless of type
         oncreate?.({ option: option_to_add })
@@ -984,7 +987,7 @@
       },
       {
         key: `clear_all`,
-        condition: () => selected.length > 0,
+        condition: () => selected.length > 0 && !searchText,
         action: () => remove_all(event),
       },
       {
@@ -1304,12 +1307,10 @@
         onmaxreached?.({ selected, maxSelect, attemptedOption: option })
         break
       }
-      // set searchText so add() can enter the user-creation branch when allowUserOptions is truthy
-      searchText = `${utils.get_label(option)}`
-      add(option, event)
+      add(option, event, true)
       if (maxSelect === 1) break
     }
-    searchText = ``
+    if (resetFilterOnAdd) searchText = ``
   }
 
   // reset form validation when required prop changes
@@ -1682,10 +1683,13 @@
       {#if selectAllOption && effective_options.length > 0 &&
         (maxSelect === null || maxSelect > 1)}
         {@const label = typeof selectAllOption === `string` ? selectAllOption : `Select all`}
-        {@const selectable = navigable_options.filter((opt) => !is_disabled(opt))}
+        {@const selectable = get_selectable_opts(navigable_options)}
         {@const max_reached = maxSelect !== null && selected.length >= maxSelect}
         {@const all_selectable_selected = selectable.every((opt) => selected_keys_set.has(key(opt)))}
         {@const all_selected = max_reached || all_selectable_selected}
+        {@const disabled_title = max_reached && !all_selectable_selected
+          ? `Maximum of ${maxSelect} options selected`
+          : `All options already selected`}
         <li
           class="select-all {liSelectAllClass}"
           class:disabled={all_selected}
@@ -1694,7 +1698,7 @@
           role="option"
           aria-selected="false"
           aria-disabled={all_selected || undefined}
-          title={all_selected ? (max_reached && !all_selectable_selected ? `Maximum of ${maxSelect} options selected` : `All options already selected`) : null}
+          title={all_selected ? disabled_title : null}
           tabindex={all_selected ? -1 : 0}
         >
           {label}
@@ -1738,12 +1742,13 @@
                 {/if}
               </span>
               {#if groupSelectAll && (maxSelect === null || maxSelect > 1)}
-                {@const group_max_blocked = !all_selected && maxSelect !== null && selected.length >= maxSelect}
+                {@const group_selectable = get_selectable_opts(group_opts, collapsed)}
+                {@const group_blocked = (!all_selected && maxSelect !== null && selected.length >= maxSelect) || (!all_selected && group_selectable.length === 0)}
                 <button
                   type="button"
                   class="group-select-all"
                   class:deselect={all_selected}
-                  disabled={group_max_blocked}
+                  disabled={group_blocked}
                   onclick={handle_group_select}
                   onkeydown={if_enter_or_space(handle_group_select)}
                 >

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1744,8 +1744,8 @@
                   class="group-select-all"
                   class:deselect={all_selected}
                   disabled={group_max_blocked}
-                  onclick={group_max_blocked ? undefined : handle_group_select}
-                  onkeydown={group_max_blocked ? undefined : if_enter_or_space(handle_group_select)}
+                  onclick={handle_group_select}
+                  onkeydown={if_enter_or_space(handle_group_select)}
                 >
                   {all_selected ? `Deselect all` : `Select all`}
                 </button>
@@ -2247,7 +2247,7 @@
     border-radius: 3pt;
     aspect-ratio: auto; /* override global button aspect-ratio: 1 */
   }
-  :is(ul.options > li.group-header button.group-select-all:hover) {
+  :is(ul.options > li.group-header button.group-select-all:hover:not(:disabled)) {
     background: var(
       --sms-group-select-all-hover-bg,
       light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1))

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -71,6 +71,7 @@
     minSelect = null,
     required = false,
     resetFilterOnAdd = true,
+    parse_paste,
     searchText = $bindable(``),
     value = $bindable(null),
     selected = $bindable(
@@ -207,8 +208,8 @@
 
   // Default shortcuts
   const default_shortcuts: KeyboardShortcuts = {
-    select_all: `${mod_key}+a`,
-    clear_all: `${mod_key}+shift+a`,
+    select_all: null,
+    clear_all: `${mod_key}+backspace`,
     open: null,
     close: null,
     undo: `${mod_key}+z`,
@@ -1125,18 +1126,22 @@
   // Batch-add options to selection with all side effects (used by select_all and group select)
   function batch_add_options(options_to_add: Option[], event: Event) {
     const remaining = Math.max(0, (maxSelect ?? Infinity) - selected.length)
-    const to_add = options_to_add
-      .filter((opt) => !selected_keys_set.has(key(opt)))
-      .slice(0, remaining)
+    const unselected = options_to_add.filter((opt) => !selected_keys_set.has(key(opt)))
+    const to_add = unselected.slice(0, remaining)
 
-    if (to_add.length === 0) return
+    if (to_add.length > 0) {
+      selected = sort_selected([...selected, ...to_add])
+      if (resetFilterOnAdd) searchText = ``
+      clear_validity()
+      handle_dropdown_after_select(event)
+      onselectAll?.({ options: to_add })
+      onchange?.({ options: selected, type: `selectAll` })
+    }
 
-    selected = sort_selected([...selected, ...to_add])
-    if (resetFilterOnAdd) searchText = ``
-    clear_validity()
-    handle_dropdown_after_select(event)
-    onselectAll?.({ options: to_add })
-    onchange?.({ options: selected, type: `selectAll` })
+    if (to_add.length < unselected.length && maxSelect !== null) {
+      wiggle = true
+      onmaxreached?.({ selected, maxSelect, attemptedOption: unselected[to_add.length] })
+    }
   }
 
   // Batch-add options for top-level "Select all" (only visible/navigable options)
@@ -1284,6 +1289,27 @@
     if (!outerDiv?.contains(event.relatedTarget as Node)) close_dropdown(event)
 
     onblur?.(event) // Call original handler (if any passed as component prop)
+  }
+
+  function handle_paste(event: ClipboardEvent) {
+    if (!parse_paste) return
+    const text = event.clipboardData?.getData(`text/plain`)
+    if (!text) return
+    const parsed = parse_paste(text)
+    if (parsed.length === 0) return
+    event.preventDefault()
+    for (const option of parsed) {
+      if (maxSelect !== null && maxSelect !== 1 && selected.length >= maxSelect) {
+        wiggle = true
+        onmaxreached?.({ selected, maxSelect, attemptedOption: option })
+        break
+      }
+      // set searchText so add() can enter the user-creation branch when allowUserOptions is truthy
+      searchText = `${utils.get_label(option)}`
+      add(option, event)
+      if (maxSelect === 1) break
+    }
+    searchText = ``
   }
 
   // reset form validation when required prop changes
@@ -1554,6 +1580,7 @@
       aria-busy={loading || load_options_pending || null}
       aria-invalid={invalid ? `true` : null}
       ondrop={() => false}
+      onpaste={handle_paste}
       onmouseup={open_dropdown}
       onkeydown={handle_input_keydown}
       onfocus={handle_input_focus}
@@ -1655,13 +1682,20 @@
       {#if selectAllOption && effective_options.length > 0 &&
         (maxSelect === null || maxSelect > 1)}
         {@const label = typeof selectAllOption === `string` ? selectAllOption : `Select all`}
+        {@const selectable = navigable_options.filter((opt) => !is_disabled(opt))}
+        {@const max_reached = maxSelect !== null && selected.length >= maxSelect}
+        {@const all_selectable_selected = selectable.every((opt) => selected_keys_set.has(key(opt)))}
+        {@const all_selected = max_reached || all_selectable_selected}
         <li
           class="select-all {liSelectAllClass}"
-          onclick={select_all}
-          onkeydown={if_enter_or_space(select_all)}
+          class:disabled={all_selected}
+          onclick={all_selected ? undefined : select_all}
+          onkeydown={all_selected ? undefined : if_enter_or_space(select_all)}
           role="option"
           aria-selected="false"
-          tabindex="0"
+          aria-disabled={all_selected || undefined}
+          title={all_selected ? (max_reached && !all_selectable_selected ? `Maximum of ${maxSelect} options selected` : `All options already selected`) : null}
+          tabindex={all_selected ? -1 : 0}
         >
           {label}
         </li>
@@ -1704,12 +1738,14 @@
                 {/if}
               </span>
               {#if groupSelectAll && (maxSelect === null || maxSelect > 1)}
+                {@const group_max_blocked = !all_selected && maxSelect !== null && selected.length >= maxSelect}
                 <button
                   type="button"
                   class="group-select-all"
                   class:deselect={all_selected}
-                  onclick={handle_group_select}
-                  onkeydown={if_enter_or_space(handle_group_select)}
+                  disabled={group_max_blocked}
+                  onclick={group_max_blocked ? undefined : handle_group_select}
+                  onkeydown={group_max_blocked ? undefined : if_enter_or_space(handle_group_select)}
                 >
                   {all_selected ? `Deselect all` : `Select all`}
                 </button>
@@ -2118,7 +2154,11 @@
     background: var(--sms-select-all-bg, transparent);
     margin-bottom: var(--sms-select-all-margin-bottom, 2pt);
   }
-  :where(ul.options > li.select-all:hover) {
+  :where(ul.options > li.select-all.disabled) {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  :where(ul.options > li.select-all:hover:not(.disabled)) {
     background: var(
       --sms-select-all-hover-bg,
       var(

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1299,8 +1299,8 @@
     const text = event.clipboardData?.getData(`text/plain`)
     if (!text) return
     const parsed = parse_paste(text)
-    if (parsed.length === 0) return
     event.preventDefault()
+    if (parsed.length === 0) return
     for (const option of parsed) {
       if (maxSelect !== null && maxSelect !== 1 && selected.length >= maxSelect) {
         wiggle = true
@@ -2251,6 +2251,10 @@
     margin-left: 8pt;
     border-radius: 3pt;
     aspect-ratio: auto; /* override global button aspect-ratio: 1 */
+  }
+  :is(ul.options > li.group-header button.group-select-all:disabled) {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
   :is(ul.options > li.group-header button.group-select-all:hover:not(:disabled)) {
     background: var(

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1299,8 +1299,8 @@
     const text = event.clipboardData?.getData(`text/plain`)
     if (!text) return
     const parsed = parse_paste(text)
-    event.preventDefault()
     if (parsed.length === 0) return
+    event.preventDefault()
     for (const option of parsed) {
       if (maxSelect !== null && maxSelect !== 1 && selected.length >= maxSelect) {
         wiggle = true

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -212,6 +212,7 @@ export interface MultiSelectProps<T extends Option = Option>
   minSelect?: number | null // null means there is no lower limit for selected.length
   required?: boolean | number
   resetFilterOnAdd?: boolean
+  parse_paste?: (text: string) => T[]
   searchText?: string
   selected?: T[] // don't allow more than maxSelect preselected options
   sortSelected?: boolean | ((op1: T, op2: T) => number)
@@ -268,8 +269,8 @@ export interface MultiSelectProps<T extends Option = Option>
 // ArrowUp/Down, Backspace). This means if you set shortcuts={{ open: 'enter' }}, the Enter
 // key will open the dropdown instead of selecting the active option (intentional to allow full customization).
 export interface KeyboardShortcuts {
-  select_all?: string | null // default: 'ctrl+a'
-  clear_all?: string | null // default: 'ctrl+shift+a'
+  select_all?: string | null // default: null (opt-in, e.g. 'ctrl+a')
+  clear_all?: string | null // default: 'ctrl+backspace' (meta+backspace on Mac)
   open?: string | null // default: null (use existing behavior)
   close?: string | null // default: null (Escape already works)
   undo?: string | null // default: platform-aware (meta+z on Mac, ctrl+z elsewhere)

--- a/src/routes/(demos)/allow-user-options/+page.md
+++ b/src/routes/(demos)/allow-user-options/+page.md
@@ -95,3 +95,61 @@ You can start with no options and let users populate MultiSelect from scratch. I
   createOptionMsg={null}
 />
 ```
+
+## Paste Multiple Values
+
+`parse_paste` lets users paste comma/space/newline-separated text and split it into multiple options at once. Useful for email lists, tags, or any bulk input. Click a snippet below to copy, then paste into the input.
+
+```svelte example id="parse-paste"
+<script lang="ts">
+  import MultiSelect, { CopyButton } from '$lib'
+
+  let selected: string[] = $state([])
+  let log: string[] = $state([])
+
+  const snippets = [
+    { label: `Comma-separated emails`, text: `alice@example.com, bob@test.org, carol@mail.net` },
+    { label: `Space-separated tags`, text: `svelte typescript javascript rust` },
+    { label: `Newline-separated`, text: `Red\nGreen\nBlue\nYellow` },
+    { label: `Mixed separators`, text: `one, two three\nfour` },
+  ]
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 0.4em; margin-bottom: 1em">
+  {#each snippets as { label, text }}
+    <div style="display: flex; align-items: center; gap: 0.5em">
+      <CopyButton
+        content={text}
+        style="padding: 0.3em 0.7em; border-radius: 4px; border: 1px solid var(--sms-border, lightgray); background: var(--sms-options-bg, white); cursor: pointer; font-size: 0.85em; white-space: nowrap"
+        labels={{
+          ready: { icon: `Copy`, text: label },
+          success: { icon: `Check`, text: `Copied!` },
+          error: { icon: `Alert`, text: `Failed` },
+        }}
+      />
+      <code style="font-size: 0.85em; opacity: 0.7">{text}</code>
+    </div>
+  {/each}
+</div>
+
+<MultiSelect
+  allowUserOptions="append"
+  bind:selected
+  noMatchingOptionsMsg=""
+  createOptionMsg={null}
+  parse_paste={(text) => text.split(/[,\s]+/).filter(Boolean)}
+  oncreate={({ option }) => log = [...log, `+ ${option}`]}
+  onremove={({ option }) => log = [...log, `- ${option}`]}
+/>
+
+<p style="margin-top: 0.5em">
+  Selected ({selected.length}): {selected.join(', ') || 'none'}
+</p>
+
+{#if log.length > 0}
+  <details open style="margin-top: 0.5em">
+    <summary>Event log ({log.length})</summary>
+    <pre style="max-height: 8em; overflow: auto; font-size: 0.85em"><code>{log.join('\n')}</code></pre>
+  </details>
+{/if}
+```

--- a/src/routes/(demos)/min-max-select/+page.md
+++ b/src/routes/(demos)/min-max-select/+page.md
@@ -97,7 +97,7 @@ Of course, you can combine `maxSelect={n}` and `required={m}` where `n>=m`.
 
 ## Select All Option
 
-Use `selectAllOption` to add a "Select all" button at the top of the dropdown. It respects `maxSelect` (only selects up to the limit) and skips disabled options.
+Use `selectAllOption` to add a "Select all" button at the top of the dropdown. It respects `maxSelect` (only selects up to the limit) and skips disabled options. Optionally set `shortcuts={{ select_all: 'ctrl+a' }}` to enable the keyboard shortcut (disabled by default to avoid hijacking the browser's native Ctrl+A).
 
 ```svelte example
 <script lang="ts">
@@ -119,6 +119,7 @@ Use `selectAllOption` to add a "Select all" button at the top of the dropdown. I
   options={fruits}
   bind:selected
   selectAllOption
+  shortcuts={{ select_all: `ctrl+a` }}
   maxSelect={5}
   placeholder="Pick your favorite fruits"
 />

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -6730,14 +6730,11 @@ describe(`parse_paste`, () => {
     expect(onchange_spy).toHaveBeenCalledTimes(3)
   })
 
-  test.each([
-    [`without parse_paste`, {}],
-    [`parse_paste returns empty array`, { parse_paste: () => [] }],
-  ])(`%s: paste is not intercepted`, async (_label, extra_props) => {
+  test(`without parse_paste: paste is not intercepted`, async () => {
     const onadd_spy = vi.fn()
     mount(MultiSelect, {
       target: document.body,
-      props: { options: [`a`, `b`, `c`], onadd: onadd_spy, ...extra_props },
+      props: { options: [`a`, `b`, `c`], onadd: onadd_spy },
     })
 
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
@@ -6747,6 +6744,22 @@ describe(`parse_paste`, () => {
 
     expect(onadd_spy).not.toHaveBeenCalled()
     expect(event.defaultPrevented).toBe(false)
+  })
+
+  test(`parse_paste returns empty array: native paste blocked, no options added`, async () => {
+    const onadd_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: { options: [`a`, `b`, `c`], onadd: onadd_spy, parse_paste: () => [] },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const event = make_paste_event(`a,b`)
+    input.dispatchEvent(event)
+    await tick()
+
+    expect(onadd_spy).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
   })
 
   test(`works with object options via allowUserOptions`, async () => {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3287,32 +3287,23 @@ describe(`selectAllOption feature`, () => {
     },
   )
 
-  test(`disabled Select All ignores click and fires no events`, async () => {
+  test(`disabled Select All ignores click`, async () => {
     const onselectAll_spy = vi.fn()
-    const onchange_spy = vi.fn()
-    const onmaxreached_spy = vi.fn()
     const props = $state<MultiSelectProps>({
       options: [`a`, `b`, `c`],
       selected: [`a`, `b`],
       selectAllOption: true,
       maxSelect: 2,
       onselectAll: onselectAll_spy,
-      onchange: onchange_spy,
-      onmaxreached: onmaxreached_spy,
     })
-
     mount(MultiSelect, { target: document.body, props })
     doc_query<HTMLInputElement>(`input[autocomplete]`).click()
     await tick()
 
-    const select_all_li = doc_query<HTMLElement>(`ul.options > li.select-all`)
-    expect(select_all_li.classList.contains(`disabled`)).toBe(true)
-    select_all_li.click()
+    doc_query<HTMLElement>(`ul.options > li.select-all`).click()
     await tick()
 
     expect(onselectAll_spy).not.toHaveBeenCalled()
-    expect(onchange_spy).not.toHaveBeenCalled()
-    expect(onmaxreached_spy).not.toHaveBeenCalled()
     expect(props.selected).toEqual([`a`, `b`])
   })
 
@@ -6673,222 +6664,150 @@ function make_paste_event(text: string): ClipboardEvent {
   return event
 }
 
+// helper: mount MultiSelect, paste text, return spies and props
+async function paste_into(extra_props: Partial<MultiSelectProps>, paste_text: string) {
+  const spies = {
+    onadd: vi.fn(),
+    oncreate: vi.fn(),
+    onchange: vi.fn(),
+    onmaxreached: vi.fn(),
+    onduplicate: vi.fn(),
+  }
+  const props = $state<MultiSelectProps>({
+    parse_paste: (text: string) => text.split(`,`),
+    ...spies,
+    ...extra_props,
+  })
+  mount(MultiSelect, { target: document.body, props })
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const event = make_paste_event(paste_text)
+  input.dispatchEvent(event)
+  await tick()
+  return { ...spies, props, event }
+}
+
 describe(`parse_paste`, () => {
   test(`splits pasted text into multiple selected options`, async () => {
-    const onadd_spy = vi.fn()
-    const onchange_spy = vi.fn()
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        options: [`alpha`, `beta`, `gamma`],
-        parse_paste: (text: string) => text.split(`,`).map((str) => str.trim()),
-        onadd: onadd_spy,
-        onchange: onchange_spy,
-      },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    const event = make_paste_event(`alpha,beta`)
-    input.dispatchEvent(event)
-    await tick()
-
+    const { onadd, event } = await paste_into(
+      { options: [`alpha`, `beta`, `gamma`] },
+      `alpha,beta`,
+    )
     expect(event.defaultPrevented).toBe(true)
-    expect(onadd_spy).toHaveBeenCalledTimes(2)
-    expect(onadd_spy).toHaveBeenCalledWith(expect.objectContaining({ option: `alpha` }))
-    expect(onadd_spy).toHaveBeenCalledWith(expect.objectContaining({ option: `beta` }))
-    expect(onchange_spy).toHaveBeenCalledTimes(2)
-    expect(onchange_spy).toHaveBeenCalledWith(
-      expect.objectContaining({ option: `alpha`, type: `add` }),
-    )
-    expect(onchange_spy).toHaveBeenCalledWith(
-      expect.objectContaining({ option: `beta`, type: `add` }),
-    )
+    expect(onadd).toHaveBeenCalledTimes(2)
+    expect(onadd).toHaveBeenCalledWith(expect.objectContaining({ option: `alpha` }))
+    expect(onadd).toHaveBeenCalledWith(expect.objectContaining({ option: `beta` }))
   })
 
   test(`fires oncreate for each created option with allowUserOptions`, async () => {
-    const oncreate_spy = vi.fn()
-    const onadd_spy = vi.fn()
-    const onchange_spy = vi.fn()
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
+    const { oncreate, onadd } = await paste_into(
+      {
         options: [`existing`],
         allowUserOptions: true,
         parse_paste: (text: string) => text.split(/[,\s]+/).filter(Boolean),
-        oncreate: oncreate_spy,
-        onadd: onadd_spy,
-        onchange: onchange_spy,
       },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(make_paste_event(`new1,new2,new3`))
-    await tick()
-
-    expect(oncreate_spy).toHaveBeenCalledTimes(3)
-    expect(onadd_spy).toHaveBeenCalledTimes(3)
-    expect(onchange_spy).toHaveBeenCalledTimes(3)
+      `new1,new2,new3`,
+    )
+    expect(oncreate).toHaveBeenCalledTimes(3)
+    expect(onadd).toHaveBeenCalledTimes(3)
   })
 
-  test(`without parse_paste: paste is not intercepted`, async () => {
-    const onadd_spy = vi.fn()
-    mount(MultiSelect, {
-      target: document.body,
-      props: { options: [`a`, `b`, `c`], onadd: onadd_spy },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    const event = make_paste_event(`a,b`)
-    input.dispatchEvent(event)
-    await tick()
-
-    expect(onadd_spy).not.toHaveBeenCalled()
+  test.each([
+    [`without parse_paste`, { parse_paste: undefined }],
+    [`parse_paste returns empty`, { parse_paste: () => [] }],
+  ])(`%s: paste not intercepted`, async (_label, override) => {
+    const { onadd, event } = await paste_into(
+      { options: [`a`, `b`, `c`], ...override },
+      `a,b`,
+    )
+    expect(onadd).not.toHaveBeenCalled()
     expect(event.defaultPrevented).toBe(false)
   })
 
-  test(`parse_paste returns empty array: native paste blocked, no options added`, async () => {
-    const onadd_spy = vi.fn()
-    mount(MultiSelect, {
-      target: document.body,
-      props: { options: [`a`, `b`, `c`], onadd: onadd_spy, parse_paste: () => [] },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    const event = make_paste_event(`a,b`)
-    input.dispatchEvent(event)
-    await tick()
-
-    expect(onadd_spy).not.toHaveBeenCalled()
-    expect(event.defaultPrevented).toBe(true)
-  })
-
-  test(`works with object options via allowUserOptions`, async () => {
-    const oncreate_spy = vi.fn()
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
+  test(`object options via allowUserOptions`, async () => {
+    const { oncreate } = await paste_into(
+      {
         options: [{ label: `existing` }],
         allowUserOptions: `append`,
         parse_paste: (text: string) => text.split(`,`).map((str) => str.trim()),
-        oncreate: oncreate_spy,
       },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(make_paste_event(`foo,bar`))
-    await tick()
-
-    expect(oncreate_spy).toHaveBeenCalledTimes(2)
-    expect(oncreate_spy).toHaveBeenCalledWith({ option: { label: `foo` } })
-    expect(oncreate_spy).toHaveBeenCalledWith({ option: { label: `bar` } })
+      `foo,bar`,
+    )
+    expect(oncreate).toHaveBeenCalledTimes(2)
+    expect(oncreate).toHaveBeenCalledWith({ option: { label: `foo` } })
+    expect(oncreate).toHaveBeenCalledWith({ option: { label: `bar` } })
   })
 
-  test(`parse_paste object options preserve extra fields with allowUserOptions`, async () => {
-    const oncreate_spy = vi.fn()
-    const props = $state<MultiSelectProps>({
-      options: [{ label: `existing`, value: 0 }],
-      selected: [],
-      allowUserOptions: `append`,
-      parse_paste: (text: string) =>
-        text.split(`,`).map((str, idx) => ({ label: str.trim(), value: idx + 1 })),
-      oncreate: oncreate_spy,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(make_paste_event(`alpha,beta`))
-    await tick()
-
-    expect(oncreate_spy).toHaveBeenCalledTimes(2)
-    expect(oncreate_spy).toHaveBeenCalledWith({ option: { label: `alpha`, value: 1 } })
-    expect(oncreate_spy).toHaveBeenCalledWith({ option: { label: `beta`, value: 2 } })
+  test(`object options preserve extra fields from parse_paste`, async () => {
+    const { oncreate, props } = await paste_into(
+      {
+        options: [{ label: `existing`, value: 0 }],
+        selected: [],
+        allowUserOptions: `append`,
+        parse_paste: (text: string) =>
+          text.split(`,`).map((str, idx) => ({ label: str.trim(), value: idx + 1 })),
+      },
+      `alpha,beta`,
+    )
+    expect(oncreate).toHaveBeenCalledWith({ option: { label: `alpha`, value: 1 } })
+    expect(oncreate).toHaveBeenCalledWith({ option: { label: `beta`, value: 2 } })
     expect(props.selected).toEqual([
       { label: `alpha`, value: 1 },
       { label: `beta`, value: 2 },
     ])
   })
 
-  test(`clears searchText after paste even when maxSelect blocks some options`, async () => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`, `d`],
-      selected: [`a`, `b`],
-      searchText: ``,
-      maxSelect: 3,
-      parse_paste: (text: string) => text.split(`,`),
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(make_paste_event(`c,d`))
-    await tick()
-
+  test(`clears searchText when maxSelect blocks some options`, async () => {
+    const { props } = await paste_into(
+      {
+        options: [`a`, `b`, `c`, `d`],
+        selected: [`a`, `b`],
+        searchText: ``,
+        maxSelect: 3,
+      },
+      `c,d`,
+    )
     expect(props.selected).toEqual([`a`, `b`, `c`])
     expect(props.searchText).toBe(``)
   })
 
-  test(`paste when already at maxSelect fires onmaxreached immediately`, async () => {
-    const onmaxreached_spy = vi.fn()
-    const onadd_spy = vi.fn()
-    const onchange_spy = vi.fn()
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        options: [`a`, `b`, `c`],
-        selected: [`a`, `b`],
-        maxSelect: 2,
-        parse_paste: (text: string) => text.split(`,`),
-        onmaxreached: onmaxreached_spy,
-        onadd: onadd_spy,
-        onchange: onchange_spy,
-      },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(make_paste_event(`c`))
-    await tick()
-
-    expect(onadd_spy).not.toHaveBeenCalled()
-    expect(onchange_spy).not.toHaveBeenCalled()
-    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
-    expect(onmaxreached_spy).toHaveBeenCalledWith(
-      expect.objectContaining({ maxSelect: 2, attemptedOption: `c` }),
-    )
-  })
+  test.each([
+    [`already at max`, [`a`, `b`], 2, `c`, 0, 1, `c`],
+    [`exceeds max mid-paste`, [`a`, `b`], 3, `c,d,e`, 1, 1, `d`],
+  ])(
+    `maxSelect: %s`,
+    async (
+      _label,
+      selected,
+      maxSelect,
+      paste_text,
+      expected_adds,
+      expected_max,
+      attempted,
+    ) => {
+      const { onadd, onmaxreached } = await paste_into(
+        { options: [`a`, `b`, `c`, `d`, `e`], selected, maxSelect },
+        paste_text,
+      )
+      expect(onadd).toHaveBeenCalledTimes(expected_adds)
+      expect(onmaxreached).toHaveBeenCalledTimes(expected_max)
+      expect(onmaxreached).toHaveBeenCalledWith(
+        expect.objectContaining({ maxSelect, attemptedOption: attempted }),
+      )
+    },
+  )
 
   test.each([
-    [`empty selection`, [] as string[], `a`, [`a`]],
-    [`replaces existing`, [`x`], `a`, [`a`]],
+    [`empty selection`, [] as string[], [`a`]],
+    [`replaces existing`, [`x`], [`a`]],
   ])(
-    `with maxSelect=1 and %s, only first parsed option is selected`,
-    async (_label, initial, first_expected, expected_selected) => {
-      const onadd_spy = vi.fn()
-      const onchange_spy = vi.fn()
-      const props = $state<MultiSelectProps>({
-        options: [`a`, `b`, `c`, `x`],
-        selected: initial,
-        maxSelect: 1,
-        parse_paste: (text: string) => text.split(`,`),
-        onadd: onadd_spy,
-        onchange: onchange_spy,
-      })
-
-      mount(MultiSelect, { target: document.body, props })
-
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-      input.dispatchEvent(make_paste_event(`a,b,c`))
-      await tick()
-
-      expect(onadd_spy).toHaveBeenCalledTimes(1)
-      expect(onadd_spy).toHaveBeenCalledWith(
-        expect.objectContaining({ option: first_expected }),
+    `maxSelect=1 with %s: only first option selected`,
+    async (_label, initial, expected) => {
+      const { onadd, props } = await paste_into(
+        { options: [`a`, `b`, `c`, `x`], selected: initial, maxSelect: 1 },
+        `a,b,c`,
       )
-      expect(onchange_spy).toHaveBeenCalledTimes(1)
-      expect(onchange_spy).toHaveBeenCalledWith(
-        expect.objectContaining({ option: first_expected, type: `add` }),
-      )
-      expect(props.selected).toEqual(expected_selected)
+      expect(onadd).toHaveBeenCalledTimes(1)
+      expect(props.selected).toEqual(expected)
     },
   )
 
@@ -6896,94 +6815,27 @@ describe(`parse_paste`, () => {
     [`pre-selected duplicate`, [`a`], `a,b,c`, 2, [`a`, `b`, `c`]],
     [`self-duplicate within paste`, [] as string[], `a,a,b`, 2, [`a`, `b`]],
   ])(
-    `handles %s in pasted text`,
+    `handles %s`,
     async (_label, initial, paste_text, expected_adds, expected_selected) => {
-      const onadd_spy = vi.fn()
-      const onduplicate_spy = vi.fn()
-      const onchange_spy = vi.fn()
-      const props = $state<MultiSelectProps>({
-        options: [`a`, `b`, `c`, `d`],
-        selected: initial,
-        parse_paste: (text: string) => text.split(`,`),
-        onadd: onadd_spy,
-        onduplicate: onduplicate_spy,
-        onchange: onchange_spy,
-      })
-
-      mount(MultiSelect, { target: document.body, props })
-
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-      input.dispatchEvent(make_paste_event(paste_text))
-      await tick()
-
-      expect(onadd_spy).toHaveBeenCalledTimes(expected_adds)
-      expect(onchange_spy).toHaveBeenCalledTimes(expected_adds)
-      expect(onduplicate_spy).toHaveBeenCalledTimes(1)
-      expect(onduplicate_spy).toHaveBeenCalledWith(
-        expect.objectContaining({ option: `a` }),
+      const { onadd, onduplicate, props } = await paste_into(
+        { options: [`a`, `b`, `c`, `d`], selected: initial },
+        paste_text,
       )
-      expect(props.selected).toEqual(expect.arrayContaining(expected_selected))
+      expect(onadd).toHaveBeenCalledTimes(expected_adds)
+      expect(onduplicate).toHaveBeenCalledTimes(1)
+      expect(onduplicate).toHaveBeenCalledWith(expect.objectContaining({ option: `a` }))
       expect(props.selected).toHaveLength(expected_selected.length)
     },
   )
 
-  test(`paste with allowUserOptions selects existing and creates new`, async () => {
-    const onadd_spy = vi.fn()
-    const oncreate_spy = vi.fn()
-    const onchange_spy = vi.fn()
-    const props = $state<MultiSelectProps>({
-      options: [`existing1`, `existing2`],
-      selected: [],
-      allowUserOptions: `append`,
-      parse_paste: (text: string) => text.split(`,`),
-      onadd: onadd_spy,
-      oncreate: oncreate_spy,
-      onchange: onchange_spy,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(make_paste_event(`existing1,brand_new,existing2`))
-    await tick()
-
-    expect(onadd_spy).toHaveBeenCalledTimes(3)
-    expect(onchange_spy).toHaveBeenCalledTimes(3)
-    expect(oncreate_spy).toHaveBeenCalledTimes(1)
-    expect(oncreate_spy).toHaveBeenCalledWith({ option: `brand_new` })
+  test(`mixed existing and new options with allowUserOptions`, async () => {
+    const { onadd, oncreate, props } = await paste_into(
+      { options: [`existing1`, `existing2`], selected: [], allowUserOptions: `append` },
+      `existing1,brand_new,existing2`,
+    )
+    expect(onadd).toHaveBeenCalledTimes(3)
+    expect(oncreate).toHaveBeenCalledTimes(1)
+    expect(oncreate).toHaveBeenCalledWith({ option: `brand_new` })
     expect(props.selected).toEqual([`existing1`, `brand_new`, `existing2`])
-  })
-
-  test(`fires onmaxreached exactly once when paste exceeds maxSelect`, async () => {
-    const onmaxreached_spy = vi.fn()
-    const onadd_spy = vi.fn()
-    const onchange_spy = vi.fn()
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        options: [`a`, `b`, `c`, `d`, `e`],
-        selected: [`a`, `b`],
-        maxSelect: 3,
-        parse_paste: (text: string) => text.split(`,`),
-        onmaxreached: onmaxreached_spy,
-        onadd: onadd_spy,
-        onchange: onchange_spy,
-      },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(make_paste_event(`c,d,e`))
-    await tick()
-
-    expect(onadd_spy).toHaveBeenCalledTimes(1)
-    expect(onadd_spy).toHaveBeenCalledWith(expect.objectContaining({ option: `c` }))
-    expect(onchange_spy).toHaveBeenCalledTimes(1)
-    expect(onchange_spy).toHaveBeenCalledWith(
-      expect.objectContaining({ option: `c`, type: `add` }),
-    )
-    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
-    expect(onmaxreached_spy).toHaveBeenCalledWith(
-      expect.objectContaining({ maxSelect: 3, attemptedOption: `d` }),
-    )
   })
 })

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3098,12 +3098,6 @@ describe(`createOptionMsg as function`, () => {
 describe(`selectAllOption feature`, () => {
   const options = [`Apple`, `Banana`, `Cherry`, `Date`]
 
-  // Helper to open dropdown and click select all
-  function click_select_all() {
-    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
-    doc_query<HTMLElement>(`ul.options > li.select-all`).click()
-  }
-
   test.each([
     [true, `Select all`],
     [`Custom label`, `Custom label`],
@@ -3141,7 +3135,8 @@ describe(`selectAllOption feature`, () => {
         onchange: onchange_spy,
       },
     })
-    click_select_all()
+    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    doc_query<HTMLElement>(`ul.options > li.select-all`).click()
     await tick()
     expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`Apple Banana Cherry Date`)
     expect(onselectAll_spy).toHaveBeenCalledWith({ options })
@@ -3166,6 +3161,62 @@ describe(`selectAllOption feature`, () => {
     expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`A C`) // skipped B (disabled), limited to 2
   })
 
+  test(`triggers onmaxreached when select_all shortcut fired at maxSelect`, async () => {
+    const onmaxreached_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [`a`, `b`, `c`],
+        selectAllOption: true,
+        selected: [`a`, `b`],
+        maxSelect: 2,
+        shortcuts: { select_all: `ctrl+a` },
+        onmaxreached: onmaxreached_spy,
+      },
+    })
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.focus()
+    input.dispatchEvent(
+      new KeyboardEvent(`keydown`, { key: `a`, ctrlKey: true, bubbles: true }),
+    )
+    await tick()
+
+    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
+    expect(onmaxreached_spy).toHaveBeenCalledWith({
+      selected: [`a`, `b`],
+      maxSelect: 2,
+      attemptedOption: `c`,
+    })
+  })
+
+  test(`triggers onmaxreached on partial batch fill (some added, some dropped)`, async () => {
+    const onmaxreached_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [`a`, `b`, `c`, `d`, `e`],
+        selectAllOption: true,
+        selected: [],
+        maxSelect: 3,
+        onmaxreached: onmaxreached_spy,
+      },
+    })
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.click()
+    await tick()
+
+    doc_query<HTMLElement>(`ul.options > li.select-all`).click()
+    await tick()
+
+    expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`a b c`)
+    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
+    expect(onmaxreached_spy).toHaveBeenCalledWith({
+      selected: [`a`, `b`, `c`],
+      maxSelect: 3,
+      attemptedOption: `d`,
+    })
+  })
+
   test.each([
     [true, ``],
     [false, `a`],
@@ -3186,14 +3237,81 @@ describe(`selectAllOption feature`, () => {
     },
   )
 
-  test(`no-op when all already selected`, () => {
-    const spy = vi.fn()
-    mount(MultiSelect, {
-      target: document.body,
-      props: { options, selected: [...options], selectAllOption: true, onselectAll: spy },
+  test.each<[string, Partial<MultiSelectProps>, boolean, string]>([
+    [
+      `all selected`,
+      { options: [`a`, `b`, `c`, `d`], selected: [`a`, `b`, `c`, `d`] },
+      true,
+      `All options already selected`,
+    ],
+    [`some unselected`, { options: [`a`, `b`, `c`, `d`], selected: [`a`] }, false, ``],
+    [
+      `all non-disabled selected`,
+      {
+        options: [{ label: `A` }, { label: `B`, disabled: true }, { label: `C` }],
+        selected: [{ label: `A` }, { label: `C` }],
+      },
+      true,
+      `All options already selected`,
+    ],
+    [
+      `maxSelect reached`,
+      { options: [`a`, `b`, `c`, `d`], selected: [`a`, `b`], maxSelect: 2 },
+      true,
+      `Maximum of 2 options selected`,
+    ],
+    [
+      `maxSelect reached AND all selectable selected`,
+      { options: [`a`, `b`], selected: [`a`, `b`], maxSelect: 2 },
+      true,
+      `All options already selected`,
+    ],
+  ])(
+    `Select All disabled state: %s`,
+    async (_label, extra_props, expected_disabled, expected_title) => {
+      mount(MultiSelect, {
+        target: document.body,
+        props: { selectAllOption: true, ...extra_props },
+      })
+      doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+      await tick()
+      const select_all_li = doc_query<HTMLElement>(`ul.options > li.select-all`)
+      expect(select_all_li.classList.contains(`disabled`)).toBe(expected_disabled)
+      expect(select_all_li.getAttribute(`aria-disabled`)).toBe(
+        expected_disabled ? `true` : null,
+      )
+      expect(select_all_li.tabIndex).toBe(expected_disabled ? -1 : 0)
+      expect(select_all_li.title).toBe(expected_title)
+    },
+  )
+
+  test(`disabled Select All ignores click and fires no events`, async () => {
+    const onselectAll_spy = vi.fn()
+    const onchange_spy = vi.fn()
+    const onmaxreached_spy = vi.fn()
+    const props = $state<MultiSelectProps>({
+      options: [`a`, `b`, `c`],
+      selected: [`a`, `b`],
+      selectAllOption: true,
+      maxSelect: 2,
+      onselectAll: onselectAll_spy,
+      onchange: onchange_spy,
+      onmaxreached: onmaxreached_spy,
     })
-    click_select_all()
-    expect(spy).not.toHaveBeenCalled()
+
+    mount(MultiSelect, { target: document.body, props })
+    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    await tick()
+
+    const select_all_li = doc_query<HTMLElement>(`ul.options > li.select-all`)
+    expect(select_all_li.classList.contains(`disabled`)).toBe(true)
+    select_all_li.click()
+    await tick()
+
+    expect(onselectAll_spy).not.toHaveBeenCalled()
+    expect(onchange_spy).not.toHaveBeenCalled()
+    expect(onmaxreached_spy).not.toHaveBeenCalled()
+    expect(props.selected).toEqual([`a`, `b`])
   })
 
   test(`applies liSelectAllClass`, async () => {
@@ -4123,6 +4241,54 @@ describe(`option grouping feature`, () => {
     },
   )
 
+  test(`group select-all button disabled when maxSelect reached`, async () => {
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: grouped_options,
+        groupSelectAll: true,
+        selected: [grouped_options[0], grouped_options[1]],
+        maxSelect: 2,
+        open: true,
+      },
+    })
+    await tick()
+
+    const genre_btn = find_group_header(`Genre`).querySelector<HTMLButtonElement>(
+      `button.group-select-all`,
+    )
+    expect(genre_btn?.disabled).toBe(true)
+  })
+
+  test(`group select-all partial fill fires onmaxreached with correct payload`, async () => {
+    const onmaxreached_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: grouped_options,
+        groupSelectAll: true,
+        selected: [grouped_options[0]],
+        maxSelect: 2,
+        open: true,
+        onmaxreached: onmaxreached_spy,
+      },
+    })
+    await tick()
+
+    const genre_btn = find_group_header(`Genre`).querySelector<HTMLButtonElement>(
+      `button.group-select-all`,
+    )
+    expect(genre_btn?.disabled).toBe(false)
+    genre_btn?.click()
+    await tick()
+
+    expect(document.querySelectorAll(`ul.selected > li`)).toHaveLength(2)
+    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
+    expect(onmaxreached_spy).toHaveBeenCalledWith(
+      expect.objectContaining({ maxSelect: 2 }),
+    )
+  })
+
   test.each([
     [
       `liGroupHeaderClass`,
@@ -4847,11 +5013,12 @@ describe(`option grouping feature`, () => {
 })
 
 describe(`keyboard shortcuts`, () => {
-  test(`ctrl+a selects all and prevents default browser behavior`, async () => {
+  test(`ctrl+a selects all when shortcut is explicitly set`, async () => {
     const props = $state<MultiSelectProps>({
       options: [`a`, `b`, `c`],
       selectAllOption: true,
       selected: [],
+      shortcuts: { select_all: `ctrl+a` },
       open: true,
     })
 
@@ -4871,10 +5038,10 @@ describe(`keyboard shortcuts`, () => {
     await tick()
 
     expect(props.selected).toEqual([`a`, `b`, `c`])
-    expect(prevent_default_spy).toHaveBeenCalled() // prevents browser default (e.g. select all text)
+    expect(prevent_default_spy).toHaveBeenCalled()
   })
 
-  test(`ctrl+shift+a clears all selected options`, async () => {
+  test(`ctrl+backspace clears all selected options`, async () => {
     const props = $state<MultiSelectProps>({
       options: [`a`, `b`, `c`],
       selected: [`a`, `b`],
@@ -4888,9 +5055,8 @@ describe(`keyboard shortcuts`, () => {
     input.focus()
     input.dispatchEvent(
       new KeyboardEvent(`keydown`, {
-        key: `a`,
+        key: `Backspace`,
         ctrlKey: true,
-        shiftKey: true,
         bubbles: true,
       }),
     )
@@ -4929,6 +5095,32 @@ describe(`keyboard shortcuts`, () => {
     expect(props.selected).toEqual([`a`, `b`, `c`])
   })
 
+  test(`select_all defaults to null so ctrl+a is not swallowed`, async () => {
+    const props = $state<MultiSelectProps>({
+      options: [`a`, `b`, `c`],
+      selectAllOption: true,
+      selected: [],
+      open: true,
+    })
+
+    mount(MultiSelect, { target: document.body, props })
+    await tick()
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.focus()
+    const event = new KeyboardEvent(`keydown`, {
+      key: `a`,
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    input.dispatchEvent(event)
+    await tick()
+
+    expect(props.selected).toEqual([])
+    expect(event.defaultPrevented).toBe(false)
+  })
+
   test(`null shortcut disables the action`, async () => {
     const props = $state<MultiSelectProps>({
       options: [`a`, `b`, `c`],
@@ -4957,6 +5149,7 @@ describe(`keyboard shortcuts`, () => {
       options: [`a`, `b`, `c`],
       selectAllOption: true,
       selected: [],
+      shortcuts: { select_all: `ctrl+a` },
       maxSelect: 2,
       open: true,
     })
@@ -4990,9 +5183,8 @@ describe(`keyboard shortcuts`, () => {
     input.focus()
     input.dispatchEvent(
       new KeyboardEvent(`keydown`, {
-        key: `a`,
+        key: `Backspace`,
         ctrlKey: true,
-        shiftKey: true,
         bubbles: true,
       }),
     )
@@ -5029,6 +5221,7 @@ describe(`keyboard shortcuts`, () => {
       options: [`a`, `b`, `c`],
       selectAllOption: false,
       selected: [],
+      shortcuts: { select_all: `ctrl+a` },
       open: true,
     })
 
@@ -5124,6 +5317,7 @@ describe(`keyboard shortcuts`, () => {
       options: [`a`, `b`, `c`],
       selectAllOption: true,
       selected: [],
+      shortcuts: { select_all: `ctrl+a` },
       disabled: true,
       open: true,
     })
@@ -5173,14 +5367,19 @@ describe(`keyboard shortcuts`, () => {
     // deno-fmt-ignore
     [
       `select_all`,
-      { selectAllOption: true, selected: [] as string[] },
+      {
+        selectAllOption: true,
+        selected: [] as string[],
+        shortcuts: { select_all: `ctrl+a` },
+      },
+      `a`,
       { ctrlKey: true },
       [`a`, `b`, `c`],
     ],
-    [`clear_all`, { selected: [`a`, `b`] }, { ctrlKey: true, shiftKey: true }, []],
+    [`clear_all`, { selected: [`a`, `b`] }, `Backspace`, { ctrlKey: true }, []],
   ])(
     `%s shortcut works when dropdown is closed`,
-    async (_name, extra_props, modifiers, expected) => {
+    async (_name, extra_props, key, modifiers, expected) => {
       const props = $state<MultiSelectProps>({
         options: [`a`, `b`, `c`],
         open: false,
@@ -5193,7 +5392,7 @@ describe(`keyboard shortcuts`, () => {
       const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
       input.focus()
       input.dispatchEvent(
-        new KeyboardEvent(`keydown`, { key: `a`, ...modifiers, bubbles: true }),
+        new KeyboardEvent(`keydown`, { key, ...modifiers, bubbles: true }),
       )
       await tick()
 
@@ -6373,5 +6572,258 @@ describe(`duplicates prop variants`, () => {
     // Verify click triggered add, not duplicate
     expect(onduplicate_spy).not.toHaveBeenCalled()
     expect(onadd_spy).toHaveBeenCalledTimes(1)
+  })
+})
+
+// === parse_paste ===
+
+function make_paste_event(text: string): ClipboardEvent {
+  const event = new ClipboardEvent(`paste`, { bubbles: true, cancelable: true })
+  const data_transfer = new DataTransfer()
+  data_transfer.setData(`text/plain`, text)
+  Object.defineProperty(event, `clipboardData`, { value: data_transfer })
+  return event
+}
+
+describe(`parse_paste`, () => {
+  test(`splits pasted text into multiple selected options`, async () => {
+    const onadd_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [`alpha`, `beta`, `gamma`],
+        parse_paste: (text: string) => text.split(`,`).map((str) => str.trim()),
+        onadd: onadd_spy,
+      },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const event = make_paste_event(`alpha,beta`)
+    input.dispatchEvent(event)
+    await tick()
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(onadd_spy).toHaveBeenCalledTimes(2)
+    expect(onadd_spy).toHaveBeenCalledWith(expect.objectContaining({ option: `alpha` }))
+    expect(onadd_spy).toHaveBeenCalledWith(expect.objectContaining({ option: `beta` }))
+  })
+
+  test(`fires oncreate for each created option with allowUserOptions`, async () => {
+    const oncreate_spy = vi.fn()
+    const onadd_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [`existing`],
+        allowUserOptions: true,
+        parse_paste: (text: string) => text.split(/[,\s]+/).filter(Boolean),
+        oncreate: oncreate_spy,
+        onadd: onadd_spy,
+      },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.dispatchEvent(make_paste_event(`new1,new2,new3`))
+    await tick()
+
+    expect(oncreate_spy).toHaveBeenCalledTimes(3)
+    expect(onadd_spy).toHaveBeenCalledTimes(3)
+  })
+
+  test.each([
+    [`without parse_paste`, {}],
+    [`parse_paste returns empty array`, { parse_paste: () => [] }],
+  ])(`%s: paste is not intercepted`, async (_label, extra_props) => {
+    const onadd_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: { options: [`a`, `b`, `c`], onadd: onadd_spy, ...extra_props },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const event = make_paste_event(`a,b`)
+    input.dispatchEvent(event)
+    await tick()
+
+    expect(onadd_spy).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  test(`works with object options via allowUserOptions`, async () => {
+    const oncreate_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [{ label: `existing` }],
+        allowUserOptions: `append`,
+        parse_paste: (text: string) => text.split(`,`).map((str) => str.trim()),
+        oncreate: oncreate_spy,
+      },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.dispatchEvent(make_paste_event(`foo,bar`))
+    await tick()
+
+    expect(oncreate_spy).toHaveBeenCalledTimes(2)
+    expect(oncreate_spy).toHaveBeenCalledWith({ option: { label: `foo` } })
+    expect(oncreate_spy).toHaveBeenCalledWith({ option: { label: `bar` } })
+  })
+
+  test(`clears searchText after paste even when maxSelect blocks some options`, async () => {
+    const props = $state<MultiSelectProps>({
+      options: [`a`, `b`, `c`, `d`],
+      selected: [`a`, `b`],
+      searchText: ``,
+      maxSelect: 3,
+      parse_paste: (text: string) => text.split(`,`),
+    })
+
+    mount(MultiSelect, { target: document.body, props })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.dispatchEvent(make_paste_event(`c,d`))
+    await tick()
+
+    expect(props.selected).toEqual([`a`, `b`, `c`])
+    expect(props.searchText).toBe(``)
+  })
+
+  test(`paste when already at maxSelect fires onmaxreached immediately`, async () => {
+    const onmaxreached_spy = vi.fn()
+    const onadd_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [`a`, `b`, `c`],
+        selected: [`a`, `b`],
+        maxSelect: 2,
+        parse_paste: (text: string) => text.split(`,`),
+        onmaxreached: onmaxreached_spy,
+        onadd: onadd_spy,
+      },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.dispatchEvent(make_paste_event(`c`))
+    await tick()
+
+    expect(onadd_spy).not.toHaveBeenCalled()
+    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
+    expect(onmaxreached_spy).toHaveBeenCalledWith(
+      expect.objectContaining({ maxSelect: 2, attemptedOption: `c` }),
+    )
+  })
+
+  test.each([
+    [`empty selection`, [] as string[], `a`, [`a`]],
+    [`replaces existing`, [`x`], `a`, [`a`]],
+  ])(
+    `with maxSelect=1 and %s, only first parsed option is selected`,
+    async (_label, initial, first_expected, expected_selected) => {
+      const onadd_spy = vi.fn()
+      const props = $state<MultiSelectProps>({
+        options: [`a`, `b`, `c`, `x`],
+        selected: initial,
+        maxSelect: 1,
+        parse_paste: (text: string) => text.split(`,`),
+        onadd: onadd_spy,
+      })
+
+      mount(MultiSelect, { target: document.body, props })
+
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      input.dispatchEvent(make_paste_event(`a,b,c`))
+      await tick()
+
+      expect(onadd_spy).toHaveBeenCalledTimes(1)
+      expect(onadd_spy).toHaveBeenCalledWith(
+        expect.objectContaining({ option: first_expected }),
+      )
+      expect(props.selected).toEqual(expected_selected)
+    },
+  )
+
+  test.each([
+    [`pre-selected duplicate`, [`a`], `a,b,c`, 2, [`a`, `b`, `c`]],
+    [`self-duplicate within paste`, [] as string[], `a,a,b`, 2, [`a`, `b`]],
+  ])(
+    `handles %s in pasted text`,
+    async (_label, initial, paste_text, expected_adds, expected_selected) => {
+      const onadd_spy = vi.fn()
+      const onduplicate_spy = vi.fn()
+      const props = $state<MultiSelectProps>({
+        options: [`a`, `b`, `c`, `d`],
+        selected: initial,
+        parse_paste: (text: string) => text.split(`,`),
+        onadd: onadd_spy,
+        onduplicate: onduplicate_spy,
+      })
+
+      mount(MultiSelect, { target: document.body, props })
+
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      input.dispatchEvent(make_paste_event(paste_text))
+      await tick()
+
+      expect(onadd_spy).toHaveBeenCalledTimes(expected_adds)
+      expect(onduplicate_spy).toHaveBeenCalledTimes(1)
+      expect(onduplicate_spy).toHaveBeenCalledWith(
+        expect.objectContaining({ option: `a` }),
+      )
+      expect(props.selected).toEqual(expect.arrayContaining(expected_selected))
+      expect(props.selected).toHaveLength(expected_selected.length)
+    },
+  )
+
+  test(`paste with allowUserOptions selects existing and creates new`, async () => {
+    const onadd_spy = vi.fn()
+    const oncreate_spy = vi.fn()
+    const props = $state<MultiSelectProps>({
+      options: [`existing1`, `existing2`],
+      selected: [],
+      allowUserOptions: `append`,
+      parse_paste: (text: string) => text.split(`,`),
+      onadd: onadd_spy,
+      oncreate: oncreate_spy,
+    })
+
+    mount(MultiSelect, { target: document.body, props })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.dispatchEvent(make_paste_event(`existing1,brand_new,existing2`))
+    await tick()
+
+    expect(onadd_spy).toHaveBeenCalledTimes(3)
+    expect(oncreate_spy).toHaveBeenCalledTimes(1)
+    expect(oncreate_spy).toHaveBeenCalledWith({ option: `brand_new` })
+    expect(props.selected).toEqual([`existing1`, `brand_new`, `existing2`])
+  })
+
+  test(`fires onmaxreached exactly once when paste exceeds maxSelect`, async () => {
+    const onmaxreached_spy = vi.fn()
+    const onadd_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [`a`, `b`, `c`, `d`, `e`],
+        selected: [`a`, `b`],
+        maxSelect: 3,
+        parse_paste: (text: string) => text.split(`,`),
+        onmaxreached: onmaxreached_spy,
+        onadd: onadd_spy,
+      },
+    })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.dispatchEvent(make_paste_event(`c,d,e`))
+    await tick()
+
+    expect(onadd_spy).toHaveBeenCalledTimes(1)
+    expect(onadd_spy).toHaveBeenCalledWith(expect.objectContaining({ option: `c` }))
+    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
+    expect(onmaxreached_spy).toHaveBeenCalledWith(
+      expect.objectContaining({ maxSelect: 3, attemptedOption: `d` }),
+    )
   })
 })

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3135,7 +3135,9 @@ describe(`selectAllOption feature`, () => {
         onchange: onchange_spy,
       },
     })
-    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.click()
+    await tick()
     doc_query<HTMLElement>(`ul.options > li.select-all`).click()
     await tick()
     expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`Apple Banana Cherry Date`)
@@ -4289,6 +4291,56 @@ describe(`option grouping feature`, () => {
     )
   })
 
+  test(`group select-all shows deselect when all selectable options in group already selected`, async () => {
+    const genre_opts = grouped_options.filter(
+      (opt) => typeof opt === `object` && opt.group === `Genre`,
+    )
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: grouped_options,
+        groupSelectAll: true,
+        keepSelectedInDropdown: `plain`,
+        selected: genre_opts,
+        open: true,
+      },
+    })
+    await tick()
+
+    const genre_btn = find_group_header(`Genre`).querySelector<HTMLButtonElement>(
+      `button.group-select-all`,
+    )
+    expect(genre_btn?.textContent?.trim()).toBe(`Deselect all`)
+    expect(genre_btn?.disabled).toBe(false)
+  })
+
+  test(`group select-all disabled when all group options are disabled`, async () => {
+    const all_disabled_options = [
+      { label: `X`, group: `AllDisabled`, disabled: true },
+      { label: `Y`, group: `AllDisabled`, disabled: true },
+      { label: `Z`, group: `HasEnabled` },
+    ]
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: all_disabled_options,
+        groupSelectAll: true,
+        open: true,
+      },
+    })
+    await tick()
+
+    const disabled_btn = find_group_header(
+      `AllDisabled`,
+    ).querySelector<HTMLButtonElement>(`button.group-select-all`)
+    expect(disabled_btn?.disabled).toBe(true)
+
+    const enabled_btn = find_group_header(`HasEnabled`).querySelector<HTMLButtonElement>(
+      `button.group-select-all`,
+    )
+    expect(enabled_btn?.disabled).toBe(false)
+  })
+
   test.each([
     [
       `liGroupHeaderClass`,
@@ -5041,29 +5093,39 @@ describe(`keyboard shortcuts`, () => {
     expect(prevent_default_spy).toHaveBeenCalled()
   })
 
-  test(`ctrl+backspace clears all selected options`, async () => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selected: [`a`, `b`],
-      open: true,
-    })
+  test.each([
+    [`ctrl+backspace (default)`, {}, { ctrlKey: true }],
+    [`meta+backspace (explicit)`, { clear_all: `meta+backspace` }, { metaKey: true }],
+  ])(
+    `%s clears all selected options and prevents default`,
+    async (_label, shortcut_override, modifiers) => {
+      const props = $state<MultiSelectProps>({
+        options: [`a`, `b`, `c`],
+        selected: [`a`, `b`],
+        open: true,
+        ...(Object.keys(shortcut_override).length > 0
+          ? { shortcuts: shortcut_override }
+          : {}),
+      })
 
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
+      mount(MultiSelect, { target: document.body, props })
+      await tick()
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, {
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      input.focus()
+      const event = new KeyboardEvent(`keydown`, {
         key: `Backspace`,
-        ctrlKey: true,
+        ...modifiers,
         bubbles: true,
-      }),
-    )
-    await tick()
+        cancelable: true,
+      })
+      input.dispatchEvent(event)
+      await tick()
 
-    expect(props.selected).toEqual([])
-  })
+      expect(props.selected).toEqual([])
+      expect(event.defaultPrevented).toBe(true)
+    },
+  )
 
   test(`custom shortcuts override defaults`, async () => {
     const props = $state<MultiSelectProps>({
@@ -5192,6 +5254,32 @@ describe(`keyboard shortcuts`, () => {
 
     // Should keep minSelect items
     expect(props.selected).toHaveLength(1)
+  })
+
+  test(`clear_all shortcut skipped when searchText is non-empty to preserve native word-delete`, async () => {
+    const props = $state<MultiSelectProps>({
+      options: [`a`, `b`, `c`],
+      selected: [`a`, `b`],
+      searchText: `xyz`,
+      open: true,
+    })
+
+    mount(MultiSelect, { target: document.body, props })
+    await tick()
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.focus()
+    const event = new KeyboardEvent(`keydown`, {
+      key: `Backspace`,
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    input.dispatchEvent(event)
+    await tick()
+
+    expect(props.selected).toEqual([`a`, `b`])
+    expect(event.defaultPrevented).toBe(false)
   })
 
   test.each([`meta+a`, `cmd+a`])(`%s shortcut works for Mac users`, async (shortcut) => {
@@ -6588,12 +6676,14 @@ function make_paste_event(text: string): ClipboardEvent {
 describe(`parse_paste`, () => {
   test(`splits pasted text into multiple selected options`, async () => {
     const onadd_spy = vi.fn()
+    const onchange_spy = vi.fn()
     mount(MultiSelect, {
       target: document.body,
       props: {
         options: [`alpha`, `beta`, `gamma`],
         parse_paste: (text: string) => text.split(`,`).map((str) => str.trim()),
         onadd: onadd_spy,
+        onchange: onchange_spy,
       },
     })
 
@@ -6606,11 +6696,19 @@ describe(`parse_paste`, () => {
     expect(onadd_spy).toHaveBeenCalledTimes(2)
     expect(onadd_spy).toHaveBeenCalledWith(expect.objectContaining({ option: `alpha` }))
     expect(onadd_spy).toHaveBeenCalledWith(expect.objectContaining({ option: `beta` }))
+    expect(onchange_spy).toHaveBeenCalledTimes(2)
+    expect(onchange_spy).toHaveBeenCalledWith(
+      expect.objectContaining({ option: `alpha`, type: `add` }),
+    )
+    expect(onchange_spy).toHaveBeenCalledWith(
+      expect.objectContaining({ option: `beta`, type: `add` }),
+    )
   })
 
   test(`fires oncreate for each created option with allowUserOptions`, async () => {
     const oncreate_spy = vi.fn()
     const onadd_spy = vi.fn()
+    const onchange_spy = vi.fn()
     mount(MultiSelect, {
       target: document.body,
       props: {
@@ -6619,6 +6717,7 @@ describe(`parse_paste`, () => {
         parse_paste: (text: string) => text.split(/[,\s]+/).filter(Boolean),
         oncreate: oncreate_spy,
         onadd: onadd_spy,
+        onchange: onchange_spy,
       },
     })
 
@@ -6628,6 +6727,7 @@ describe(`parse_paste`, () => {
 
     expect(oncreate_spy).toHaveBeenCalledTimes(3)
     expect(onadd_spy).toHaveBeenCalledTimes(3)
+    expect(onchange_spy).toHaveBeenCalledTimes(3)
   })
 
   test.each([
@@ -6670,6 +6770,32 @@ describe(`parse_paste`, () => {
     expect(oncreate_spy).toHaveBeenCalledWith({ option: { label: `bar` } })
   })
 
+  test(`parse_paste object options preserve extra fields with allowUserOptions`, async () => {
+    const oncreate_spy = vi.fn()
+    const props = $state<MultiSelectProps>({
+      options: [{ label: `existing`, value: 0 }],
+      selected: [],
+      allowUserOptions: `append`,
+      parse_paste: (text: string) =>
+        text.split(`,`).map((str, idx) => ({ label: str.trim(), value: idx + 1 })),
+      oncreate: oncreate_spy,
+    })
+
+    mount(MultiSelect, { target: document.body, props })
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.dispatchEvent(make_paste_event(`alpha,beta`))
+    await tick()
+
+    expect(oncreate_spy).toHaveBeenCalledTimes(2)
+    expect(oncreate_spy).toHaveBeenCalledWith({ option: { label: `alpha`, value: 1 } })
+    expect(oncreate_spy).toHaveBeenCalledWith({ option: { label: `beta`, value: 2 } })
+    expect(props.selected).toEqual([
+      { label: `alpha`, value: 1 },
+      { label: `beta`, value: 2 },
+    ])
+  })
+
   test(`clears searchText after paste even when maxSelect blocks some options`, async () => {
     const props = $state<MultiSelectProps>({
       options: [`a`, `b`, `c`, `d`],
@@ -6692,6 +6818,7 @@ describe(`parse_paste`, () => {
   test(`paste when already at maxSelect fires onmaxreached immediately`, async () => {
     const onmaxreached_spy = vi.fn()
     const onadd_spy = vi.fn()
+    const onchange_spy = vi.fn()
     mount(MultiSelect, {
       target: document.body,
       props: {
@@ -6701,6 +6828,7 @@ describe(`parse_paste`, () => {
         parse_paste: (text: string) => text.split(`,`),
         onmaxreached: onmaxreached_spy,
         onadd: onadd_spy,
+        onchange: onchange_spy,
       },
     })
 
@@ -6709,6 +6837,7 @@ describe(`parse_paste`, () => {
     await tick()
 
     expect(onadd_spy).not.toHaveBeenCalled()
+    expect(onchange_spy).not.toHaveBeenCalled()
     expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
     expect(onmaxreached_spy).toHaveBeenCalledWith(
       expect.objectContaining({ maxSelect: 2, attemptedOption: `c` }),
@@ -6722,12 +6851,14 @@ describe(`parse_paste`, () => {
     `with maxSelect=1 and %s, only first parsed option is selected`,
     async (_label, initial, first_expected, expected_selected) => {
       const onadd_spy = vi.fn()
+      const onchange_spy = vi.fn()
       const props = $state<MultiSelectProps>({
         options: [`a`, `b`, `c`, `x`],
         selected: initial,
         maxSelect: 1,
         parse_paste: (text: string) => text.split(`,`),
         onadd: onadd_spy,
+        onchange: onchange_spy,
       })
 
       mount(MultiSelect, { target: document.body, props })
@@ -6739,6 +6870,10 @@ describe(`parse_paste`, () => {
       expect(onadd_spy).toHaveBeenCalledTimes(1)
       expect(onadd_spy).toHaveBeenCalledWith(
         expect.objectContaining({ option: first_expected }),
+      )
+      expect(onchange_spy).toHaveBeenCalledTimes(1)
+      expect(onchange_spy).toHaveBeenCalledWith(
+        expect.objectContaining({ option: first_expected, type: `add` }),
       )
       expect(props.selected).toEqual(expected_selected)
     },
@@ -6752,12 +6887,14 @@ describe(`parse_paste`, () => {
     async (_label, initial, paste_text, expected_adds, expected_selected) => {
       const onadd_spy = vi.fn()
       const onduplicate_spy = vi.fn()
+      const onchange_spy = vi.fn()
       const props = $state<MultiSelectProps>({
         options: [`a`, `b`, `c`, `d`],
         selected: initial,
         parse_paste: (text: string) => text.split(`,`),
         onadd: onadd_spy,
         onduplicate: onduplicate_spy,
+        onchange: onchange_spy,
       })
 
       mount(MultiSelect, { target: document.body, props })
@@ -6767,6 +6904,7 @@ describe(`parse_paste`, () => {
       await tick()
 
       expect(onadd_spy).toHaveBeenCalledTimes(expected_adds)
+      expect(onchange_spy).toHaveBeenCalledTimes(expected_adds)
       expect(onduplicate_spy).toHaveBeenCalledTimes(1)
       expect(onduplicate_spy).toHaveBeenCalledWith(
         expect.objectContaining({ option: `a` }),
@@ -6779,6 +6917,7 @@ describe(`parse_paste`, () => {
   test(`paste with allowUserOptions selects existing and creates new`, async () => {
     const onadd_spy = vi.fn()
     const oncreate_spy = vi.fn()
+    const onchange_spy = vi.fn()
     const props = $state<MultiSelectProps>({
       options: [`existing1`, `existing2`],
       selected: [],
@@ -6786,6 +6925,7 @@ describe(`parse_paste`, () => {
       parse_paste: (text: string) => text.split(`,`),
       onadd: onadd_spy,
       oncreate: oncreate_spy,
+      onchange: onchange_spy,
     })
 
     mount(MultiSelect, { target: document.body, props })
@@ -6795,6 +6935,7 @@ describe(`parse_paste`, () => {
     await tick()
 
     expect(onadd_spy).toHaveBeenCalledTimes(3)
+    expect(onchange_spy).toHaveBeenCalledTimes(3)
     expect(oncreate_spy).toHaveBeenCalledTimes(1)
     expect(oncreate_spy).toHaveBeenCalledWith({ option: `brand_new` })
     expect(props.selected).toEqual([`existing1`, `brand_new`, `existing2`])
@@ -6803,6 +6944,7 @@ describe(`parse_paste`, () => {
   test(`fires onmaxreached exactly once when paste exceeds maxSelect`, async () => {
     const onmaxreached_spy = vi.fn()
     const onadd_spy = vi.fn()
+    const onchange_spy = vi.fn()
     mount(MultiSelect, {
       target: document.body,
       props: {
@@ -6812,6 +6954,7 @@ describe(`parse_paste`, () => {
         parse_paste: (text: string) => text.split(`,`),
         onmaxreached: onmaxreached_spy,
         onadd: onadd_spy,
+        onchange: onchange_spy,
       },
     })
 
@@ -6821,6 +6964,10 @@ describe(`parse_paste`, () => {
 
     expect(onadd_spy).toHaveBeenCalledTimes(1)
     expect(onadd_spy).toHaveBeenCalledWith(expect.objectContaining({ option: `c` }))
+    expect(onchange_spy).toHaveBeenCalledTimes(1)
+    expect(onchange_spy).toHaveBeenCalledWith(
+      expect.objectContaining({ option: `c`, type: `add` }),
+    )
     expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
     expect(onmaxreached_spy).toHaveBeenCalledWith(
       expect.objectContaining({ maxSelect: 3, attemptedOption: `d` }),


### PR DESCRIPTION
- **New `parse_paste` prop** (#406): callback `(text: string) => Option[]` that intercepts paste events and splits clipboard text into multiple options. Fires `oncreate`/`onadd`/`onchange` per option, cleans up `searchText` even when `maxSelect` blocks some options, and fires `onmaxreached` + wiggle when the limit is hit mid-paste.
- **Shortcut defaults**: `select_all` changed from `Ctrl+A` to `null` (opt-in) so the browser's native text selection isn't silently swallowed. `clear_all` changed from `Ctrl+Shift+A` to `Ctrl/Cmd+Backspace` for a more intuitive binding.
- **Select-all disabled state**: both top-level and per-group "Select all" buttons now disable (greyed out, `cursor: not-allowed`, `aria-disabled`, tooltip) when all selectable options are selected, only disabled options remain, or `maxSelect` is reached.
- **Wiggle + `onmaxreached` from `batch_add_options`**: previously silently returned when nothing could be added. Now fires feedback consistent with the single-option `add()` path, including partial batch fills.
- **Demo pages**: interactive `parse_paste` demo with copy-to-paste snippets on `/allow-user-options`, and `select_all` shortcut example on `/min-max-select`.

Closes #406