### PR TITLE
oncreate reject/transform, onparsed_paste event, selectAllDisabledTitle i18n

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -800,8 +800,8 @@
             option_to_add = label_text as Option
           }
         }
-        // Fire oncreate event for all user-created options, regardless of type
-        oncreate?.({ option: option_to_add })
+        // Fire oncreate event — return false to reject the option
+        if (oncreate?.({ option: option_to_add }) === false) return
         if (allowUserOptions === `append`) {
           if (loadOptions) loaded_options = [...loaded_options, option_to_add]
           else options = [...(options ?? []), option_to_add]
@@ -2015,13 +2015,13 @@
     overflow: hidden;
   }
   :is(div.multiselect button.remove-all) {
-    margin: 0 3pt;
-    padding: 1pt;
+    margin: 0 2pt;
+    padding: 0;
   }
   :is(div.multiselect button.remove-all:not(.default-icon)) {
     border-radius: 3pt;
     aspect-ratio: auto;
-    padding: 1pt 2pt;
+    padding: 0 2pt;
   }
   :is(ul.selected > li button:hover, button.remove-all:hover, button:focus) {
     color: var(--sms-remove-btn-hover-color, inherit);
@@ -2096,6 +2096,14 @@
     border-radius: var(--sms-options-border-radius, 1ex);
     padding: var(--sms-options-padding, 0);
     margin: var(--sms-options-margin, 6pt 0 0 0);
+  }
+  :where(ul.options:not(:has(li))) {
+    visibility: hidden;
+    height: 0;
+    overflow: hidden;
+    padding: 0;
+    margin: 0;
+    border: none;
   }
   :where(ul.options.hidden) {
     visibility: hidden;

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -123,6 +123,7 @@
     portal: portal_params = {},
     // Select all feature
     selectAllOption = false,
+    selectAllDisabledTitle,
     liSelectAllClass = ``,
     // Dynamic options loading
     loadOptions,
@@ -147,6 +148,7 @@
     onsearch,
     onmaxreached,
     onduplicate,
+    onparsed_paste,
     onactivate,
     collapseAllGroups = $bindable(),
     expandAllGroups = $bindable(),
@@ -800,8 +802,12 @@
             option_to_add = label_text as Option
           }
         }
