### PR TITLE
Fix loadOptions scrollbar absence with small batchSize

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "overrides": {
     "svelte": "$svelte",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.16",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,23 +64,23 @@
     "changelog": "npx tsx https://github.com/janosh/workflows/raw/refs/heads/main/scripts/make-release-notes.ts"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.59.1",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.55.0",
+    "@sveltejs/kit": "^2.57.1",
     "@sveltejs/package": "2.5.7",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "^4.1.2",
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.4",
     "@wooorm/starry-night": "^3.9.0",
     "acorn": "^8.16.0",
-    "happy-dom": "^20.8.8",
+    "happy-dom": "^20.9.0",
     "mdsvex": "^0.12.7",
-    "svelte": "^5.55.0",
+    "svelte": "^5.55.3",
     "svelte-toc": "^0.6.3",
-    "typescript": "5.9.3",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "typescript": "6.0.2",
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.16",
     "vite-plus": "latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.16"
   },
   "peerDependencies": {
     "@wooorm/starry-night": "^3.0.0",

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -411,14 +411,15 @@
   let load_options_loading = $state(false)
   let load_options_last_search: string | null = $state(null)
   let debounce_timer: ReturnType<typeof setTimeout> | null = null
-  let load_options_session = 0 // incremented on close to invalidate in-flight fetches
+  let load_request_id = 0 // monotonic counter to invalidate stale in-flight fetches
+  let auto_fill_count = 0
+  const MAX_AUTO_FILL_ROUNDS = 20
 
-  // True when loadOptions is configured and results for the current search haven't
-  // arrived yet (either debouncing or actively fetching). Prevents premature user
-  // messages and option creation while search is pending.
+  // has_more check: errors (has_more=false) clear pending state
   let load_options_pending = $derived(
     Boolean(load_options_config) &&
-      (load_options_loading || (open && (load_options_last_search ?? ``) !== searchText)),
+      (load_options_loading || (open && load_options_has_more
+        && (load_options_last_search ?? ``) !== searchText)),
   )
 
   let effective_options = $derived(
@@ -1262,8 +1263,7 @@
     event,
   ) => {
     handle_keydown(event) // Restore internal logic
-    // Call original forwarded handler
-    onkeydown?.(event)
+    onkeydown?.(event) // Call original forwarded handler
   }
 
   const handle_input_focus: FocusEventHandler<HTMLInputElement> = (event) => {
@@ -1398,30 +1398,43 @@
     }
   }
 
-  // Dynamic options loading - captures search at call time to avoid race conditions
+  // Dynamic options loading - captures search at call time to avoid race conditions.
+  // reset=true bypasses the loading mutex so search changes can start a new fetch
+  // even while a previous one is in-flight (the request_id discards stale results).
   async function load_dynamic_options(reset: boolean) {
-    if (
-      !load_options_config ||
-      load_options_loading ||
-      (!reset && !load_options_has_more)
-    ) {
+    if (!load_options_config || (!reset && (load_options_loading || !load_options_has_more))) {
       return
     }
+    if (reset) auto_fill_count = 0
     const search = searchText
     const offset = reset ? 0 : loaded_options.length
-    const session = load_options_session
+    const request_id = ++load_request_id
     load_options_loading = true
     try {
       const limit = load_options_config.batch_size
       const result = await load_options_config.fetch({ search, offset, limit })
-      if (session !== load_options_session) return // dropdown closed during fetch, discard
+      if (request_id !== load_request_id) return // stale request, discard
       loaded_options = reset ? result.options : [...loaded_options, ...result.options]
       load_options_has_more = result.hasMore
+      load_options_last_search = search
     } catch (error) {
       console.error(`MultiSelect: loadOptions error:`, error)
+      if (request_id === load_request_id) load_options_has_more = false
     } finally {
-      if (session === load_options_session) load_options_last_search = search
-      load_options_loading = false
+      // Only clear loading if this is still the active request — a newer
+      // reset call may have started while this one was in-flight
+      if (request_id === load_request_id) load_options_loading = false
+    }
+    // Auto-fill: if the loaded batch doesn't overflow the dropdown, the scrollbar
+    // won't appear and onscroll can never fire. Keep loading until scrollable or done.
+    if (request_id === load_request_id && load_options_has_more
+      && open && ul_options && auto_fill_count < MAX_AUTO_FILL_ROUNDS) {
+      await tick()
+      if (open && ul_options && ul_options.clientHeight > 0
+        && ul_options.scrollHeight <= ul_options.clientHeight) {
+        auto_fill_count++
+        load_dynamic_options(false)
+      }
     }
   }
 
@@ -1431,10 +1444,11 @@
 
     // Reset state when dropdown closes so next open triggers fresh load
     if (!open) {
-      load_options_session++
+      load_request_id++
       load_options_last_search = null
       loaded_options = []
       load_options_has_more = true
+      load_options_loading = false
       return
     }
 
@@ -1473,6 +1487,7 @@
   function handle_options_scroll(event: Event) {
     if (!load_options_config || load_options_loading || !load_options_has_more ||
       !(event.target instanceof HTMLElement)) return
+    auto_fill_count = 0
     const { scrollTop, scrollHeight, clientHeight } = event.target
     if (scrollHeight - scrollTop - clientHeight <= 100) {
       load_dynamic_options(false)

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,5 +1,6 @@
 <!-- eslint-disable-next-line @stylistic/quotes -- TS generics require string literals -->
 <script lang="ts" generics="Option extends import('./types').Option">
+  // === Imports ===
   import { tick, untrack } from 'svelte'
   import { flip } from 'svelte/animate'
   import type { FocusEventHandler, KeyboardEventHandler } from 'svelte/elements'
@@ -11,6 +12,7 @@
   import * as utils from './utils'
   import Wiggle from './Wiggle.svelte'
 
+  // === Props ===
   let {
     activeIndex = $bindable(null),
     activeOption = $bindable(null),
@@ -165,43 +167,11 @@
     ...rest
   }: MultiSelectProps<Option> = $props()
 
+  // === Config normalization ===
   // Generate unique IDs for ARIA associations (combobox pattern)
   // Uses provided id prop or generates a random one using crypto API
   const internal_id = $derived(id ?? `sms-${utils.get_uuid().slice(0, 8)}`)
   const listbox_id = $derived(`${internal_id}-listbox`)
-
-  // Parse shortcut string into modifier+key parts
-  function parse_shortcut(shortcut: string): {
-    key: string
-    ctrl: boolean
-    shift: boolean
-    alt: boolean
-    meta: boolean
-  } {
-    const parts = shortcut.toLowerCase().split(`+`).map((part) => part.trim())
-    const key = parts.pop() ?? ``
-    const ctrl = parts.includes(`ctrl`)
-    const shift = parts.includes(`shift`)
-    const alt = parts.includes(`alt`)
-    const meta = parts.includes(`meta`) || parts.includes(`cmd`)
-    return { key, ctrl, shift, alt, meta }
-  }
-
-  function matches_shortcut(
-    event: KeyboardEvent,
-    shortcut: string | null | undefined,
-  ): boolean {
-    if (!shortcut) return false
-    const parsed = parse_shortcut(shortcut)
-    // Require non-empty key to prevent "ctrl+" from matching any key with ctrl pressed
-    if (!parsed.key) return false
-    const key_matches = event.key.toLowerCase() === parsed.key
-    const ctrl_matches = event.ctrlKey === parsed.ctrl
-    const shift_matches = event.shiftKey === parsed.shift
-    const alt_matches = event.altKey === parsed.alt
-    const meta_matches = event.metaKey === parsed.meta
-    return key_matches && ctrl_matches && shift_matches && alt_matches && meta_matches
-  }
 
   // Platform detection for keyboard shortcuts (Mac uses Cmd, others use Ctrl)
   const is_mac = typeof navigator !== `undefined` &&
@@ -231,31 +201,14 @@
     }
   })
 
