### PR TITLE
Fix whitespace guards, falsy value sync, paste reporting, sortable bugs, and type safety

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -265,7 +265,7 @@
   })
   $effect.pre(() => {
     const new_selected = maxSelect === 1
-      ? (value ? [value as Option] : [])
+      ? (value === null || value === undefined ? [] : [value as Option])
       : (Array.isArray(value) ? value : [])
     if (
       !values_equal(
@@ -426,18 +426,17 @@
   )
 
   let has_search_text = $derived(searchText.trim().length > 0)
-
   // Cache selected keys and labels to avoid repeated .map() calls
   let selected_keys = $derived(selected.map(key))
   let selected_labels = $derived(selected.map(utils.get_label))
   // Sets for O(1) lookups (used in template, has_user_msg, group_header_state, batch operations)
   let selected_keys_set = $derived(new Set(selected_keys))
   // String-normalized for consistent comparison (numeric labels like 123 match "123")
-  let selected_labels_set = $derived(new Set(selected_labels.map((lbl) => `${lbl}`)))
+  let selected_labels_set = $derived(new Set(selected_labels.map((label) => `${label}`)))
   // Lowercase labels set for case-insensitive duplicate detection
   let selected_labels_lower_set = $derived(
     duplicates === `case-insensitive`
-      ? new Set(selected_labels.map((lbl) => `${lbl}`.toLowerCase()))
+      ? new Set(selected_labels.map((label) => `${label}`.toLowerCase()))
       : null,
   )
   // Helper to check if a label is already selected (respects case-insensitive mode)
@@ -591,7 +590,7 @@
 
   // Auto-expand collapsed groups when search matches their options
   $effect(() => {
-    if (searchExpandsCollapsedGroups && searchText && collapsibleGroups) {
+    if (searchExpandsCollapsedGroups && has_search_text && collapsibleGroups) {
       expand_groups(get_collapsed_with_matches())
     }
   })
@@ -813,9 +812,8 @@
           console.error(`MultiSelect: oncreate must be synchronous, got a Promise`)
           return
         }
-        const result_type = typeof oncreate_result
-        if (result_type === `string` ? (oncreate_result as string).length > 0
-          : result_type === `number` || (result_type === `object` && oncreate_result !== null)) {
+        if (oncreate_result !== undefined && oncreate_result !== null &&
+          oncreate_result !== ``) {
           option_to_add = oncreate_result as Option
         }
         if (allowUserOptions === `append`) {
@@ -825,7 +823,7 @@
       }
 
       if (resetFilterOnAdd) searchText = `` // reset search string on selection
-      if ([``, undefined, null].includes(option_to_add as string | null)) {
+      if (option_to_add === `` || option_to_add === undefined || option_to_add === null) {
         console.error(`MultiSelect: encountered falsy option`, option_to_add)
         return
       }
@@ -1217,14 +1215,11 @@
   }
 
   function on_click_outside(event: MouseEvent | TouchEvent) {
-    if (!outerDiv) return
-    const target = event.target as Node
+    if (!outerDiv || !(event.target instanceof Node)) return
     // Check if click is inside the main component
-    if (outerDiv.contains(target)) return
+    if (outerDiv.contains(event.target)) return
     // If portal is active, also check if click is inside the portalled options dropdown
-    if (portal_params?.active && ul_options && ul_options.contains(target)) {
-      return
-    }
+    if (portal_params?.active && ul_options?.contains(event.target)) return
     // Click is outside both the main component and any portalled dropdown
     close_dropdown(event)
   }
@@ -1305,7 +1300,8 @@
     }
 
     // For non-portalled dropdowns, close when focus moves outside the component
-    if (!outerDiv?.contains(event.relatedTarget as Node)) close_dropdown(event)
+    if (!(event.relatedTarget instanceof Node) || !outerDiv?.contains(event.relatedTarget))
+      close_dropdown(event)
 
     onblur?.(event) // Call original handler (if any passed as component prop)
   }
@@ -1321,19 +1317,21 @@
     const rejected: Option[] = []
     const overflow: Option[] = []
     for (let idx = 0; idx < parsed.length; idx++) {
-      const option = parsed[idx] as Option
+      const option = parsed[idx]
       if (maxSelect !== null && maxSelect !== 1 && selected.length >= maxSelect) {
-        overflow.push(option, ...parsed.slice(idx + 1) as Option[])
+        overflow.push(option, ...parsed.slice(idx + 1))
         wiggle = true
         onmaxreached?.({ selected, maxSelect, attemptedOption: option })
         break
       }
       const before = selected.length
+      const before_first = maxSelect === 1 ? selected[0] : undefined
       add(option, event, true)
-      if (selected.length > before) added.push(option)
-      else rejected.push(option)
+      if (selected.length > before || (maxSelect === 1 && selected[0] !== before_first)) {
+        added.push(option)
+      } else rejected.push(option)
       if (maxSelect === 1) {
-        overflow.push(...parsed.slice(idx + 1) as Option[])
+        overflow.push(...parsed.slice(idx + 1))
         break
       }
     }
@@ -1472,10 +1470,9 @@
   })
 
   function handle_options_scroll(event: Event) {
-    if (!load_options_config || load_options_loading || !load_options_has_more) {
-      return
-    }
-    const { scrollTop, scrollHeight, clientHeight } = event.target as HTMLElement
+    if (!load_options_config || load_options_loading || !load_options_has_more ||
+      !(event.target instanceof HTMLElement)) return
+    const { scrollTop, scrollHeight, clientHeight } = event.target
     if (scrollHeight - scrollTop - clientHeight <= 100) {
       load_dynamic_options(false)
     }
@@ -1681,7 +1678,7 @@
   {/if}
 
   <!-- only render options dropdown if options or searchText is not empty (needed to avoid briefly flashing empty dropdown) -->
-  {#if (searchText && noMatchingOptionsMsg) || effective_options.length > 0 ||
+  {#if (has_search_text && noMatchingOptionsMsg) || effective_options.length > 0 ||
       loadOptions}
     <ul
       use:portal={{ target_node: outerDiv, ...portal_params }}

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -367,10 +367,10 @@
           onmouseleave={() => schedule_hide(parsed_route.href, is_pinned)}
           onfocusin={() => open_dropdown(parsed_route.href)}
           onfocusout={(event: FocusEvent) => {
-            const next = event.relatedTarget as Node | null
-            if (!next || !(event.currentTarget as HTMLElement).contains(next)) {
-              if (!is_pinned) hovered_dropdown = null
-            }
+            if (event.relatedTarget instanceof Node &&
+              event.currentTarget instanceof HTMLElement &&
+              event.currentTarget.contains(event.relatedTarget)) return
+            if (!is_pinned) hovered_dropdown = null
           }}
         >
           <div>
@@ -426,11 +426,9 @@
             onmouseenter={() => open_dropdown(parsed_route.href, true)}
             onmouseleave={(event: MouseEvent) => {
               // Don't schedule hide if mouse moved to sibling element within same dropdown
-              const related = event.relatedTarget as Node | null
-              const dropdown_el = (event.currentTarget as Element).closest(
-                `.dropdown`,
-              )
-              if (related && dropdown_el?.contains(related)) return
+              if (event.relatedTarget instanceof Node &&
+                event.currentTarget instanceof Element &&
+                event.currentTarget.closest(`.dropdown`)?.contains(event.relatedTarget)) return
               schedule_hide(parsed_route.href, is_pinned)
             }}
           >

--- a/src/lib/Toggle.svelte
+++ b/src/lib/Toggle.svelte
@@ -20,8 +20,7 @@
     onkeydown?.(event)
     if (event.key === `Enter`) {
       event.preventDefault()
-      const target = event.target as HTMLInputElement
-      target.click() // simulate real user toggle so 'change' is dispatched
+      if (event.target instanceof HTMLInputElement) event.target.click() // simulate real user toggle so 'change' is dispatched
     }
   }
 </script>

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -355,16 +355,20 @@ export const sortable =
           const val_1 = get_html_sort_value(cell_1)
           const val_2 = get_html_sort_value(cell_2)
 
-          if (val_1 === val_2) return 0
-          if (val_1 === ``) return 1 // treat empty string as lower than any value
-          if (val_2 === ``) return -1 // any value is considered higher than empty string
-
-          const num_1 = Number(val_1)
-          const num_2 = Number(val_2)
-
+          const [trimmed_1, trimmed_2] = [val_1.trim(), val_2.trim()]
+          if (trimmed_1 === trimmed_2) return 0
+          if (trimmed_1 === ``) return 1 // treat empty/whitespace as lower than any value
+          if (trimmed_2 === ``) return -1
+          const num_1 = Number(trimmed_1)
+          const num_2 = Number(trimmed_2)
           if (isNaN(num_1) && isNaN(num_2)) {
-            return sort_dir * val_1.localeCompare(val_2, undefined, { numeric: true })
+            return (
+              sort_dir * trimmed_1.localeCompare(trimmed_2, undefined, { numeric: true })
+            )
           }
+          // sort non-numeric values after numeric ones
+          if (isNaN(num_1)) return sort_dir
+          if (isNaN(num_2)) return -sort_dir
           return sort_dir * (num_1 - num_2)
         })
 

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -330,6 +330,23 @@ test.each([[null], [1]])(`2-way binding of value updates selected`, async (maxSe
   }
 })
 