-        // Fire oncreate event — return false to reject the option
-        if (oncreate?.({ option: option_to_add }) === false) return
+        // Fire oncreate — return false to reject, return Option to transform
+        const oncreate_result = oncreate?.({ option: option_to_add })
+        if (oncreate_result === false) return
+        const is_option = typeof oncreate_result === `string` ? oncreate_result.length > 0
+          : typeof oncreate_result === `number` || (typeof oncreate_result === `object` && oncreate_result !== null)
+        if (is_option) option_to_add = oncreate_result as Option
         if (allowUserOptions === `append`) {
           if (loadOptions) loaded_options = [...loaded_options, option_to_add]
           else options = [...(options ?? []), option_to_add]
@@ -1301,16 +1307,30 @@
     const parsed = parse_paste(text)
     if (parsed.length === 0) return
     event.preventDefault()
-    for (const option of parsed) {
+    const added: Option[] = []
+    const rejected: Option[] = []
+    const overflow: Option[] = []
+    for (let idx = 0; idx < parsed.length; idx++) {
+      const option = parsed[idx] as Option
       if (maxSelect !== null && maxSelect !== 1 && selected.length >= maxSelect) {
-        wiggle = true
-        onmaxreached?.({ selected, maxSelect, attemptedOption: option })
+        overflow.push(option, ...parsed.slice(idx + 1) as Option[])
+        if (overflow.length === parsed.length - idx) {
+          wiggle = true
+          onmaxreached?.({ selected, maxSelect, attemptedOption: option })
+        }
         break
       }
+      const before = selected.length
       add(option, event, true)
-      if (maxSelect === 1) break
+      if (selected.length > before) added.push(option)
+      else rejected.push(option)
+      if (maxSelect === 1) {
+        overflow.push(...parsed.slice(idx + 1) as Option[])
+        break
+      }
     }
     if (resetFilterOnAdd) searchText = ``
+    onparsed_paste?.({ added, rejected, overflow, raw_text: text })
   }
 
   // reset form validation when required prop changes
@@ -1687,9 +1707,13 @@
         {@const max_reached = maxSelect !== null && selected.length >= maxSelect}
         {@const all_selectable_selected = selectable.every((opt) => selected_keys_set.has(key(opt)))}
         {@const all_selected = max_reached || all_selectable_selected}
-        {@const disabled_title = max_reached && !all_selectable_selected
+        {@const default_title = max_reached && !all_selectable_selected
           ? `Maximum of ${maxSelect} options selected`
           : `All options already selected`}
+        {@const disabled_title = selectAllDisabledTitle === null ? ``
+          : typeof selectAllDisabledTitle === `function`
+            ? selectAllDisabledTitle({ max_reached, maxSelect, selected_count: selected.length })
+            : selectAllDisabledTitle ?? default_title}
         <li
           class="select-all {liSelectAllClass}"
           class:disabled={all_selected}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,7 +30,7 @@ export type PlaceholderConfig = {
 // custom events created by MultiSelect
 export interface MultiSelectEvents<T extends Option = Option> {
   onadd?: (data: { option: T; selected: T[] }) => unknown
-  oncreate?: (data: { option: T }) => unknown // return false to reject the option before it's added
+  oncreate?: (data: { option: T }) => unknown // return false to reject, return T to transform, void to accept as-is
   onremove?: (data: { option: T; selected: T[] }) => unknown
   onremoveAll?: (data: { options: T[] }) => unknown
   onselectAll?: (data: { options: T[] }) => unknown // fires when select all is triggered
@@ -53,6 +53,12 @@ export interface MultiSelectEvents<T extends Option = Option> {
     attemptedOption: T
   }) => unknown // fires when user tries to exceed maxSelect
   onduplicate?: (data: { option: T }) => unknown // fires when user tries to add duplicate (when duplicates=false)
+  onparsed_paste?: (data: {
+    added: T[]
+    rejected: T[]
+    overflow: T[]
+    raw_text: string
+  }) => unknown
   onactivate?: (data: { option: T | null; index: number | null }) => unknown // fires on keyboard navigation through options
   // History/undo-redo events
   onundo?: (data: { previous: T[]; current: T[] }) => unknown // fires when undo is triggered
@@ -226,6 +232,14 @@ export interface MultiSelectProps<T extends Option = Option>
   portal?: PortalParams
   // Select all feature
   selectAllOption?: boolean | string // enable select all; if string, use as label
+  selectAllDisabledTitle?:
+    | string
+    | ((state: {
+        max_reached: boolean
+        maxSelect: number | null
+        selected_count: number
+      }) => string)
+    | null
   liSelectAllClass?: string // CSS class for the select all <li>
   // Dynamic options loading for large datasets (https://github.com/janosh/svelte-multiselect/discussions/342)
   // Pass a function for simple usage, or an object with config for advanced usage

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,7 +30,7 @@ export type PlaceholderConfig = {
 // custom events created by MultiSelect
 export interface MultiSelectEvents<T extends Option = Option> {
   onadd?: (data: { option: T; selected: T[] }) => unknown
-  oncreate?: (data: { option: T }) => unknown // fires when users entered custom text from which new option is created
+  oncreate?: (data: { option: T }) => unknown // return false to reject the option before it's added
   onremove?: (data: { option: T; selected: T[] }) => unknown
   onremoveAll?: (data: { options: T[] }) => unknown
   onselectAll?: (data: { options: T[] }) => unknown // fires when select all is triggered

--- a/src/routes/(demos)/allow-user-options/+page.md
+++ b/src/routes/(demos)/allow-user-options/+page.md
@@ -98,7 +98,7 @@ You can start with no options and let users populate MultiSelect from scratch. I
 
 ## Paste Multiple Values
 
-`parse_paste` lets users paste comma/space/newline-separated text and split it into multiple options at once. Useful for email lists, tags, or any bulk input. Click a snippet below to copy, then paste into the input.
+`parse_paste` lets users paste comma or newline-separated text and split it into multiple options at once. Useful for email lists, tags, or any bulk input. Click a snippet below to copy, then paste into the input.
 
 ```svelte example id="parse-paste"
 <script lang="ts">
@@ -109,9 +109,9 @@ You can start with no options and let users populate MultiSelect from scratch. I
 
   const snippets = [
     { label: `Comma-separated emails`, text: `alice@example.com, bob@test.org, carol@mail.net` },
-    { label: `Space-separated tags`, text: `svelte typescript javascript rust` },
+    { label: `Multi-word values`, text: `New York, Los Angeles, San Francisco` },
     { label: `Newline-separated`, text: `Red\nGreen\nBlue\nYellow` },
-    { label: `Mixed separators`, text: `one, two three\nfour` },
+    { label: `Mixed commas & newlines`, text: `one, two\nthree, four` },
   ]
 </script>
 
@@ -120,7 +120,7 @@ You can start with no options and let users populate MultiSelect from scratch. I
     <div style="display: flex; align-items: center; gap: 0.5em">
       <CopyButton
         content={text}
-        style="padding: 0.3em 0.7em; border-radius: 4px; border: 1px solid var(--sms-border, lightgray); background: var(--sms-options-bg, white); cursor: pointer; font-size: 0.85em; white-space: nowrap"
+        style="padding: 0.3em 0.7em; border-radius: 4px; border: 1px solid var(--sms-border, light-dark(lightgray, #555)); background: var(--sms-options-bg, light-dark(white, #333)); cursor: pointer; font-size: 0.85em; white-space: nowrap"
         labels={{
           ready: { icon: `Copy`, text: label },
           success: { icon: `Check`, text: `Copied!` },
@@ -137,8 +137,14 @@ You can start with no options and let users populate MultiSelect from scratch. I
   bind:selected
   noMatchingOptionsMsg=""
   createOptionMsg={null}
-  parse_paste={(text) => text.split(/[,\s]+/).filter(Boolean)}
-  oncreate={({ option }) => log = [...log, `+ ${option}`]}
+  parse_paste={(text) => text.split(/[,\n]+/).map((s) => s.trim()).filter(Boolean)}
+  oncreate={({ option }) => {
+    if (String(option).length < 3) {
+      log = [...log, `✗ rejected "${option}" (too short)`]
+      return false
+    }
+    log = [...log, `+ ${option}`]
+  }}
   onremove={({ option }) => log = [...log, `- ${option}`]}
 />
 

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -2149,6 +2149,60 @@ test.each([
   },
 )
 
+test.each<[string, boolean | `append`]>([
+  [`allowUserOptions=true`, true],
+  [`allowUserOptions=append`, `append`],
+])(`oncreate returning false rejects option (%s)`, async (_label, mode) => {
+  const onadd_spy = vi.fn()
+  const initial_options = [`a`, `b`]
+  const props = $state<MultiSelectProps>({
+    options: [...initial_options],
+    selected: [],
+    allowUserOptions: mode,
+    oncreate: () => false,
+    onadd: onadd_spy,
+  })
+  mount(MultiSelect, { target: document.body, props })
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.value = `rejected`
+  input.dispatchEvent(input_event)
+  await tick()
+  doc_query<HTMLElement>(`ul.options li.user-msg`).click()
+  await tick()
+
+  expect(onadd_spy).not.toHaveBeenCalled()
+  expect(props.selected).toEqual([])
+  if (mode === `append`) expect(props.options).toEqual(initial_options)
+})
+
+test.each([
+  [`undefined`, undefined],
+  [`true`, true],
+  [`null`, null],
+  [`empty string`, ``],
+])(`oncreate returning %s does not reject`, async (_label, return_val) => {
+  const onadd_spy = vi.fn()
+  mount(MultiSelect, {
+    target: document.body,
+    props: {
+      options: [`a`, `b`],
+      allowUserOptions: true,
+      oncreate: () => return_val,
+      onadd: onadd_spy,
+    },
+  })
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.value = `new-opt`
+  input.dispatchEvent(input_event)
+  await tick()
+  doc_query<HTMLElement>(`ul.options li.user-msg`).click()
+  await tick()
+
+  expect(onadd_spy).toHaveBeenCalledTimes(1)
+})
+
 test(`onadd selected accumulates and onremove selected reflects removal`, async () => {
   const [onadd_spy, onremove_spy] = [vi.fn(), vi.fn()]
 
@@ -4024,7 +4078,7 @@ describe(`CSS static analysis`, () => {
     expect(custom_remove_all).toBeTruthy()
     expect(custom_remove_all).toMatch(/border-radius:\s*3pt/)
     expect(custom_remove_all).toMatch(/aspect-ratio:\s*auto/)
-    expect(custom_remove_all).toMatch(/padding:\s*1pt 2pt/)
+    expect(custom_remove_all).toMatch(/padding:\s*0 2pt/)
   })
 })
 
@@ -5148,14 +5202,17 @@ describe(`keyboard shortcuts`, () => {
     expect(props.selected).toEqual([`a`, `b`, `c`])
   })
 
-  test(`select_all defaults to null so ctrl+a is not swallowed`, async () => {
+  test.each([
+    [`default (null)`, {}],
+    [`explicitly null`, { shortcuts: { select_all: null } }],
+  ])(`select_all %s: ctrl+a not swallowed`, async (_label, extra_props) => {
     const props = $state<MultiSelectProps>({
       options: [`a`, `b`, `c`],
       selectAllOption: true,
       selected: [],
       open: true,
+      ...extra_props,
     })
-
     mount(MultiSelect, { target: document.body, props })
     await tick()
 
@@ -5174,87 +5231,48 @@ describe(`keyboard shortcuts`, () => {
     expect(event.defaultPrevented).toBe(false)
   })
 
-  test(`null shortcut disables the action`, async () => {
+  test.each([
+    [
+      `select_all respects maxSelect`,
+      {
+        selected: [],
+        selectAllOption: true,
+        shortcuts: { select_all: `ctrl+a` },
+        maxSelect: 2,
+      },
+      { key: `a`, ctrlKey: true },
+      2,
+    ],
+    [
+      `clear_all respects minSelect`,
+      { selected: [`a`, `b`, `c`], minSelect: 1 },
+      { key: `Backspace`, ctrlKey: true },
+      1,
+    ],
+  ])(`%s`, async (_label, extra_props, key_event, expected_length) => {
     const props = $state<MultiSelectProps>({
       options: [`a`, `b`, `c`],
-      selectAllOption: true,
-      selected: [],
-      shortcuts: { select_all: null },
       open: true,
+      ...extra_props,
     })
-
     mount(MultiSelect, { target: document.body, props })
     await tick()
 
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
     input.focus()
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, { key: `a`, ctrlKey: true, bubbles: true }),
-    )
+    input.dispatchEvent(new KeyboardEvent(`keydown`, { ...key_event, bubbles: true }))
     await tick()
 
-    // Should NOT select all since shortcut is disabled
-    expect(props.selected).toEqual([])
+    expect(props.selected).toHaveLength(expected_length)
   })
 
-  test(`select_all shortcut respects maxSelect constraint`, async () => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selectAllOption: true,
-      selected: [],
-      shortcuts: { select_all: `ctrl+a` },
-      maxSelect: 2,
-      open: true,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, { key: `a`, ctrlKey: true, bubbles: true }),
-    )
-    await tick()
-
-    // Should only select up to maxSelect
-    expect(props.selected).toHaveLength(2)
-  })
-
-  test(`clear_all shortcut respects minSelect constraint`, async () => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selected: [`a`, `b`, `c`],
-      minSelect: 1,
-      open: true,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, {
-        key: `Backspace`,
-        ctrlKey: true,
-        bubbles: true,
-      }),
-    )
-    await tick()
-
-    // Should keep minSelect items
-    expect(props.selected).toHaveLength(1)
-  })
-
-  test(`clear_all shortcut skipped when searchText is non-empty to preserve native word-delete`, async () => {
+  test(`clear_all skipped when searchText is non-empty`, async () => {
     const props = $state<MultiSelectProps>({
       options: [`a`, `b`, `c`],
       selected: [`a`, `b`],
       searchText: `xyz`,
       open: true,
     })
-
     mount(MultiSelect, { target: document.body, props })
     await tick()
 
@@ -6654,13 +6672,40 @@ describe(`duplicates prop variants`, () => {
   })
 })
 
+test(`dropdown has no li children when all user-created options are selected`, async () => {
+  mount(MultiSelect, {
+    target: document.body,
+    props: {
+      allowUserOptions: `append`,
+      noMatchingOptionsMsg: ``,
+      createOptionMsg: null,
+    },
+  })
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.value = `tag1`
+  input.dispatchEvent(input_event)
+  input.dispatchEvent(enter)
+  await tick()
+
+  input.value = `tag2`
+  input.dispatchEvent(input_event)
+  input.dispatchEvent(enter)
+  await tick()
+
+  input.focus()
+  await tick()
+  const items = document.querySelectorAll(`ul.options > li`)
+  expect(items).toHaveLength(0)
+})
+
 // === parse_paste ===
 
 function make_paste_event(text: string): ClipboardEvent {
-  const event = new ClipboardEvent(`paste`, { bubbles: true, cancelable: true })
   const data_transfer = new DataTransfer()
   data_transfer.setData(`text/plain`, text)
-  Object.defineProperty(event, `clipboardData`, { value: data_transfer })
+  const event = new ClipboardEvent(`paste`, { bubbles: true, cancelable: true })
+  Object.assign(event, { clipboardData: data_transfer })
   return event
 }
 
@@ -6837,5 +6882,19 @@ describe(`parse_paste`, () => {
     expect(oncreate).toHaveBeenCalledTimes(1)
     expect(oncreate).toHaveBeenCalledWith({ option: `brand_new` })
     expect(props.selected).toEqual([`existing1`, `brand_new`, `existing2`])
+  })
+
+  test(`oncreate returning false during paste skips only rejected options`, async () => {
+    const oncreate_spy = vi.fn(({ option }: { option: Option }) => {
+      const label = typeof option === `object` ? option.label : option
+      return `${label}`.length >= 3 ? undefined : false
+    })
+    const { onadd, props } = await paste_into(
+      { options: [], selected: [], allowUserOptions: `append`, oncreate: oncreate_spy },
+      `ab,valid,x,also_ok`,
+    )
+    expect(oncreate_spy).toHaveBeenCalledTimes(4)
+    expect(onadd).toHaveBeenCalledTimes(2)
+    expect(props.selected).toEqual([`valid`, `also_ok`])
   })
 })

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -2203,6 +2203,52 @@ test.each([
   expect(onadd_spy).toHaveBeenCalledTimes(1)
 })
 
+test(`oncreate returning a string transforms the option`, async () => {
+  const props = $state<MultiSelectProps>({
+    options: [`a`, `b`],
+    selected: [],
+    allowUserOptions: `append`,
+    oncreate: ({ option }) =>
+      (typeof option === `object` ? option.label : option).toString().toUpperCase(),
+  })
+  mount(MultiSelect, { target: document.body, props })
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.value = `hello`
+  input.dispatchEvent(input_event)
+  await tick()
+  doc_query<HTMLElement>(`ul.options li.user-msg`).click()
+  await tick()
+
+  expect(props.selected).toEqual([`HELLO`])
+})
+
+test(`oncreate returning an object transforms the option with extra fields`, async () => {
+  const props = $state<MultiSelectProps>({
+    options: [{ label: `existing`, value: 1 }],
+    selected: [],
+    allowUserOptions: `append`,
+    oncreate: ({ option }) => ({
+      ...(typeof option === `object` && option),
+      label: typeof option === `object` ? option.label : option,
+      validated: true,
+    }),
+  })
+  mount(MultiSelect, { target: document.body, props })
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.value = `new-item`
+  input.dispatchEvent(input_event)
+  await tick()
+  doc_query<HTMLElement>(`ul.options li.user-msg`).click()
+  await tick()
+
+  expect(props.selected).toHaveLength(1)
+  expect(props.selected?.[0]).toEqual(
+    expect.objectContaining({ label: `new-item`, validated: true }),
+  )
+})
+
 test(`onadd selected accumulates and onremove selected reflects removal`, async () => {
   const [onadd_spy, onremove_spy] = [vi.fn(), vi.fn()]
 
@@ -3271,6 +3317,31 @@ describe(`selectAllOption feature`, () => {
       maxSelect: 3,
       attemptedOption: `d`,
     })
+  })
+
+  test.each([
+    [`custom string`, `Tout est selectionne`, `Tout est selectionne`],
+    [
+      `function`,
+      (state: { selected_count: number }) => `${state.selected_count} ausgewahlt`,
+      `4 ausgewahlt`,
+    ],
+    [`null suppresses`, null, ``],
+  ])(`selectAllDisabledTitle %s`, async (_label, title_prop, expected_title) => {
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options,
+        selected: [...options],
+        selectAllOption: true,
+        selectAllDisabledTitle: title_prop,
+      },
+    })
+    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    await tick()
+    expect(doc_query<HTMLElement>(`ul.options > li.select-all`).title).toBe(
+      expected_title,
+    )
   })
 
   test.each([
@@ -6717,6 +6788,7 @@ async function paste_into(extra_props: Partial<MultiSelectProps>, paste_text: st
     onchange: vi.fn(),
     onmaxreached: vi.fn(),
     onduplicate: vi.fn(),
+    onparsed_paste: vi.fn(),
   }
   const props = $state<MultiSelectProps>({
     parse_paste: (text: string) => text.split(`,`),
@@ -6896,5 +6968,36 @@ describe(`parse_paste`, () => {
     expect(oncreate_spy).toHaveBeenCalledTimes(4)
     expect(onadd).toHaveBeenCalledTimes(2)
     expect(props.selected).toEqual([`valid`, `also_ok`])
+  })
+
+  test(`onparsed_paste fires with added/rejected/overflow summary`, async () => {
+    const { onparsed_paste } = await paste_into(
+      { options: [`a`, `b`, `c`, `d`, `e`], selected: [`a`], maxSelect: 3 },
+      `b,c,d,e`,
+    )
+    expect(onparsed_paste).toHaveBeenCalledTimes(1)
+    const payload = onparsed_paste.mock.calls[0][0]
+    expect(payload.added).toEqual([`b`, `c`])
+    expect(payload.overflow).toEqual([`d`, `e`])
+    expect(payload.raw_text).toBe(`b,c,d,e`)
+  })
+
+  test(`onparsed_paste reports rejected options from oncreate`, async () => {
+    const { onparsed_paste } = await paste_into(
+      {
+        options: [],
+        selected: [],
+        allowUserOptions: `append`,
+        oncreate: ({ option }) =>
+          `${typeof option === `object` ? option.label : option}`.length >= 3
+            ? undefined
+            : false,
+      },
+      `ab,valid,x`,
+    )
+    const payload = onparsed_paste.mock.calls[0][0]
+    expect(payload.added).toEqual([`valid`])
+    expect(payload.rejected).toEqual([`ab`, `x`])
+    expect(payload.overflow).toEqual([])
   })
 })


### PR DESCRIPTION
Expands `oncreate` and adds two new props for paste feedback and i18n.

- **oncreate reject** (#408 original): return `false` to reject an option before it's added. Strict `=== false` check, backward compatible.
- **oncreate transform**: return a string, number, or object to replace the option (e.g. normalize email casing, add metadata). Returning `undefined`/`void`/`null`/`true` accepts as-is.
- **onparsed_paste event**: fires once after paste processing with `{ added, rejected, overflow, raw_text }`. Named `onparsed_paste` to avoid conflict with native HTML `onpaste`.
- **selectAllDisabledTitle prop**: accepts a string (static i18n), a function `({ max_reached, maxSelect, selected_count }) => string` (dynamic), or `null` (suppress tooltip).

Also: collapse empty dropdown via CSS `:has()`, tighten remove-all button padding, fix dark mode copy button styling.

Addresses follow-up from #406.