-  // Helper to compare arrays/values for equality to avoid unnecessary updates.
-  // Prevents infinite loops when value/selected are bound to reactive wrappers
-  // that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.
-  // Treats null/undefined/[] as equivalent empty states to prevent extra updates on init (#369).
-  function values_equal(val1: unknown, val2: unknown): boolean {
-    if (val1 === val2) return true
-    const empty1 = val1 === null || val1 === undefined || (Array.isArray(val1) && val1.length === 0)
-    const empty2 = val2 === null || val2 === undefined || (Array.isArray(val2) && val2.length === 0)
-    if (empty1 && empty2) return true
-    if (Array.isArray(val1) && Array.isArray(val2)) {
-      return (
-        val1.length === val2.length &&
-        val1.every((item, idx) => item === val2[idx])
-      )
-    }
-    return false
-  }
-
+  // === Selection and value sync ===
   // Sync selected ↔ value bidirectionally. Use untrack to prevent each effect from
-  // reacting to changes in the "destination" value, and values_equal to prevent
+  // reacting to changes in the "destination" value, and utils.values_equal to prevent
   // infinite loops with reactive wrappers that clone arrays. See issue #309.
   $effect.pre(() => {
     const new_value = maxSelect === 1 ? (selected[0] ?? null) : selected
     if (
-      !values_equal(
+      !utils.values_equal(
         untrack(() => value),
         new_value,
       )
@@ -268,7 +221,7 @@
       ? (value === null || value === undefined ? [] : [value as Option])
       : (Array.isArray(value) ? value : [])
     if (
-      !values_equal(
+      !utils.values_equal(
         untrack(() => selected),
         new_selected,
       )
@@ -331,7 +284,7 @@
       return
     }
     // Check if actually changed (avoid duplicates from reactive updates)
-    if (values_equal(selected, prev_selected)) return
+    if (utils.values_equal(selected, prev_selected)) return
 
     // On first change, push initial state first
     if (history_stack.length === 0) {
@@ -422,6 +375,7 @@
         && (load_options_last_search ?? ``) !== searchText)),
   )
 
+  // === Derived collections and indexing ===
   let effective_options = $derived(
     loadOptions ? loaded_options : (options ?? []),
   )
@@ -537,6 +491,7 @@
     return state
   })
 
+  // === Grouping ===
   // Update collapsedGroups state: 'add' adds groups, 'delete' removes groups, 'set' replaces all
   function update_collapsed_groups(
     action: `add` | `delete` | `set`,
@@ -739,6 +694,25 @@
     minSelect === null || selected.length > minSelect,
   )
 
+  function get_option_view(option_item: Option) {
+    const flat_idx = navigable_index_map.get(option_item) ?? -1
+    const {
+      label,
+      disabled = null,
+      title = null,
+      selectedTitle = null,
+      disabledTitle = defaultDisabledTitle,
+    } = utils.is_object(option_item) ? option_item : { label: option_item }
+    return {
+      flat_idx, label, disabled, title, selectedTitle, disabledTitle,
+      active: activeIndex === flat_idx && flat_idx >= 0,
+      selected: is_selected(label),
+      style: [utils.get_style(option_item, `option`), liOptionStyle]
+        .filter(Boolean).join(` `) || null,
+    }
+  }
+
+  // === Selection mutations ===
   // toggle an option between selected and unselected states (for keepSelectedInDropdown mode)
   function toggle_option(option_to_toggle: Option, event: Event) {
     const is_currently_selected = selected_keys_set.has(key(option_to_toggle))
@@ -930,6 +904,7 @@
         can_show_no_match_msg),
   )
 