+// falsy but valid option values (0, "") must survive the value→selected sync
+test.each([
+  [0, [0, 1, 2]],
+  [``, [``, `a`, `b`]],
+])(`maxSelect=1 preserves falsy value %j`, async (falsy_val, opts) => {
+  const select = mount(Test2WayBind, {
+    target: document.body,
+    props: { options: opts, maxSelect: 1 },
+  })
+
+  select.value = falsy_val
+  await tick()
+
+  expect(select.value).toEqual(falsy_val)
+  expect(select.selected).toEqual([falsy_val])
+})
+
 // Bug: value/selected should update when maxSelect changes at runtime
 test.each([
   {
@@ -1156,22 +1173,32 @@ test.each([
   expect(doc_query(`div.multiselect`).classList.contains(`open`)).toBe(expect_open)
 })
 
-test(`closes dropdown on tab out`, async () => {
-  mount(MultiSelect, { target: document.body, props: { options: [1, 2, 3] } })
+test(`closes dropdown on tab out and blur to external element`, async () => {
+  const onclose = vi.fn()
+  mount(MultiSelect, { target: document.body, props: { options: [1, 2, 3], onclose } })
   // starts with closed dropdown
   expect(doc_query(`ul.options.hidden`)).toBeInstanceOf(HTMLUListElement)
 
   // opens dropdown on focus
-  doc_query<HTMLInputElement>(`input[autocomplete]`).focus()
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.focus()
   await tick()
   expect(document.querySelector(`ul.options.hidden`)).toBeNull()
 
   // closes dropdown again on tab out
-  doc_query<HTMLInputElement>(`input[autocomplete]`).dispatchEvent(
-    new KeyboardEvent(`keydown`, { key: `Tab`, bubbles: true }),
-  )
+  input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Tab`, bubbles: true }))
   await tick()
   expect(doc_query(`ul.options.hidden`)).toBeInstanceOf(HTMLUListElement)
+  expect(onclose).toHaveBeenCalledTimes(1)
+
+  // reopen, then blur to an element outside the component
+  input.focus()
+  await tick()
+  const external = document.createElement(`button`)
+  document.body.append(external)
+  input.dispatchEvent(new FocusEvent(`blur`, { bubbles: true, relatedTarget: external }))
+  await tick()
+  expect(onclose).toHaveBeenCalledTimes(2)
 })
 
 describe.each([
@@ -1553,6 +1580,21 @@ test(`whitespace-only input rejected with loadOptions (root cause path)`, async 
   } finally {
     vi.useRealTimers()
   }
+})
+
+// whitespace-only input should not mount the options dropdown when there are no options
+test(`whitespace-only input does not mount options dropdown`, async () => {
+  mount(MultiSelect, {
+    target: document.body,
+    props: { options: [], allowUserOptions: true, open: true },
+  })
+
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  input.value = ` `
+  input.dispatchEvent(input_event)
+  await tick()
+
+  expect(document.querySelector(`ul.options`)).toBeNull()
 })
 
 test.each([[[1]], [[1, 2]], [[1, 2, 3]], [[1, 2, 3, 4]]])(
@@ -3635,8 +3677,8 @@ describe(`loadOptions feature`, () => {
       target: document.body,
       props: { loadOptions: load_options, open: true },
     })
-    await tick()
-    await tick()
+    await tick() // effect starts async fetch
+    await tick() // fetch resolves, results applied
 
     const options_ul = doc_query(`ul.options`)
     expect(options_ul.textContent).toContain(`Apple`)
@@ -4125,12 +4167,10 @@ describe(`binding update event count`, () => {
         props: { options: [1, 2, 3], maxSelect, onSelectedChanged: spy },
       })
       await tick()
-      await tick()
       expect(spy.mock.calls.length).toBeLessThanOrEqual(1) // init: at most 1 call
 
       spy.mockClear()
       doc_query<HTMLElement>(`ul.options li`).click()
-      await tick()
       await tick()
       expect(spy).toHaveBeenCalledTimes(1) // selection: exactly 1 call
     },
@@ -4147,7 +4187,6 @@ describe(`binding update event count`, () => {
         target: document.body,
         props: { options: [1, 2, 3], maxSelect, onValueChanged: spy },
       })
-      await tick()
       await tick()
 
       // The effect in Test2WayBind fires at least once on mount with initial value
@@ -4317,7 +4356,6 @@ describe(`option grouping feature`, () => {
     // Navigate down - first active should be first option, not group header
     input.dispatchEvent(arrow_down)
     await tick()
-    await tick() // extra tick for reactive effects
 
     const active_option = document.querySelector(`ul.options > li.active`)
     // Check that it's not a group header if an active element exists
@@ -4998,11 +5036,35 @@ describe(`option grouping feature`, () => {
     input.value = `Rock`
     input.dispatchEvent(input_event)
     await tick()
-    await tick() // extra tick for effect
 
     // Genre group should now be expanded because "Rock" matches
     // ongroupToggle should have been called
     expect(ongroupToggle_spy).toHaveBeenCalledWith({ group: `Genre`, collapsed: false })
+  })
+
+  test(`searchExpandsCollapsedGroups ignores whitespace-only input`, async () => {
+    // "C Major" and "D Minor" contain spaces, so a single space fuzzy-matches them.
+    // Without the has_search_text guard, the Key group would expand on whitespace input.
+    const ongroupToggle_spy = vi.fn()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: grouped_options,
+        collapsibleGroups: true,
+        collapsedGroups: new Set([`Genre`, `Key`]),
+        searchExpandsCollapsedGroups: true,
+        ongroupToggle: ongroupToggle_spy,
+        open: true,
+      },
+    })
+    await tick()
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.value = ` `
+    input.dispatchEvent(input_event)
+    await tick()
+
+    expect(ongroupToggle_spy).not.toHaveBeenCalled()
   })
 
   test.each([
@@ -5104,7 +5166,6 @@ describe(`option grouping feature`, () => {
     const genre_header = find_group_header(`Genre`)
     genre_header.click()
     await tick()
-    await tick()
 
     // Genre is collapsed, so its options should be hidden
     const visible_options = document.querySelectorAll(
@@ -5119,8 +5180,6 @@ describe(`option grouping feature`, () => {
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
     input.focus()
     input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `ArrowDown`, bubbles: true }))
-    await tick()
-    await tick()
     await tick()
 
     // Genre group should now be expanded (Rock should be visible)
@@ -7052,6 +7111,18 @@ describe(`parse_paste`, () => {
     expect(payload.added).toEqual([`b`, `c`])
     expect(payload.overflow).toEqual([`d`, `e`])
     expect(payload.raw_text).toBe(`b,c,d,e`)
+  })
+
+  test(`onparsed_paste with maxSelect=1 reports replaced option as added`, async () => {
+    const { onparsed_paste, props } = await paste_into(
+      { options: [`a`, `b`, `c`], selected: [`a`], maxSelect: 1 },
+      `b,c`,
+    )
+    expect(onparsed_paste).toHaveBeenCalledTimes(1)
+    const payload = onparsed_paste.mock.calls[0][0]
+    expect(payload.added).toEqual([`b`])
+    expect(payload.overflow).toEqual([`c`])
+    expect(props.selected).toEqual([`b`])
   })
 
   test(`onparsed_paste reports rejected options from oncreate`, async () => {

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -1465,6 +1465,25 @@ describe(`sortable`, () => {
 
     expect(header.style.color).toBe(`blue`)
   })
+
+  it.each([
+    [`whitespace-only cells as empty`, [`   `, `5`, `1`], [`1`, `5`, ``]],
+    [
+      `mixed numeric and text cells`,
+      [`foo`, `10`, `bar`, `2`],
+      [`2`, `10`, `bar`, `foo`],
+    ],
+  ])(`should sort %s correctly`, (_desc, cells, expected) => {
+    const table = document.createElement(`table`)
+    const rows = cells.map((val: string) => `<tr><td>${val}</td></tr>`).join(``)
+    table.innerHTML = `<thead><tr><th>Col</th></tr></thead><tbody>${rows}</tbody>`
+    document.body.append(table)
+
+    sortable()(table)
+    get_required_header(table).dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+
+    expect(get_column_values(table, 0).map((val) => val?.trim())).toEqual(expected)
+  })
 })
 
 describe(`resizable`, () => {


### PR DESCRIPTION
Follow-up to #410 — systematic audit for similar and unrelated bugs across the codebase.

### Bug fixes
- **Whitespace guards**: `searchExpandsCollapsedGroups` effect and dropdown render condition used raw `searchText` (truthy for whitespace), causing collapsed groups to expand and empty dropdowns to mount on whitespace-only input. Fixed by using `has_search_text`.
- **Falsy value sync** (`maxSelect=1`): `value ? [value] : []` silently dropped valid falsy options like `0` and `""` because they're falsy in JS. Fixed with explicit null/undefined check.
- **Paste replacement reporting** (`maxSelect=1`): When pasting replaces the current selection, the length-based detection (`selected.length > before`) misclassified the replaced option as "rejected" in `onparsed_paste`. Fixed by also checking if `selected[0]` changed.
- **Sortable attachment**: Whitespace-only cell content coerced to `0` via `Number("  ")`, and mixed numeric/text columns returned `NaN` from the sort comparator. Fixed by trimming values and adding individual `isNaN` guards.
- **Interaction and loading guards**: harden outside/blur and keyboard handling, guard scrolling and infinite loading, and reject truly empty created options.

### Type safety
- Replaced 8 unsafe `as` type casts with `instanceof` guards across MultiSelect, Nav, Toggle — adds runtime safety.
- Removed 5 redundant casts in paste handler and oncreate check.
- Renamed `lbl` → `label` in map callbacks.

All fixes verified via mutation testing (each regression is caught by its test).