+  // === Keyboard and pointer handlers ===
   // Handle arrow key navigation through options (uses navigable_options to skip collapsed groups)
   async function handle_arrow_navigation(direction: 1 | -1) {
     ignore_hover = true
@@ -1032,7 +1007,7 @@
     ]
 
     for (const { key, condition, action } of shortcut_actions) {
-      if (matches_shortcut(event, effective_shortcuts[key]) && condition()) {
+      if (utils.matches_shortcut(event, effective_shortcuts[key]) && condition()) {
         event.preventDefault()
         event.stopPropagation()
         action()
@@ -1226,6 +1201,7 @@
     close_dropdown(event)
   }
 
+  // === Drag, input, and paste handlers ===
   let drag_idx: number | null = $state(null)
   // event handlers enable dragging to reorder selected options
   const drop = (target_idx: number) => (event: DragEvent) => {
@@ -1347,6 +1323,7 @@
     form_input?.setCustomValidity(``)
   })
 
+  // === DOM, portal, and focus ===
   // Portal action: use: directive instead of @attach because portalling requires
   // synchronous DOM manipulation during element creation and in-place updates
   // (the action's update method avoids teardown/re-creation when outerDiv changes).
@@ -1398,6 +1375,7 @@
     }
   }
 
+  // === Async loadOptions ===
   // Dynamic options loading - captures search at call time to avoid race conditions.
   // reset=true bypasses the loading mutex so search changes can start a new fetch
   // even while a previous one is in-flight (the request_id discards stale results).
@@ -1495,6 +1473,16 @@
   }
 </script>
 
+{#snippet render_label(opt: Option, idx: number, type: `selected` | `option`)}
+  {#if children}
+    {@render children({ option: opt, idx, type })}
+  {:else if parseLabelsAsHtml}
+    {@html utils.get_label(opt)}
+  {:else}
+    {utils.get_label(opt)}
+  {/if}
+{/snippet}
+
 <svelte:window
   onclick={on_click_outside}
   ontouchstart={on_click_outside}
@@ -1578,12 +1566,8 @@
       >
         {#if selectedItem}
           {@render selectedItem({ option, idx })}
-        {:else if children}
-          {@render children({ option, idx, type: `selected` })}
-        {:else if parseLabelsAsHtml}
-          {@html utils.get_label(option)}
         {:else}
-          {utils.get_label(option)}
+          {@render render_label(option, idx, `selected`)}
         {/if}
         {#if !disabled && can_remove}
           <button
@@ -1817,48 +1801,36 @@
         ? `${key(option_item)}-${group_idx}-${local_idx}`
         : key(option_item))
           }
-            {@const flat_idx = navigable_index_map.get(option_item) ?? -1}
-            {@const {
-        label,
-        disabled = null,
-        title = null,
-        selectedTitle = null,
-        disabledTitle = defaultDisabledTitle,
-      } = utils.is_object(option_item) ? option_item : { label: option_item }}
-            {@const active = activeIndex === flat_idx && flat_idx >= 0}
-            {@const selected = is_selected(label)}
-            {@const optionStyle = [utils.get_style(option_item, `option`), liOptionStyle]
-        .filter(Boolean)
-        .join(` `) || null}
-            {#if is_option_visible(flat_idx)}
+            {@const view = get_option_view(option_item)}
+            {#if is_option_visible(view.flat_idx)}
               <li
-                id="{internal_id}-opt-{flat_idx}"
-                onclick={(event) => handle_option_interact(option_item, disabled, event)}
-                title={disabled ? disabledTitle : (selected && selectedTitle) || title}
-                class:selected
-                class:active
-                class:disabled
-                class="{liOptionClass} {active ? liActiveOptionClass : ``}"
+                id="{internal_id}-opt-{view.flat_idx}"
+                onclick={(event) => handle_option_interact(option_item, view.disabled, event)}
+                title={view.disabled ? view.disabledTitle : (view.selected && view.selectedTitle) || view.title}
+                class:selected={view.selected}
+                class:active={view.active}
+                class:disabled={view.disabled}
+                class="{liOptionClass} {view.active ? liActiveOptionClass : ``}"
                 onmouseover={() => {
-                  if (!disabled && !ignore_hover) activeIndex = flat_idx
+                  if (!view.disabled && !ignore_hover) activeIndex = view.flat_idx
                 }}
                 onfocus={() => {
-                  if (!disabled) activeIndex = flat_idx
+                  if (!view.disabled) activeIndex = view.flat_idx
                 }}
                 role="option"
-                aria-selected={selected ? `true` : `false`}
-                aria-posinset={flat_idx + 1}
+                aria-selected={view.selected ? `true` : `false`}
+                aria-posinset={view.flat_idx + 1}
                 aria-setsize={navigable_options.length}
-                style={optionStyle}
+                style={view.style}
                 onkeydown={if_enter_or_space((event) =>
-                  handle_option_interact(option_item, disabled, event)
+                  handle_option_interact(option_item, view.disabled, event)
                 )}
               >
                 {#if keepSelectedInDropdown === `checkboxes`}
                   <input
                     type="checkbox"
                     class="option-checkbox"
-                    checked={selected}
+                    checked={view.selected}
                     aria-label="Toggle {utils.get_label(option_item)}"
                     tabindex="-1"
                   />
@@ -1866,17 +1838,13 @@
                 {#if option}
                   {@render option({
           option: option_item,
-          idx: flat_idx,
-          selected,
-          active,
-          disabled: disabled ?? false,
+          idx: view.flat_idx,
+          selected: view.selected,
+          active: view.active,
+          disabled: view.disabled ?? false,
         })}
-                {:else if children}
-                  {@render children({ option: option_item, idx: flat_idx, type: `option` })}
-                {:else if parseLabelsAsHtml}
-                  {@html utils.get_label(option_item)}
                 {:else}
-                  {utils.get_label(option_item)}
+                  {@render render_label(option_item, view.flat_idx, `option`)}
                 {/if}
               </li>
             {/if}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -62,6 +62,58 @@ export function get_style(
   return css_str
 }
 
+// Parse shortcut string into modifier+key parts
+export function parse_shortcut(shortcut: string): {
+  key: string
+  ctrl: boolean
+  shift: boolean
+  alt: boolean
+  meta: boolean
+} {
+  const parts = shortcut
+    .toLowerCase()
+    .split(`+`)
+    .map((part) => part.trim())
+  const key = parts.pop() ?? ``
+  const ctrl = parts.includes(`ctrl`)
+  const shift = parts.includes(`shift`)
+  const alt = parts.includes(`alt`)
+  const meta = parts.includes(`meta`) || parts.includes(`cmd`)
+  return { key, ctrl, shift, alt, meta }
+}
+
+export function matches_shortcut(
+  event: KeyboardEvent,
+  shortcut: string | null | undefined,
+): boolean {
+  if (!shortcut) return false
+  const { key, ctrl, shift, alt, meta } = parse_shortcut(shortcut)
+  // Require non-empty key to prevent "ctrl+" from matching any key with ctrl pressed
+  if (!key) return false
+  return (
+    event.key.toLowerCase() === key &&
+    event.ctrlKey === ctrl &&
+    event.shiftKey === shift &&
+    event.altKey === alt &&
+    event.metaKey === meta
+  )
+}
+
+// Compare arrays/values for equality to avoid unnecessary updates.
+// Prevents infinite loops when value/selected are bound to reactive wrappers
+// that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.
+// Treats null/undefined/[] as equivalent empty states to prevent extra updates on init (#369).
+export function values_equal(val1: unknown, val2: unknown): boolean {
+  if (val1 === val2) return true
+  const is_empty = (val: unknown) =>
+    val === null || val === undefined || (Array.isArray(val) && val.length === 0)
+  if (is_empty(val1) && is_empty(val2)) return true
+  if (Array.isArray(val1) && Array.isArray(val2)) {
+    return val1.length === val2.length && val1.every((item, idx) => item === val2[idx])
+  }
+  return false
+}
+
 // Fuzzy string matching function
 // Returns true if the search string can be found as a subsequence in the target string
 // e.g., "tageoo" matches "tasks/geo-opt" because t-a-g-e-o-o appears in order

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3615,6 +3615,31 @@ describe.each([[1], [2], [null]])(
 // Dynamic options loading tests (https://github.com/janosh/svelte-multiselect/discussions/342)
 describe(`loadOptions feature`, () => {
   const mock_data = Array.from({ length: 100 }, (_, idx) => `Option ${idx + 1}`)
+  type LoadResult = { options: string[]; hasMore: boolean }
+
+  function deferred_load() {
+    const resolvers: Array<(val: LoadResult) => void> = []
+    const rejectors: Array<(err: Error) => void> = []
+    const fn = vi.fn(
+      () =>
+        new Promise<LoadResult>((resolve, reject) => {
+          resolvers.push(resolve)
+          rejectors.push(reject)
+        }),
+    )
+    return { fn, resolvers, rejectors }
+  }
+
+  async function flush_ticks(count = 4) {
+    for (let idx = 0; idx < count; idx++) await tick()
+  }
+
+  function mock_scroll_near_bottom(ul: Element) {
+    vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(500)
+    vi.spyOn(ul, `clientHeight`, `get`).mockReturnValue(200)
+    vi.spyOn(ul, `scrollTop`, `get`).mockReturnValue(250) // 500-250-200=50 < 100 threshold
+    ul.dispatchEvent(new Event(`scroll`))
+  }
 
   test(`loadOptions is called when dropdown opens`, async () => {
     const load_options = vi.fn(() =>
@@ -3689,88 +3714,21 @@ describe(`loadOptions feature`, () => {
   })
 
   test(`loadOptions shows loading indicator while loading`, async () => {
-    let resolve_load: (() => void) | undefined
-    const load_options = vi.fn(
-      () =>
-        new Promise<{ options: string[]; hasMore: boolean }>((resolve) => {
-          resolve_load = () => resolve({ options: [`Test`], hasMore: false })
-        }),
-    )
-
+    const { fn: load_options, resolvers } = deferred_load()
     mount(MultiSelect, {
       target: document.body,
       props: { loadOptions: load_options, open: true },
     })
-    await tick() // Wait for effect to start loading
-
-    // Loading indicator should be visible while loading
-    const loading_li = document.querySelector(`ul.options > li.loading-more`)
-    expect(loading_li).toBeInstanceOf(HTMLLIElement)
-
-    // Resolve the load
-    if (resolve_load) resolve_load()
     await tick()
 
-    // Loading indicator should be gone
+    expect(document.querySelector(`ul.options > li.loading-more`)).toBeInstanceOf(
+      HTMLLIElement,
+    )
+
+    resolvers[0]({ options: [`Test`], hasMore: false })
+    await tick()
+
     expect(document.querySelector(`ul.options > li.loading-more`)).toBeNull()
-  })
-
-  test(`static options work without loadOptions`, async () => {
-    mount(MultiSelect, {
-      target: document.body,
-      props: { options: [`A`, `B`, `C`], open: true },
-    })
-    await tick()
-
-    const options_ul = doc_query(`ul.options`)
-    expect(options_ul.textContent).toContain(`A`)
-    expect(options_ul.textContent).toContain(`B`)
-    expect(options_ul.textContent).toContain(`C`)
-  })
-
-  test(`dropdown renders when loadOptions is provided but not yet loaded`, async () => {
-    const load_options = vi.fn(() =>
-      Promise.resolve({ options: [`Test`], hasMore: false }),
-    )
-    mount(MultiSelect, {
-      target: document.body,
-      props: { loadOptions: load_options, open: true },
-    })
-    await tick()
-
-    // Dropdown should exist even before options are loaded
-    const options_ul = document.querySelector(`ul.options`)
-    expect(options_ul).not.toBeNull()
-  })
-
-  test(`loadOptions handles errors gracefully`, async () => {
-    const console_error = vi.spyOn(console, `error`).mockImplementation(() => {})
-    let reject_fn: ((reason: Error) => void) | undefined
-    const load_options = vi.fn(
-      () =>
-        new Promise<{ options: string[]; hasMore: boolean }>((_, reject) => {
-          reject_fn = reject
-        }),
-    )
-
-    mount(MultiSelect, {
-      target: document.body,
-      props: { loadOptions: load_options, open: true },
-    })
-    await tick()
-
-    // Reject the promise
-    if (reject_fn) reject_fn(new Error(`Network error`))
-    await tick()
-
-    // Error should be logged
-    expect(console_error).toHaveBeenCalledWith(
-      `MultiSelect: loadOptions error:`,
-      expect.any(Error),
-    )
-    // Component should still function (dropdown visible)
-    expect(document.querySelector(`ul.options`)).not.toBeNull()
-    console_error.mockRestore()
   })
 
   test(`scroll triggers pagination when hasMore=true`, async () => {
@@ -3784,19 +3742,14 @@ describe(`loadOptions feature`, () => {
       props: { loadOptions: load_options, open: true },
     })
     await tick()
+    await tick()
 
     expect(load_options).toHaveBeenCalledTimes(1)
 
-    // Simulate scroll event - the handler checks scroll position
     const ul = doc_query(`ul.options`)
-    // Mock the scroll position properties for the scroll handler
-    vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(500)
-    vi.spyOn(ul, `clientHeight`, `get`).mockReturnValue(200)
-    vi.spyOn(ul, `scrollTop`, `get`).mockReturnValue(250) // 500-250-200=50 < 100 threshold
-    ul.dispatchEvent(new Event(`scroll`))
+    mock_scroll_near_bottom(ul)
     await tick()
 
-    // Should have loaded second batch
     expect(load_options).toHaveBeenCalledTimes(2)
     expect(load_options).toHaveBeenLastCalledWith({
       search: ``,
@@ -3815,53 +3768,444 @@ describe(`loadOptions feature`, () => {
       props: { loadOptions: load_options, open: true },
     })
     await tick()
+    await tick()
 
     expect(load_options).toHaveBeenCalledTimes(1)
 
-    // Simulate scroll event
     const ul = doc_query(`ul.options`)
-    vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(500)
-    vi.spyOn(ul, `clientHeight`, `get`).mockReturnValue(200)
-    vi.spyOn(ul, `scrollTop`, `get`).mockReturnValue(250)
-    ul.dispatchEvent(new Event(`scroll`))
+    mock_scroll_near_bottom(ul)
     await tick()
 
-    // Should NOT have loaded again since hasMore=false
     expect(load_options).toHaveBeenCalledTimes(1)
   })
 
-  test(`typing during pending request clears stale results and triggers new load`, async () => {
-    vi.useFakeTimers()
-    type LoadResult = { options: string[]; hasMore: boolean }
-    const resolvers: Array<(val: LoadResult) => void> = []
-    const load_options = vi.fn(
-      () => new Promise<LoadResult>((res) => resolvers.push(res)),
-    )
-
+  // https://github.com/janosh/svelte-multiselect/issues/412
+  test(`auto-fills when small batchSize doesn't overflow dropdown`, async () => {
+    const { fn: load_options, resolvers } = deferred_load()
     mount(MultiSelect, {
       target: document.body,
-      props: { loadOptions: { fetch: load_options, debounceMs: 10 }, open: true },
+      props: { loadOptions: { fetch: load_options, batchSize: 5 }, open: true },
     })
-    await vi.runAllTimersAsync()
-    expect(load_options).toHaveBeenCalledWith({ search: ``, offset: 0, limit: 50 })
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(1)
 
-    // Type while first request pending
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.value = `foo`
-    input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+    // Mock a rendered but non-overflowing list
+    const ul = doc_query(`ul.options`)
+    vi.spyOn(ul, `clientHeight`, `get`).mockReturnValue(400)
+    vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(100)
 
-    // Resolve stale request, verify new request is made for current search
-    resolvers[0]({ options: [`Stale A`, `Stale B`], hasMore: false })
-    await vi.runAllTimersAsync()
+    resolvers[0]({ options: mock_data.slice(0, 5), hasMore: true })
+    await flush_ticks()
     expect(load_options).toHaveBeenCalledTimes(2)
-    expect(load_options).toHaveBeenLastCalledWith({ search: `foo`, offset: 0, limit: 50 })
 
-    // Stale results should be cleared, new results shown after resolve
-    const options_ul = doc_query(`ul.options`)
-    expect(options_ul.textContent).not.toContain(`Stale`)
-    resolvers[1]({ options: [`Foo Result`], hasMore: false })
-    await vi.runAllTimersAsync()
-    expect(options_ul.textContent).toContain(`Foo Result`)
+    resolvers[1]({ options: mock_data.slice(5, 10), hasMore: true })
+    await flush_ticks()
+    expect(load_options).toHaveBeenCalledTimes(3)
+
+    resolvers[2]({ options: mock_data.slice(10, 15), hasMore: false })
+    await flush_ticks()
+    expect(load_options).toHaveBeenCalledTimes(3)
+  })
+
+  test(`auto-fill stops when list becomes scrollable`, async () => {
+    const { fn: load_options, resolvers } = deferred_load()
+    mount(MultiSelect, {
+      target: document.body,
+      props: { loadOptions: { fetch: load_options, batchSize: 5 }, open: true },
+    })
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(1)
+
+    // Mock overflow BEFORE resolving so auto-fill sees the list as scrollable
+    const ul = doc_query(`ul.options`)
+    vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(500)
+    vi.spyOn(ul, `clientHeight`, `get`).mockReturnValue(400)
+
+    resolvers[0]({ options: mock_data.slice(0, 5), hasMore: true })
+    await flush_ticks()
+    expect(load_options).toHaveBeenCalledTimes(1)
+  })
+
+  test(`stale fetch result discarded when search changes during load`, async () => {
+    const { fn: load_options, resolvers } = deferred_load()
+    vi.useFakeTimers()
+    try {
+      mount(MultiSelect, {
+        target: document.body,
+        props: { loadOptions: { fetch: load_options, debounceMs: 10 }, open: true },
+      })
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(1)
+
+      // Type new search while first fetch is pending
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      input.value = `xyz`
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(2)
+      expect(load_options).toHaveBeenLastCalledWith({
+        search: `xyz`,
+        offset: 0,
+        limit: 50,
+      })
+
+      // Resolve the STALE first request after the new one was initiated
+      resolvers[0]({ options: [`Stale Result`], hasMore: false })
+      await vi.runAllTimersAsync()
+
+      const ul = doc_query(`ul.options`)
+      expect(ul.textContent).not.toContain(`Stale Result`)
+
+      // Resolve the current request
+      resolvers[1]({ options: [`Fresh Result`], hasMore: false })
+      await vi.runAllTimersAsync()
+      expect(ul.textContent).toContain(`Fresh Result`)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test(`error stops further pagination`, async () => {
+    const console_error = vi.spyOn(console, `error`).mockImplementation(() => {})
+    const { fn: load_options, resolvers, rejectors } = deferred_load()
+    mount(MultiSelect, {
+      target: document.body,
+      props: { loadOptions: load_options, open: true },
+    })
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(1)
+
+    resolvers[0]({ options: mock_data.slice(0, 50), hasMore: true })
+    await tick()
+
+    const ul = doc_query(`ul.options`)
+    mock_scroll_near_bottom(ul)
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(2)
+
+    rejectors[1](new Error(`Server error`))
+    await tick()
+    expect(console_error).toHaveBeenCalledWith(
+      `MultiSelect: loadOptions error:`,
+      expect.any(Error),
+    )
+
+    mock_scroll_near_bottom(ul)
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(2)
+    console_error.mockRestore()
+  })
+
+  test(`close during fetch clears loading state`, async () => {
+    const { fn: load_options, resolvers } = deferred_load()
+    mount(MultiSelect, {
+      target: document.body,
+      props: { loadOptions: load_options, open: true },
+    })
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(1)
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
+
+    // Close dropdown via Escape while fetch is still pending
+    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
+    await tick()
+
+    // aria-busy should clear immediately on close
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
+
+    // Stale fetch resolves after close — should not corrupt state
+    resolvers[0]({ options: [`Result`], hasMore: false })
+    await tick()
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
+
+    // Reopen — should trigger fresh load, not be stuck
+    doc_query(`div.multiselect`).dispatchEvent(
+      new MouseEvent(`mouseup`, { bubbles: true }),
+    )
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(2)
+  })
+
+  test(`rapid search changes only apply final result`, async () => {
+    const { fn: load_options, resolvers } = deferred_load()
+    vi.useFakeTimers()
+    try {
+      mount(MultiSelect, {
+        target: document.body,
+        props: { loadOptions: { fetch: load_options, debounceMs: 10 }, open: true },
+      })
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(1)
+
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      // Type "a", debounce, then "ab" before first completes
+      input.value = `a`
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(2)
+
+      input.value = `ab`
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(3)
+
+      // Resolve all three in reverse order (worst-case network jitter)
+      resolvers[2]({ options: [`AB Result`], hasMore: false })
+      resolvers[1]({ options: [`A Result`], hasMore: false })
+      resolvers[0]({ options: [`Initial`], hasMore: false })
+      await vi.runAllTimersAsync()
+
+      const ul = doc_query(`ul.options`)
+      expect(ul.textContent).toContain(`AB Result`)
+      expect(ul.textContent).not.toContain(`A Result`)
+      expect(ul.textContent).not.toContain(`Initial`)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test(`scroll after auto-fill cap resets counter and allows more loading`, async () => {
+    const { fn: load_options, resolvers } = deferred_load()
+    mount(MultiSelect, {
+      target: document.body,
+      props: { loadOptions: { fetch: load_options, batchSize: 5 }, open: true },
+    })
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(1)
+
+    const ul = doc_query(`ul.options`)
+    vi.spyOn(ul, `clientHeight`, `get`).mockReturnValue(400)
+    vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(100)
+
+    // Resolve batches until auto-fill cap is reached (20 rounds + 1 initial)
+    for (let idx = 0; idx < 20; idx++) {
+      resolvers[idx]({ options: [`Item ${idx}`], hasMore: true })
+      await flush_ticks()
+    }
+    const capped_count = load_options.mock.calls.length
+    // Auto-fill should have stopped at the cap
+    resolvers[capped_count - 1]({ options: [`Capped`], hasMore: true })
+    await flush_ticks()
+    expect(load_options).toHaveBeenCalledTimes(capped_count)
+
+    // Simulate user scroll — should reset counter and allow more loading
+    vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(500)
+    vi.spyOn(ul, `scrollTop`, `get`).mockReturnValue(250)
+    ul.dispatchEvent(new Event(`scroll`))
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(capped_count + 1)
+
+    // After scroll-triggered load resolves, auto-fill should resume
+    // (list still doesn't overflow) — this verifies counter was actually reset
+    vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(100)
+    resolvers[capped_count]({ options: [`Post-scroll`], hasMore: true })
+    await flush_ticks()
+    expect(load_options).toHaveBeenCalledTimes(capped_count + 2)
+  })
+
+  test(`error clears pending state via has_more`, async () => {
+    const console_error = vi.spyOn(console, `error`).mockImplementation(() => {})
+    const { fn: load_options, resolvers, rejectors } = deferred_load()
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        loadOptions: load_options,
+        noMatchingOptionsMsg: `No matches`,
+        open: true,
+      },
+    })
+    await tick()
+
+    // First load succeeds
+    resolvers[0]({ options: [`Apple`], hasMore: true })
+    await tick()
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
+
+    const ul = doc_query(`ul.options`)
+    mock_scroll_near_bottom(ul)
+    await tick()
+    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
+
+    // Fetch fails
+    rejectors[1](new Error(`Server error`))
+    await tick()
+
+    // After error: aria-busy should clear (has_more=false clears pending)
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
+    console_error.mockRestore()
+  })
+
+  test(`reopen before stale fetch resolves triggers fresh load`, async () => {
+    const { fn: load_options, resolvers } = deferred_load()
+    mount(MultiSelect, {
+      target: document.body,
+      props: { loadOptions: load_options, open: true },
+    })
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(1)
+
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+
+    // Close while first fetch is still pending (NOT resolved)
+    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
+    await tick()
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
+
+    // Reopen BEFORE old fetch resolves — this is the critical timing
+    doc_query(`div.multiselect`).dispatchEvent(
+      new MouseEvent(`mouseup`, { bubbles: true }),
+    )
+    await tick()
+    expect(load_options).toHaveBeenCalledTimes(2)
+    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
+
+    // Old fetch resolves late — must be discarded, not corrupt new session
+    resolvers[0]({ options: [`Stale`], hasMore: false })
+    await tick()
+    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
+    expect(doc_query(`ul.options`).textContent).not.toContain(`Stale`)
+
+    // New fetch resolves — applied normally
+    resolvers[1]({ options: [`Fresh`], hasMore: false })
+    await tick()
+    expect(doc_query(`ul.options`).textContent).toContain(`Fresh`)
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
+  })
+
+  test(`stale error does not affect current request state`, async () => {
+    const console_error = vi.spyOn(console, `error`).mockImplementation(() => {})
+    const { fn: load_options, resolvers, rejectors } = deferred_load()
+    vi.useFakeTimers()
+    try {
+      mount(MultiSelect, {
+        target: document.body,
+        props: { loadOptions: { fetch: load_options, debounceMs: 10 }, open: true },
+      })
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(1)
+
+      // Type to trigger a new search while first fetch is pending
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      input.value = `test`
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(2)
+
+      // New fetch succeeds FIRST with hasMore=true
+      resolvers[1]({ options: [`Result A`], hasMore: true })
+      await vi.runAllTimersAsync()
+
+      const ul = doc_query(`ul.options`)
+      expect(ul.textContent).toContain(`Result A`)
+
+      // Old (stale) fetch ERRORS AFTER success — must not corrupt hasMore
+      rejectors[0](new Error(`Stale network error`))
+      await vi.runAllTimersAsync()
+
+      // Scroll should trigger pagination (hasMore was NOT corrupted by stale error)
+      mock_scroll_near_bottom(ul)
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+      console_error.mockRestore()
+    }
+  })
+
+  test(`failed initial load retries on close+reopen`, async () => {
+    const console_error = vi.spyOn(console, `error`).mockImplementation(() => {})
+    const { fn: load_options, resolvers, rejectors } = deferred_load()
+    vi.useFakeTimers()
+    try {
+      // Use onOpen=false so retry requires typing, exposing has_more via pending
+      mount(MultiSelect, {
+        target: document.body,
+        props: {
+          loadOptions: { fetch: load_options, onOpen: false, debounceMs: 10 },
+          open: true,
+        },
+      })
+
+      // Type to trigger initial load (onOpen=false requires user input)
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      input.value = `q`
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(1)
+
+      rejectors[0](new Error(`Server down`))
+      await vi.runAllTimersAsync()
+
+      // Close and reopen
+      input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
+      await vi.runAllTimersAsync()
+      doc_query(`div.multiselect`).dispatchEvent(
+        new MouseEvent(`mouseup`, { bubbles: true }),
+      )
+      await vi.runAllTimersAsync()
+
+      // Type to trigger load again (onOpen=false)
+      input.value = `q`
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      // During debounce: aria-busy must be true (has_more was reset on close)
+      await tick()
+      expect(input.getAttribute(`aria-busy`)).toBe(`true`)
+
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(2)
+
+      resolvers[1]({ options: [`Recovered`], hasMore: false })
+      await vi.runAllTimersAsync()
+      expect(doc_query(`ul.options`).textContent).toContain(`Recovered`)
+      expect(input.getAttribute(`aria-busy`)).toBeNull()
+    } finally {
+      vi.useRealTimers()
+      console_error.mockRestore()
+    }
+  })
+
+  test(`failed search retryable via input change`, async () => {
+    const console_error = vi.spyOn(console, `error`).mockImplementation(() => {})
+    const { fn: load_options, resolvers, rejectors } = deferred_load()
+    vi.useFakeTimers()
+    try {
+      mount(MultiSelect, {
+        target: document.body,
+        props: { loadOptions: { fetch: load_options, debounceMs: 0 }, open: true },
+      })
+      await vi.runAllTimersAsync()
+      // Initial load succeeds
+      resolvers[0]({ options: [`Apple`], hasMore: false })
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(1)
+
+      // Search "x" triggers load, which fails
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      input.value = `x`
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await vi.runAllTimersAsync()
+      expect(load_options).toHaveBeenCalledTimes(2)
+      rejectors[1](new Error(`fail`))
+      await vi.runAllTimersAsync()
+
+      // Clear and retype same search — should trigger a new load for "x"
+      // because last_search was NOT updated on failure (still "")
+      input.value = ``
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await vi.runAllTimersAsync()
+      input.value = `x`
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await vi.runAllTimersAsync()
+
+      expect(load_options).toHaveBeenLastCalledWith({ search: `x`, offset: 0, limit: 50 })
+    } finally {
+      vi.useRealTimers()
+      console_error.mockRestore()
+    }
   })
 })
 
@@ -6841,11 +7185,7 @@ describe(`duplicates prop variants`, () => {
   test(`dropdown options with same label but different values remain selectable`, async () => {
     // Issue: label check was blocking dropdown options even when values differ
     // The is_from_options check should skip label-based duplicate detection for dropdown items
-    const options = [
-      { label: `apple`, value: 1 },
-      { label: `apple`, value: 2 },
-      { label: `apple`, value: 3 },
-    ]
+    const options = [1, 2, 3].map((value) => ({ label: `apple`, value }))
 
     const onadd_spy = vi.fn()
     const onduplicate_spy = vi.fn()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -99,4 +99,9 @@ export default defineConfig({
   preview: {
     port: 3000,
   },
+
+  build: {
+    // Default cssTarget is chrome111 which doesn't support light-dark(),
+    cssTarget: `esnext`, // causing LightningCSS to polyfill it with broken space toggles
+  },
 })


### PR DESCRIPTION
Closes #412

- **Auto-fill when dropdown doesn't overflow**: after each batch load, checks if the list overflows. If not and `hasMore` is true, automatically fetches the next batch until scrollable or all loaded. Capped at 20 rounds, reset on user scroll.
- **Stale fetch race fix**: replaced close-only session counter with monotonic request ID covering search changes. `reset=true` loads bypass the loading mutex so new searches start immediately while stale results are discarded.
- **Error handling**: `hasMore=false` on fetch error stops retrying. `last_search` only set on success so failed searches can be retried via close+reopen or input change.
- **Pending/aria-busy fix**: `load_options_pending` now checks `hasMore` so errors clear `aria-busy`.
- **Close cleanup**: resets `load_options_loading` when dropdown closes to prevent stuck loading state.
- **Readability**: moved pure helpers (`parse_shortcut`, `matches_shortcut`, `values_equal`) to `utils.ts`, added section headers, deduplicated render fallback chain with local snippet, consolidated option-row `{@const}` blocks into `get_option_view` helper.