### PR TITLE
Improve accessibility and package smoke coverage

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - run: npm install
       - run: npx vp build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - run: npm install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,15 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - run: npm install
 
       - name: Unit tests
         run: npx vp test --run
+
+      - name: Package smoke test
+        run: npm run test:package
 
       - name: Install Playwright
         run: npx playwright install chromium

--- a/contributing.md
+++ b/contributing.md
@@ -38,7 +38,7 @@ Any new features should come with corresponding tests. If you fix a bug, please 
 This repo has 3 required CI checks that have to pass for every PR before merging:
 
 - tests: run as [GitHub Action](https://github.com/janosh/svelte-multiselect/actions/workflows/test.yml) ([workflow code](https://github.com/janosh/svelte-multiselect/blob/main/.github/workflows/test.yml))
-- linting: handled by [prek](https://github.com/j178/prek) pre-commit hooks
+- linting: handled by `vp lint`
 - docs: [continuous deployment](https://github.com/janosh/svelte-multiselect/blob/main/.github/workflows/gh-pages.yml) through GitHub Pages
 
 ## 🆕 New release
@@ -53,12 +53,6 @@ Now run the `changelog` script from `package.json` to update `changelog.md`.
 
 ```sh
 npm run changelog
-```
-
-If there have been significant code changes since the last release, it's good to update the coverage badges in the readme.
-
-```sh
-npm run update-coverage
 ```
 
 Then commit `package.json`, `changelog.md` and `readme.md` files to the `main` branch using the new version number prefixed by `'v'` as commit message and tag:

--- a/package.json
+++ b/package.json
@@ -52,35 +52,30 @@
     "access": "public"
   },
   "scripts": {
-    "dev": "vp dev",
-    "build": "vp build",
-    "preview": "vp preview",
     "test": "vp test --run && playwright test",
-    "check": "vp check",
-    "lint": "vp lint",
-    "fmt": "vp fmt --write",
-    "package": "svelte-package && find dist -name '*.js' -o -name '*.d.ts' | xargs sed -i '' -E \"s/(\\.\\.?\\/[^'\\\"]*)\\.ts(['\\\"])/\\1.js\\2/g\"",
+    "test:package": "npm run package && npm pack --dry-run && vp build --config tests/package-smoke/vite.config.ts",
+    "package": "svelte-package && find dist \\( -name '*.js' -o -name '*.d.ts' \\) -type f -exec perl -pi -e \"s/(\\.\\.?\\/[^'\\\"]*)\\.ts(['\\\"])/\\1.js\\2/g\" {} +",
     "prepublishOnly": "npm run package",
     "changelog": "npx tsx https://github.com/janosh/workflows/raw/refs/heads/main/scripts/make-release-notes.ts"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.59.1",
+    "@sveltejs/kit": "^2.60.1",
     "@sveltejs/package": "2.5.7",
-    "@sveltejs/vite-plugin-svelte": "^7.1.1",
-    "@types/node": "^25.6.0",
-    "@vitest/coverage-v8": "^4.1.5",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@types/node": "^25.8.0",
+    "@vitest/coverage-v8": "4.1.5",
     "@wooorm/starry-night": "^3.9.0",
     "acorn": "^8.16.0",
     "happy-dom": "^20.9.0",
     "mdsvex": "^0.12.7",
-    "svelte": "^5.55.5",
+    "svelte": "^5.55.7",
     "svelte-toc": "^0.6.3",
     "typescript": "6.0.3",
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.20",
-    "vite-plus": "latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.20"
+    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.21",
+    "vite-plus": "0.1.21",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.21"
   },
   "peerDependencies": {
     "@wooorm/starry-night": "^3.0.0",
@@ -97,7 +92,7 @@
   },
   "overrides": {
     "svelte": "$svelte",
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.20",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.20"
+    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.21",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.21"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -107,10 +107,10 @@ Complete reference of all props. Props are organized by importance - **Essential
 These are the core props you'll use in most cases:
 
 1. ```ts
-   options: Option[]  // REQUIRED
+   options?: Option[]  // required unless loadOptions is provided
    ```
 
-   **The only required prop.** Array of strings, numbers, or objects that users can select from. Objects must have a `label` property that will be displayed in the dropdown.
+   Array of strings, numbers, or objects that users can select from. Objects must have a `label` property that will be displayed in the dropdown. Omit this when using `loadOptions` as the source of dynamic options.
 
    ```svelte
    <!-- Simple options -->
@@ -455,7 +455,13 @@ See the [grouping demo](https://janosh.github.io/svelte-multiselect/grouping) fo
    name: string | null = null
    ```
 
-   Form field name for form submission.
+   Form field name for form submission. When selected options are displayed as chips (the default display mode), they submit as `JSON.stringify(selected)`. Prefer stable object `value` fields for server processing, or customize serialization with `formSerialize`.
+
+1. ```ts
+   formSerialize: (selected: Option[]) => string | null = JSON.stringify
+   ```
+
+   Customizes the submitted value in chip mode. For object options, use `formSerialize={(selected) => selected.map(({ value }) => value).join(',')}`. For primitive options, use `formSerialize={(selected) => selected.join(',')}`.
 
 1. ```ts
    autocomplete: string = 'off'
@@ -984,6 +990,7 @@ import {
   LoadOptionsFn,
   LoadOptionsParams,
   LoadOptionsResult,
+  FormSerialize, // Type signature for custom form serialization
   MultiSelectEvents,
   MultiSelectSnippets,
   ObjectOption,

--- a/src/lib/CmdPalette.svelte
+++ b/src/lib/CmdPalette.svelte
@@ -16,6 +16,7 @@
     open = $bindable(false),
     dialog = $bindable(null),
     input = $bindable(null),
+    aria_label = `Command palette`,
     placeholder = `Filter actions...`,
     dialog_props,
     ...rest
@@ -28,9 +29,20 @@
     open?: boolean
     dialog?: HTMLDialogElement | null
     input?: HTMLInputElement | null
+    aria_label?: string
     placeholder?: string
     dialog_props?: HTMLAttributes<HTMLDialogElement>
   } = $props()
+
+  $effect(() => {
+    if (!dialog || !open || dialog.open) return
+    try {
+      if (typeof dialog.showModal === `function`) dialog.showModal()
+      else dialog.setAttribute(`open`, ``)
+    } catch {
+      dialog.setAttribute(`open`, ``)
+    }
+  })
 
   $effect(() => {
     if (open && input && document.activeElement !== input) input.focus()
@@ -62,10 +74,11 @@
 
 {#if open}
   <dialog
-    open
     bind:this={dialog}
     transition:fade={{ duration: fade_duration }}
     style={dialog_style}
+    aria-label={aria_label}
+    onclose={() => (open = false)}
     {...dialog_props}
   >
     <MultiSelect

--- a/src/lib/FileDetails.svelte
+++ b/src/lib/FileDetails.svelte
@@ -66,7 +66,7 @@
 
   // Infer language from title (may contain HTML like <code>foo.ts</code>)
   function lang_from_title(title: string): string | undefined {
-    const ext = title.replaceAll(/<[^>]*>/g, ``).match(/\.(\w+)$/)?.[1]?.toLowerCase()
+    const ext = title.replaceAll(/<[^>]*>/gu, ``).match(/\.(\w+)$/u)?.[1]?.toLowerCase()
     return ext ? ext_to_lang[ext] ?? ext : undefined
   }
 

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -39,6 +39,7 @@
     fuzzy = true,
     closeDropdownOnSelect = false,
     form_input = $bindable(null),
+    formSerialize: form_serialize = (selected) => JSON.stringify(selected),
     highlightMatches = true,
     id = null,
     input = $bindable(null),
@@ -179,7 +180,7 @@
 
   // Platform detection for keyboard shortcuts (Mac uses Cmd, others use Ctrl)
   const is_mac = typeof navigator !== `undefined` &&
-    /Mac|iPhone|iPad|iPod/.test(navigator.userAgent)
+    /Mac|iPhone|iPad|iPod/u.test(navigator.userAgent)
   const mod_key = is_mac ? `meta` : `ctrl`
 
   // Default shortcuts
@@ -397,7 +398,7 @@
   )
   let form_value = $derived.by(() => {
     if (input_display) return has_search_text ? searchText : null
-    return selected.length >= Number(required) ? JSON.stringify(selected) : null
+    return selected.length >= Number(required) ? form_serialize(selected) : null
   })
   let prev_input_committed_label: string | null = null
   // Keep searchText in sync with committed selections, including external value changes.
@@ -423,13 +424,13 @@
         && (load_options_last_search ?? ``) !== effective_filter_text)),
   )
   // Sets for O(1) lookups (used in template, has_user_msg, group_header_state, batch operations)
-  let selected_keys_set = $derived(new Set(selected_keys))
+  let selected_keys_set = $derived(new SvelteSet(selected_keys))
   // String-normalized for consistent comparison (numeric labels like 123 match "123")
-  let selected_labels_set = $derived(new Set(selected_labels.map((label) => `${label}`)))
+  let selected_labels_set = $derived(new SvelteSet(selected_labels.map((label) => `${label}`)))
   // Lowercase labels set for case-insensitive duplicate detection
   let selected_labels_lower_set = $derived(
     duplicates === `case-insensitive`
-      ? new Set(selected_labels.map((label) => `${label}`.toLowerCase()))
+      ? new SvelteSet(selected_labels.map((label) => `${label}`.toLowerCase()))
       : null,
   )
   // Helper to check if a label is already selected (respects case-insensitive mode)
@@ -440,7 +441,7 @@
 
   // Memoized Set of disabled option keys for O(1) lookups in large option sets
   let disabled_option_keys = $derived(
-    new Set(
+    new SvelteSet(
       effective_options
         .filter((opt) => utils.is_object(opt) && opt.disabled)
         .map(key),
@@ -450,9 +451,22 @@
   // Check if an option is disabled (uses memoized Set for O(1) lookup)
   const is_disabled = (opt: Option) => disabled_option_keys.has(key(opt))
 
+  // Check if option index is within maxOptions visibility limit
+  const is_option_visible = (idx: number) =>
+    idx >= 0 && (maxOptions === null || maxOptions === undefined || idx < maxOptions)
+
+  // Get non-disabled, selectable options from a list
+  // For collapsed groups: returns all non-disabled options (user explicitly wants this group)
+  // For expanded groups/top-level: respects maxOptions rendering limit
+  function get_selectable_opts(opts: Option[], skip_visibility_check = false) {
+    return opts.filter((opt) => {
+      if (is_disabled(opt)) return false
+      if (skip_visibility_check) return true
+      return is_option_visible(navigable_index_map.get(opt) ?? -1)
+    })
+  }
+
   // Group matching options by their `group` key
-  // Note: SvelteMap used here to satisfy eslint svelte/prefer-svelte-reactivity rule,
-  // though a plain Map would work since this is recreated fresh on each derivation
   let grouped_options = $derived.by((): GroupedOptions<Option>[] => {
     const groups_map = new SvelteMap<string, Option[]>()
     const ungrouped: Option[] = []
@@ -473,7 +487,6 @@
       collapsed: collapsedGroups.has(group),
     }))
 
-    // Apply group sorting if specified
     if (groupSortOrder && groupSortOrder !== `none`) {
       grouped = grouped.toSorted((group_a, group_b) => {
         if (typeof groupSortOrder === `function`) {
@@ -505,7 +518,7 @@
 
   // Pre-computed Map for O(1) index lookups (avoids O(n²) in template)
   let navigable_index_map = $derived(
-    new Map(navigable_options.map((opt, idx) => [opt, idx])),
+    new SvelteMap(navigable_options.map((opt, idx) => [opt, idx])),
   )
 
   // Pre-computed group header state (avoids repeated calculations in template)
@@ -517,7 +530,6 @@
       const selectable = get_selectable_opts(opts, collapsed)
       const all_selected = selectable.length > 0 &&
         selectable.every((opt) => selected_keys_set.has(key(opt)))
-      // Count selected options (only needed when keepSelectedInDropdown is enabled)
       let selected_count = 0
       if (keepSelectedInDropdown) {
         for (const opt of opts) {
@@ -724,14 +736,12 @@
     activeOption = navigable_options[activeIndex ?? -1] ?? null
   })
 
-  // Compute the ID of the currently active element for aria-activedescendant
-  // (highlighted selected pill takes priority, then active dropdown option)
+  // Compute the ID of the currently active dropdown option for aria-activedescendant.
+  // Selected chips are plain list items, so left/right chip highlighting stays visual.
   const active_option_id = $derived(
-    highlighted_idx === null || input_display
-      ? activeIndex !== null && activeIndex < navigable_options.length
-        ? `${internal_id}-opt-${activeIndex}`
-        : undefined
-      : `${internal_id}-selected-${highlighted_idx}`,
+    activeIndex !== null && activeIndex < navigable_options.length
+      ? `${internal_id}-opt-${activeIndex}`
+      : undefined,
   )
 
   // Helper to check if removing an option would violate minSelect constraint
@@ -1159,20 +1169,6 @@
     }
   }
 
-  // Check if option index is within maxOptions visibility limit
-  const is_option_visible = (idx: number) =>
-    idx >= 0 && (maxOptions === null || maxOptions === undefined || idx < maxOptions)
-
-  // Get non-disabled, selectable options from a list
-  // For collapsed groups: returns all non-disabled options (user explicitly wants this group)
-  // For expanded groups/top-level: respects maxOptions rendering limit
-  const get_selectable_opts = (opts: Option[], skip_visibility_check = false) =>
-    opts.filter((opt) => {
-      if (is_disabled(opt)) return false
-      if (skip_visibility_check) return true
-      return is_option_visible(navigable_index_map.get(opt) ?? -1)
-    })
-
   // Batch-add options to selection with all side effects (used by select_all and group select)
   function batch_add_options(options_to_add: Option[], event: Event) {
     const remaining = Math.max(0, (maxSelect ?? Infinity) - selected.length)
@@ -1574,6 +1570,7 @@
   bind:innerWidth={window_width}
 />
 
+<!-- svelte-ignore a11y_no_static_element_interactions -- the nested combobox input owns the interactive ARIA semantics -->
 <div
   bind:this={outerDiv}
   class:disabled
@@ -1585,7 +1582,6 @@
   onmouseup={open_dropdown}
   title={disabled ? disabledInputTitle : null}
   data-id={id}
-  role="searchbox"
   tabindex="-1"
   {style}
 >
@@ -1597,7 +1593,6 @@
     value={form_value}
     tabindex="-1"
     aria-hidden="true"
-    aria-label="ignore this, used only to prevent form submission if select is required but empty"
     class="form-control"
     bind:this={form_input}
     oninvalid={() => {
@@ -1633,12 +1628,11 @@
         {@const selectedOptionStyle = [utils.get_style(option, `selected`), liSelectedStyle]
         .filter(Boolean)
         .join(` `) || null}
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -- selected chips stay plain list items; nested buttons handle removal -->
         <li
           id="{internal_id}-selected-{idx}"
           class={liSelectedClass}
           class:highlighted={highlighted_idx === idx}
-          role="option"
-          aria-selected="true"
           animate:flip={selectedFlipParams}
           draggable={selectedOptionsDraggable && !disabled && selected.length > 1}
           ondragstart={dragstart(idx)}
@@ -2196,7 +2190,7 @@
     /* Default z-index if not portaled/overridden by portal */
     z-index: var(--sms-options-z-index, 3);
     overflow: auto;
-    transition: all 0.2s; /* is this transition is desirable with portal positioning? */
+    transition: opacity 0.2s, transform 0.2s, visibility 0.2s;
     box-sizing: border-box;
     background: var(--sms-options-bg, light-dark(#fcfcfc, #222226));
     max-height: var(--sms-options-max-height, 50vh);

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -112,7 +112,7 @@
       setTimeout(() => {
         document
           .querySelector<HTMLElement>(
-            `.dropdown[data-href="${CSS.escape(href)}"] [role="menuitem"]`,
+            `.dropdown[data-href="${CSS.escape(href)}"] [data-submenu] a`,
           )
           ?.focus()
       }, 0)
@@ -163,7 +163,7 @@
       )
       document
         .querySelectorAll<HTMLElement>(
-          `.dropdown[data-href="${CSS.escape(href)}"] [role="menuitem"]`,
+          `.dropdown[data-href="${CSS.escape(href)}"] [data-submenu] a`,
         )
         ?.[focused_item_index]?.focus()
     }
@@ -181,7 +181,7 @@
       close_menus()
       document
         .querySelector<HTMLButtonElement>(
-          `.dropdown[data-href="${href}"] [data-dropdown-toggle]`,
+          `.dropdown[data-href="${CSS.escape(href)}"] [data-dropdown-toggle]`,
         )
         ?.focus()
     }
@@ -207,7 +207,7 @@
     if (custom_label) return { label: custom_label, style: `` }
 
     if (remove_parent) text = text.split(`/`).findLast(Boolean) ?? text
-    let label = text.replace(/^\//, ``).replaceAll(`-`, ` `)
+    let label = text.replace(/^\//u, ``).replaceAll(`-`, ` `)
     // Handle root path '/' which becomes empty after stripping
     if (!label && text === `/`) label = `Home`
     return { label, style: label ? `text-transform: capitalize` : `` }
@@ -320,8 +320,6 @@
     id={panel_id}
     class="menu"
     class:open={is_open}
-    tabindex="0"
-    role="menu"
     {onkeydown}
     {...menu_props}
   >
@@ -356,13 +354,12 @@
       )}
         {@const is_pinned = pinned_dropdown === parsed_route.href}
         {@const dropdown_open = hovered_dropdown === parsed_route.href || is_pinned}
+        <!-- svelte-ignore a11y_no_static_element_interactions -- native navigation links keep semantics; mouse handlers only control hover disclosure -->
         <div
           class="dropdown"
           class:active={child_is_active}
           class:align-right={is_right}
           data-href={parsed_route.href}
-          role="group"
-          aria-current={child_is_active ? `true` : undefined}
           onmouseenter={() => open_dropdown(parsed_route.href, true)}
           onmouseleave={() => schedule_hide(parsed_route.href, is_pinned)}
           onfocusin={() => open_dropdown(parsed_route.href)}
@@ -419,9 +416,10 @@
               <Icon icon="ChevronDown" style="width: 0.7em; height: 0.7em" />
             </button>
           </div>
+          <!-- svelte-ignore a11y_no_static_element_interactions -- hover keeps the native-link submenu open while traversing it -->
           <div
             class:visible={dropdown_open}
-            role="menu"
+            data-submenu
             tabindex="-1"
             onmouseenter={() => open_dropdown(parsed_route.href, true)}
             onmouseleave={(event: MouseEvent) => {
@@ -444,7 +442,6 @@
               {:else}
                 <a
                   href={child_href}
-                  role="menuitem"
                   aria-current={is_current(child_href)}
                   onclick={(event: MouseEvent) =>
                   handle_link_click(event, { href: child_href })}
@@ -685,7 +682,7 @@
     height: 0.18rem;
     background-color: var(--text);
     border-radius: 8pt;
-    transition: all 0.2s linear;
+    transition: opacity 0.2s linear, transform 0.2s linear;
     transform-origin: center;
   }
   .burger[aria-expanded='true'] span:first-child {
@@ -710,7 +707,7 @@
     box-shadow: var(--nav-surface-shadow);
     opacity: 0;
     visibility: hidden;
-    transition: all 0.3s ease;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
     z-index: var(--nav-mobile-z-index, 2);
     flex-direction: column;
     align-items: stretch;

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -340,7 +340,7 @@ export const sortable =
         }
         header.classList.add(sort_dir > 0 ? asc_class : desc_class)
         Object.assign(header.style, sorted_style)
-        header.textContent = `${header.textContent?.replace(/ ↑| ↓/, ``)} ${
+        header.textContent = `${header.textContent?.replace(/ ↑| ↓/u, ``)} ${
           sort_dir > 0 ? `↑` : `↓`
         }`
 
@@ -492,7 +492,7 @@ export const highlight_matches = (ops: HighlightOptions) => (node: HTMLElement) 
 }
 
 // Global tooltip state to ensure only one tooltip is shown at a time
-let current_tooltip: (HTMLElement & { _owner?: HTMLElement }) | null = null
+let current_tooltip: (HTMLElement & { owner_element?: HTMLElement }) | null = null
 let show_timeout: ReturnType<typeof setTimeout> | undefined
 let hide_timeout: ReturnType<typeof setTimeout> | undefined
 
@@ -501,7 +501,7 @@ function clear_tooltip() {
   if (hide_timeout) clearTimeout(hide_timeout)
   if (current_tooltip) {
     // Remove aria-describedby from the trigger element
-    current_tooltip._owner?.removeAttribute(`aria-describedby`)
+    current_tooltip.owner_element?.removeAttribute(`aria-describedby`)
     current_tooltip.remove()
     current_tooltip = null
   }
@@ -517,9 +517,7 @@ export interface TooltipOptions {
   style?: string
   show_arrow?: boolean // Whether to show the arrow pointer (default: true)
   offset?: number // Distance from trigger element in pixels (default: 12)
-  // Security: When true (default), content is rendered as HTML. If allowing user-provided
-  // content via `title`, `aria-label`, or `data-title` attributes, you MUST sanitize to
-  // prevent XSS. Set to false to render content as plain text.
+  // Security: HTML rendering is opt-in. Set to true only for trusted or sanitized content.
   allow_html?: boolean
   // Optional sanitizer for HTML content - called before setting innerHTML when allow_html is true
   sanitize_html?: (html: string) => string
@@ -530,7 +528,7 @@ function render_tooltip_content(
   content: string,
   options: TooltipOptions,
 ) {
-  if (options.allow_html === false) {
+  if (options.allow_html !== true) {
     content_el.textContent = content
     return
   }
@@ -606,7 +604,7 @@ export const tooltip =
           if (!new_content) continue
           content = new_content
           // Only update tooltip if this element owns it
-          if (current_tooltip?._owner === element) {
+          if (current_tooltip?.owner_element === element) {
             const content_el =
               current_tooltip.querySelector<HTMLElement>(`.tooltip-content`)
             if (content_el) {
@@ -670,7 +668,7 @@ export const tooltip =
         const is_transparent =
           !border_color ||
           border_color === `transparent` ||
-          /rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*0\s*\)/.test(border_color)
+          /rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*0\s*\)/u.test(border_color)
         const has_border = !is_transparent && border_width_num > 0
         if (!has_border) {
           border_arrow.remove()
@@ -880,7 +878,7 @@ export const tooltip =
           // Wrap content in a span for reactive content updates
           const content_span = document.createElement(`span`)
           content_span.className = `tooltip-content`
-          // Security: allow_html defaults to true; set to false for plain text rendering
+          // Security: content renders as plain text unless allow_html is explicitly true.
           render_tooltip_content(content_span, content ?? ``, options)
           tooltip_el.append(content_span)
 
@@ -917,12 +915,14 @@ export const tooltip =
 
           resize_and_position_tooltip(tooltip_el, element)
 
-          current_tooltip = Object.assign(tooltip_el, { _owner: element })
+          current_tooltip = Object.assign(tooltip_el, { owner_element: element })
         }, options.delay ?? 100)
       }
 
       function handle_keydown(event: KeyboardEvent) {
-        if (event.key === `Escape` && current_tooltip?._owner === element) clear_tooltip()
+        if (event.key === `Escape` && current_tooltip?.owner_element === element) {
+          clear_tooltip()
+        }
       }
 
       function hide_tooltip() {
@@ -960,7 +960,7 @@ export const tooltip =
               node === element || (node instanceof Element && node.contains(element)),
           ),
         )
-        if (was_removed && current_tooltip?._owner === element) clear_tooltip()
+        if (was_removed && current_tooltip?.owner_element === element) clear_tooltip()
       })
       if (element.parentElement) {
         removal_observer.observe(element.parentElement, {
@@ -977,7 +977,7 @@ export const tooltip =
         document.removeEventListener(`keydown`, handle_keydown)
 
         // Clear tooltip if this element owns it (also removes aria-describedby)
-        if (current_tooltip?._owner === element) clear_tooltip()
+        if (current_tooltip?.owner_element === element) clear_tooltip()
 
         if (element.hasAttribute(`data-original-title`)) {
           element.setAttribute(`title`, element.getAttribute(`data-original-title`) ?? ``)

--- a/src/lib/heading-anchors.ts
+++ b/src/lib/heading-anchors.ts
@@ -7,8 +7,8 @@
 // Avoid matching inside src={...} attributes by requiring these specific contexts
 // Note: [^>]* for attributes won't match if an attribute value contains > (e.g., data-foo="a>b")
 // This edge case is rare in practice and would require significantly more complex parsing
-const heading_regex_line_start = /^(\s*)<(h[1-6])([^>]*)>([\s\S]*?)<\/\2>/gim
-const heading_regex_after_tag = /(>)(\s*)<(h[1-6])([^>]*)>([\s\S]*?)<\/\3>/gi
+const heading_regex_line_start = /^(\s*)<(h[1-6])([^>]*)>([\s\S]*?)<\/\2>/gimu
+const heading_regex_after_tag = /(>)(\s*)<(h[1-6])([^>]*)>([\s\S]*?)<\/\3>/giu
 
 // Remove Svelte expressions handling nested braces (e.g., {fn({a: 1})})
 // Treats unmatched } as literal text to avoid dropping content
@@ -27,10 +27,10 @@ function strip_svelte_expressions(str: string): string {
 const slugify = (text: string): string =>
   text
     .toLowerCase()
-    .replaceAll(/\s+/g, `-`)
-    .replaceAll(/[^\w-]/g, ``)
-    .replaceAll(/-+/g, `-`) // collapse multiple dashes
-    .replaceAll(/^-|-$/g, ``) // trim leading/trailing dashes
+    .replaceAll(/\s+/gu, `-`)
+    .replaceAll(/[^\w-]/gu, ``)
+    .replaceAll(/-+/gu, `-`) // collapse multiple dashes
+    .replaceAll(/^-|-$/gu, ``) // trim leading/trailing dashes
 
 /** @type {() => import('svelte/compiler').PreprocessorGroup} */
 export function heading_ids() {
@@ -42,9 +42,9 @@ export function heading_ids() {
 
       const process_heading = (attrs: string, inner: string): string | null => {
         // Skip if already has an id (use ^|\s to avoid matching data-id, aria-id, etc.)
-        if (/(^|\s)id\s*=/.test(attrs)) return null
+        if (/(^|\s)id\s*=/u.test(attrs)) return null
 
-        const text = strip_svelte_expressions(inner.replaceAll(/<[^>]+>/g, ``)).trim()
+        const text = strip_svelte_expressions(inner.replaceAll(/<[^>]+>/gu, ``)).trim()
         if (!text) return null
 
         const base_id = slugify(text)
@@ -112,7 +112,7 @@ function add_anchor_to_heading(heading: Element, icon_svg: string = link_svg): v
   heading.append(anchor)
 }
 
-const is_heading = (element: Element): boolean => /^H[1-6]$/.test(element.tagName)
+const is_heading = (element: Element): boolean => /^H[1-6]$/u.test(element.tagName)
 
 const get_default_headings = (node: Element): Element[] => {
   const headings: Element[] = []

--- a/src/lib/live-examples/mdsvex-transform.ts
+++ b/src/lib/live-examples/mdsvex-transform.ts
@@ -14,13 +14,13 @@ const encode_escapes = (src: string) =>
 // Note: These patterns handle common cases but may have edge cases with nested
 // comments containing </script> strings or complex attribute syntax
 const RE_SCRIPT_START =
-  /<script(?:\s+?[a-zA-Z]+(=(?:["']){0,1}[a-zA-Z0-9]+(?:["']){0,1}){0,1})*\s*?>/
-const RE_SCRIPT_BLOCK = /(<script[\s\S]*?>)([\s\S]*?)(<\/script>)/g
-const RE_STYLE_BLOCK = /(<style[\s\S]*?>)([\s\S]*?)(<\/style>)/g
+  /<script(?:\s+?[a-zA-Z]+(=(?:["']){0,1}[a-zA-Z0-9]+(?:["']){0,1}){0,1})*\s*?>/u
+const RE_SCRIPT_BLOCK = /(<script[\s\S]*?>)([\s\S]*?)(<\/script>)/gu
+const RE_STYLE_BLOCK = /(<style[\s\S]*?>)([\s\S]*?)(<\/style>)/gu
 
 // Parses key=value pairs from a string. Supports strings (with escaped quotes),
 // numbers, booleans, and arrays. Note: nested structures in arrays are not supported.
-const RE_PARSE_META = /(\w+=\d+|\w+="(?:[^"\\]|\\.)*"|\w+=\[[^\]]*\]|\w+)/g
+const RE_PARSE_META = /(\w+=\d+|\w+="(?:[^"\\]|\\.)*"|\w+=\[[^\]]*\]|\w+)/gu
 
 export const EXAMPLE_MODULE_PREFIX = `___live_example___`
 export const EXAMPLE_COMPONENT_PREFIX = `LiveExample___`

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -100,7 +100,7 @@ export default function live_examples_plugin(
 
         // Skip derived module requests (CSS, scripts) - let vite-plugin-svelte handle them.
         // Must check BEFORE virtual_files lookup to avoid returning Svelte source for CSS.
-        if (/type=(style|script|module)/.test(query)) return
+        if (/type=(style|script|module)/u.test(query)) return
 
         const src = virtual_files.get(base_id)
         if (src) return src
@@ -198,7 +198,7 @@ export default function live_examples_plugin(
           if (typeof prop.start === `number` && typeof prop.end === `number`) {
             let end = prop.end
             const max_end = Math.min(prop.end + TRAILING_CLEANUP_BOUND, code.length)
-            while (end < max_end && /[\s,]/.test(code[end])) end++
+            while (end < max_end && /[\s,]/u.test(code[end])) end++
             edits.push({ start: prop.start, end, content: `` })
           }
         }
@@ -215,7 +215,7 @@ export default function live_examples_plugin(
         for (const import_node of imports) {
           const source = import_node.source
           if (!is_record(source) || typeof source.value !== `string`) continue
-          const match = source.value.match(/___live_example___(\d+)\.svelte/)
+          const match = source.value.match(/___live_example___(\d+)\.svelte/u)
           if (
             match &&
             typeof source.start === `number` &&

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -92,6 +92,8 @@ export type LoadOptions<T extends Option = Option> =
   | LoadOptionsFn<T>
   | LoadOptionsConfig<T>
 
+export type FormSerialize<T extends Option = Option> = (selected: T[]) => string | null
+
 type AfterInputProps = Pick<
   MultiSelectProps,
   | `selected`
@@ -187,6 +189,7 @@ export interface MultiSelectProps<T extends Option = Option>
   fuzzy?: boolean // whether to use fuzzy matching (default: true) or substring matching (false)
   closeDropdownOnSelect?: boolean | `if-mobile` | `retain-focus`
   form_input?: HTMLInputElement | null
+  formSerialize?: FormSerialize<T>
   highlightMatches?: boolean
   id?: string | null
   input?: HTMLInputElement | null

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,7 +9,7 @@ let uuid_counter = 0
 export function get_uuid(): string {
   if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
   const hex = (Date.now().toString(16) + (uuid_counter++).toString(16)).padStart(32, `0`)
-  return hex.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, `$1-$2-$3-$4-$5`)
+  return hex.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/u, `$1-$2-$3-$4-$5`)
 }
 
 // Type guard for checking if a value is a non-null object

--- a/src/routes/(demos)/kit-form-actions/+page.server.ts
+++ b/src/routes/(demos)/kit-form-actions/+page.server.ts
@@ -4,6 +4,7 @@ import type { Actions } from './$types'
 // Form actions require a server and cannot work on static sites.
 // The underscore prefix disables this export during static build.
 // To test locally with `npm run dev`, rename `_actions` to `actions`.
+// eslint-disable-next-line no-underscore-dangle -- intentionally disabled for static builds
 export const _actions = {
   'validate-form': async ({ request }) => {
     const data = await request.formData()

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -5,6 +5,6 @@ export const prerender = true
 
 export const load: LayoutLoad = ({ url }) => {
   if (url.pathname.endsWith(`.md`)) {
-    redirect(307, url.pathname.replace(/\.md$/, ``))
+    redirect(307, url.pathname.replace(/\.md$/u, ``))
   }
 }

--- a/src/site/options.ts
+++ b/src/site/options.ts
@@ -13,7 +13,7 @@ export const frontend_libs: FrontendLib[] = [
   [`Laravel`, `PHP`, `laravel/laravel`],
   [`Django`, `Python`, `django/django`],
   [`Express`, `JavaScript`, `expressjs/express`],
-  [`Spring`, `JavaScript`, `spring-projects/spring-framework`],
+  [`Spring`, `Java`, `spring-projects/spring-framework`],
   [`jQuery`, `JavaScript`, `jquery/jquery`],
   [`Flask`, `Python`, `pallets/flask`],
   [`Flutter`, `Dart`, `flutter/flutter`],

--- a/tests/package-smoke/SmokeApp.svelte
+++ b/tests/package-smoke/SmokeApp.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import MultiSelect, { fuzzy_match, MultiSelect as NamedSelect } from 'svelte-multiselect'
+  import type { MultiSelectProps, Option } from 'svelte-multiselect'
+  import DirectMultiSelect from 'svelte-multiselect/MultiSelect.svelte'
+  import { click_outside } from 'svelte-multiselect/attachments'
+  import { get_label } from 'svelte-multiselect/utils'
+
+  const options = [`One`, { label: `Two`, value: 2 }] satisfies Option[]
+  const props: MultiSelectProps<Option> = { options }
+  const direct_export_matches = DirectMultiSelect === NamedSelect
+  const utility_export_works = fuzzy_match(`tw`, String(get_label(options[1])))
+  let selected = $state<Option[]>([])
+</script>
+
+<main {@attach click_outside({ callback: () => undefined })}>
+  <MultiSelect bind:selected {options} name="choices" />
+  <DirectMultiSelect {...props} />
+  <p>{direct_export_matches && utility_export_works ? `package ok` : `package failed`}</p>
+</main>

--- a/tests/package-smoke/index.html
+++ b/tests/package-smoke/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>svelte-multiselect package smoke test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/tests/package-smoke/main.ts
+++ b/tests/package-smoke/main.ts
@@ -1,0 +1,7 @@
+import { mount } from 'svelte'
+import App from './SmokeApp.svelte'
+
+const target = document.querySelector(`#app`)
+if (!target) throw new Error(`package smoke fixture target missing`)
+
+mount(App, { target })

--- a/tests/package-smoke/vite.config.ts
+++ b/tests/package-smoke/vite.config.ts
@@ -1,0 +1,16 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [svelte()],
+  resolve: {
+    conditions: [`svelte`, `browser`],
+  },
+  build: {
+    emptyOutDir: true,
+    outDir: `test-results/package-smoke-build`,
+    rollupOptions: {
+      input: `tests/package-smoke/index.html`,
+    },
+  },
+})

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -22,7 +22,7 @@ test(`array cloning infinite loop prevention (issue #309)`, async ({ page }) => 
 
   // Also verify count directly for robustness
   const count_text = await status.textContent()
-  const count = parseInt(count_text?.match(/\d+/)?.[0] ?? `0`, 10)
+  const count = parseInt(count_text?.match(/\d+/u)?.[0] ?? `0`, 10)
   expect(count).toBeLessThan(10)
 })
 
@@ -129,12 +129,12 @@ test.describe(`input`, () => {
   test(`opens dropdown on focus`, async ({ page }) => {
     await page.goto(`/ui`, { waitUntil: `networkidle` })
     const dropdown = page.locator(`#foods ul.options`)
-    await expect(dropdown).toHaveClass(/hidden/)
+    await expect(dropdown).toHaveClass(/hidden/u)
     await expect(page.locator(`#foods.open`)).toHaveCount(0)
 
     await page.click(`#foods input[autocomplete]`)
 
-    await expect(dropdown).not.toHaveClass(/hidden/)
+    await expect(dropdown).not.toHaveClass(/hidden/u)
     await expect(dropdown).toBeVisible()
   })
 
@@ -143,14 +143,14 @@ test.describe(`input`, () => {
     await page.goto(`/ui`, { waitUntil: `networkidle` })
     const dropdown = page.locator(`#foods div.multiselect > ul.options`)
     // confirm initial state
-    await expect(dropdown).toHaveClass(/hidden/)
+    await expect(dropdown).toHaveClass(/hidden/u)
     await expect(dropdown).toBeHidden()
 
     await page.evaluate(() => {
       const input = document.querySelector<HTMLInputElement>(`#foods input[autocomplete]`)
       input?.focus()
     })
-    await expect(dropdown).not.toHaveClass(/hidden/)
+    await expect(dropdown).not.toHaveClass(/hidden/u)
     await expect(dropdown).toBeVisible()
 
     // also test that input.blur() closes dropdown
@@ -158,7 +158,7 @@ test.describe(`input`, () => {
       const input = document.querySelector<HTMLInputElement>(`#foods input[autocomplete]`)
       input?.blur()
     })
-    await expect(dropdown).toHaveClass(/hidden/)
+    await expect(dropdown).toHaveClass(/hidden/u)
     await expect(dropdown).toBeHidden()
   })
 
@@ -244,7 +244,7 @@ test.describe(`input dropdown display`, () => {
     }
     const red_option = options.locator(`li:has-text("Red")`)
     await expect(red_option).toHaveAttribute(`aria-selected`, `true`)
-    await expect(red_option).toHaveClass(/selected/)
+    await expect(red_option).toHaveClass(/selected/u)
 
     await options.locator(`li:has-text("Green")`).click()
     await expect(input).toHaveValue(`Green`)
@@ -253,23 +253,29 @@ test.describe(`input dropdown display`, () => {
     await input.fill(`Gr`)
     await expand_icon.click()
     await expect(input).toHaveAttribute(`aria-expanded`, `false`)
+    await expect(options).toBeHidden()
 
     await expand_icon.click()
-    await expect(options.locator(`li:has-text("Green")`)).toBeVisible()
-    await expect(options.locator(`li:has-text("Red")`)).toBeVisible()
+    await expect(input).toHaveAttribute(`aria-expanded`, `true`)
+    await expect(options).toBeVisible()
+    await expect(options).toContainText(`Green`)
+    await expect(options).toContainText(`Red`)
 
     await input.fill(`Purple`)
     await expect(options.locator(`li.user-msg`)).toContainText(`No matching options`)
 
     await expand_icon.click()
     await expect(input).toHaveAttribute(`aria-expanded`, `false`)
+    await expect(options).toBeHidden()
 
     await expand_icon.click()
 
+    await expect(input).toHaveAttribute(`aria-expanded`, `true`)
+    await expect(options).toBeVisible()
     await expect(input).toHaveValue(`Purple`)
-    for (const color of [`Red`, `Green`, `Blue`]) {
-      await expect(options.locator(`li:has-text("${color}")`)).toBeVisible()
-    }
+    await expect(options).toContainText(`Green`)
+    await expect(options).toContainText(`Red`)
+    await expect(options).toContainText(`Blue`)
     await expect(options.locator(`li.user-msg`)).toHaveCount(0)
 
     await options.locator(`li:has-text("Blue")`).click()
@@ -528,7 +534,7 @@ test.describe(`accessibility`, () => {
     expect(after).toBe(`true`)
   })
 
-  test(`options have aria-selected='false' and selected items have aria-selected='true'`, async ({
+  test(`dropdown options expose ARIA selection while selected chips stay plain list items`, async ({
     page,
   }) => {
     await page.click(`#foods input[autocomplete]`)
@@ -538,11 +544,12 @@ test.describe(`accessibility`, () => {
     await dropdown.locator(`li`).first().click()
     const aria_option = await page.getAttribute(`#foods ul.options > li`, `aria-selected`)
     expect(aria_option).toBe(`false`)
-    const aria_selected = await page.getAttribute(
-      `#foods ul.selected > li`,
-      `aria-selected`,
-    )
-    expect(aria_selected).toBe(`true`)
+    await expect(page.locator(`#foods ul.selected > li[role="option"]`)).toHaveCount(0)
+    await expect(page.locator(`#foods ul.selected > li[aria-selected]`)).toHaveCount(0)
+  })
+
+  test(`wrapper does not duplicate the input combobox role`, async ({ page }) => {
+    await expect(page.locator(`#foods`)).not.toHaveAttribute(`role`, `combobox`)
   })
 
   test(`invisible input.form-control is aria-hidden`, async ({ page }) => {
@@ -615,19 +622,19 @@ test.describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
 
     // Live region announces option count
     await expect(live_region).toHaveAttribute(`aria-atomic`, `true`)
-    await expect(live_region).toContainText(/\d+ options? available/)
+    await expect(live_region).toContainText(/\d+ options? available/u)
 
     // Get first option and select it - should announce with label
     const first_option = page.locator(`#foods ul.options > li[role="option"]:first-child`)
 
     // Select option - should announce with label
     await first_option.click()
-    await expect(live_region).toContainText(/selected/)
+    await expect(live_region).toContainText(/selected/u)
 
     // Remove option - should announce removal
     const remove_btn = page.locator(`#foods ul.selected button.remove`).first()
     await remove_btn.click()
-    await expect(live_region).toContainText(/removed/)
+    await expect(live_region).toContainText(/removed/u)
   })
 
   test(`keyboard navigation with aria-activedescendant is fully accessible`, async ({
@@ -652,7 +659,7 @@ test.describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
     // Verify referenced element exists and is active
     const active_option = page.locator(`#${first_active_id}`)
     await expect(active_option).toHaveAttribute(`role`, `option`)
-    await expect(active_option).toHaveClass(/active/)
+    await expect(active_option).toHaveClass(/active/u)
 
     // Navigate again - activedescendant should change
     await page.keyboard.press(`ArrowDown`)
@@ -663,7 +670,7 @@ test.describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
     await page.keyboard.press(`Enter`)
 
     // Verify selection was made
-    const selected = page.locator(`#foods ul.selected > li[aria-selected="true"]`)
+    const selected = page.locator(`#foods ul.selected > li`)
     await expect(selected).toHaveCount(1)
 
     // Escape should close dropdown
@@ -683,7 +690,7 @@ test.describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
     for (let idx = 0; idx < count; idx++) {
       const header = group_headers.nth(idx)
       const aria_label = await header.getAttribute(`aria-label`)
-      expect(aria_label).toMatch(/^Group: /)
+      expect(aria_label).toMatch(/^Group: /u)
     }
   })
 })
@@ -767,9 +774,6 @@ test.describe(`multiselect`, () => {
     }
     const active_option = page.locator(`#foods ul.options > li.active`)
     await expect(active_option).toHaveText(foods[2]) // Watermelon
-
-    // Wait for any async scroll operations to complete from arrow navigation
-    await page.waitForTimeout(100)
 
     // Simulate scroll-triggered mouseover (no actual mouse movement)
     await page.evaluate(() => {
@@ -993,7 +997,7 @@ test.describe(`minSelect pill click behavior`, () => {
     page,
   }) => {
     // JavaScript is preselected with minSelect=1, so can_remove is false
-    const selected_li = page.locator(`#languages ul.selected > li[aria-selected="true"]`)
+    const selected_li = page.locator(`#languages ul.selected > li`)
     await expect(selected_li).toHaveCount(1)
     await expect(selected_li).toContainText(`JavaScript`)
 
@@ -1016,9 +1020,7 @@ test.describe(`minSelect pill click behavior`, () => {
     await expect(dropdown).toBeVisible()
     await dropdown.locator(`li`).first().click()
 
-    const selected_items = page.locator(
-      `#languages ul.selected > li[aria-selected="true"]`,
-    )
+    const selected_items = page.locator(`#languages ul.selected > li`)
     await expect(selected_items).toHaveCount(2)
 
     // Close dropdown
@@ -1054,14 +1056,13 @@ test.describe(`maxSelect`, () => {
     const dropdown = page.locator(`#languages ul.options`)
 
     await expect(dropdown).toBeHidden()
-    await expect(dropdown).toHaveClass(/hidden/)
+    await expect(dropdown).toHaveClass(/hidden/u)
   })
 
   test(`no more options can be added after reaching maxSelect items`, async ({
     page,
   }) => {
-    // query for li[aria-selected=true] to avoid matching the ul.selected > li containing the <input/>
-    const selected_items = page.locator(`#languages ul.selected > li[aria-selected=true]`)
+    const selected_items = page.locator(`#languages ul.selected > li`)
     await expect(selected_items).toHaveCount(max_select)
 
     // Try to add another option - should not work
@@ -1291,6 +1292,83 @@ test.describe(`portal feature`, () => {
     await page.getByRole(`button`, { name: `Close Modal 2` }).click() // Name from svelte file
     await expect(modal_content).toBeHidden()
   })
+
+  test(`portalled dropdown tracks trigger after nested scroll and resize`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 900, height: 700 })
+    await page.goto(`/portal`, { waitUntil: `networkidle` })
+    await page.getByRole(`button`, { name: `Open Modal` }).click()
+
+    const modal_content = page.locator(`div.modal-content.modal`)
+    const languages_input_selector = `div.multiselect input[placeholder='Choose languages...']`
+    const languages_input = modal_content.locator(languages_input_selector)
+
+    await page.evaluate(() => {
+      const modal = document.querySelector<HTMLElement>(`div.modal-content.modal`)
+      const first_multiselect = modal?.querySelector(`div.multiselect`)
+      if (!modal || !first_multiselect) throw new Error(`portal modal setup missing`)
+
+      modal.style.maxHeight = `220px`
+      modal.style.overflowY = `auto`
+      const spacer = document.createElement(`div`)
+      spacer.style.height = `120px`
+      spacer.textContent = `scroll spacer`
+      first_multiselect.before(spacer)
+    })
+
+    await languages_input.click()
+    const portalled_languages_options = page.locator(
+      `body > ul.options[aria-expanded="true"]:has(li:has-text("${languages[0]}"))`,
+    )
+    await expect(portalled_languages_options).toBeVisible()
+
+    const assert_aligned = async () => {
+      const metrics_handle = await page.waitForFunction((input_selector) => {
+        const input = document.querySelector<HTMLInputElement>(
+          `div.modal-content.modal ${input_selector}`,
+        )
+        const wrapper = input?.closest<HTMLElement>(`div.multiselect`)
+        const dropdown = document.querySelector<HTMLElement>(
+          `body > ul.options[aria-expanded="true"]`,
+        )
+        if (!wrapper || !dropdown) return false
+
+        const wrapper_rect = wrapper.getBoundingClientRect()
+        const dropdown_rect = dropdown.getBoundingClientRect()
+        const left_delta = Math.abs(dropdown_rect.left - wrapper_rect.left)
+        const top_delta = Math.abs(dropdown_rect.top - wrapper_rect.bottom)
+        const width_delta = Math.abs(dropdown_rect.width - wrapper_rect.width)
+        const aligned =
+          left_delta <= 2 &&
+          top_delta <= 10 &&
+          width_delta <= 2 &&
+          dropdown_rect.top >= 0 &&
+          dropdown_rect.right <= globalThis.innerWidth + 1
+        return aligned ? [left_delta, top_delta, width_delta] : false
+      }, languages_input_selector)
+      const metrics = await metrics_handle.jsonValue()
+      if (metrics === false) throw new Error(`portal dropdown alignment timed out`)
+      const [left_delta, top_delta, width_delta] = metrics
+
+      expect(left_delta).toBeLessThanOrEqual(2)
+      expect(top_delta).toBeLessThanOrEqual(10)
+      expect(width_delta).toBeLessThanOrEqual(2)
+    }
+
+    await assert_aligned()
+
+    await page.evaluate(() => {
+      const modal = document.querySelector<HTMLElement>(`div.modal-content.modal`)
+      if (!modal) throw new Error(`portal modal missing`)
+      modal.scrollTop = 80
+      modal.dispatchEvent(new Event(`scroll`, { bubbles: true }))
+    })
+    await assert_aligned()
+
+    await page.setViewportSize({ width: 760, height: 620 })
+    await assert_aligned()
+  })
 })
 
 test(`input width minimizes when options are selected`, async ({ page }) => {
@@ -1439,6 +1517,9 @@ test.describe(`option grouping`, () => {
     // Re-open dropdown (might have closed) and click Expand All
     await page.click(`#collapsible-groups input[autocomplete]`)
     await page.click(`#collapsible-groups button:has-text("Expand All")`)
+    if (!(await options_list.isVisible())) {
+      await page.click(`#collapsible-groups input[autocomplete]`)
+    }
 
     // All options should be visible
     await expect(apple_option).toBeVisible()
@@ -1765,7 +1846,7 @@ test.describe(`CSS class override specificity (issue #380)`, () => {
               const sel = rule.selectorText
               // Check div.multiselect uses :where() (not just any selector containing it)
               if (
-                /:where\(div\.multiselect\.[a-zA-Z0-9_-]+\)\s*\{?$|:where\(div\.multiselect\.[a-zA-Z0-9_-]+\)$/.test(
+                /:where\(div\.multiselect\.[a-zA-Z0-9_-]+\)\s*\{?$|:where\(div\.multiselect\.[a-zA-Z0-9_-]+\)$/u.test(
                   sel,
                 )
               ) {

--- a/tests/playwright/Nav.test.ts
+++ b/tests/playwright/Nav.test.ts
@@ -4,16 +4,20 @@ import { expect, test } from '@playwright/test'
 test.describe(`Nav dropdown`, () => {
   // Move the cursor out first so hover() crosses the dropdown boundary.
   const hover_open = async (page: Page, dropdown: Locator, menu: Locator) => {
-    await page.mouse.move(0, 0)
-    await dropdown.hover({ force: true })
-    await expect(menu).toHaveCSS(`display`, `flex`, { timeout: 10_000 })
+    const trigger = dropdown.locator(`:scope > div`).first()
+    await expect(trigger).toBeVisible()
+    await expect(async () => {
+      await page.mouse.move(0, 0)
+      await trigger.hover()
+      await expect(menu).toHaveCSS(`display`, `flex`, { timeout: 500 })
+    }).toPass({ timeout: 10_000 })
   }
 
   test(`opens on hover and closes on mouse leave`, async ({ page }) => {
     await page.goto(`/nav`, { waitUntil: `networkidle` })
 
     const dropdown = page.locator(`.dropdown`).first()
-    const menu = dropdown.locator(`div[role="menu"]`)
+    const menu = dropdown.locator(`[data-submenu]`)
 
     await expect(menu).toHaveCSS(`display`, `none`)
     await hover_open(page, dropdown, menu)
@@ -25,9 +29,9 @@ test.describe(`Nav dropdown`, () => {
     await page.goto(`/nav`, { waitUntil: `networkidle` })
 
     const dropdown = page.locator(`.dropdown`).first()
-    const menu = dropdown.locator(`div[role="menu"]`)
+    const menu = dropdown.locator(`[data-submenu]`)
     await hover_open(page, dropdown, menu)
-    await expect(dropdown.locator(`div[role="menu"] a`).first()).toBeVisible()
+    await expect(menu.locator(`a`).first()).toBeVisible()
   })
 
   test(`click pins dropdown: stays open on mouse leave, closes on click outside/Escape/toggle`, async ({
@@ -36,7 +40,7 @@ test.describe(`Nav dropdown`, () => {
     await page.goto(`/nav`, { waitUntil: `networkidle` })
 
     const dropdown = page.locator(`.dropdown`).first()
-    const menu = dropdown.locator(`div[role="menu"]`)
+    const menu = dropdown.locator(`[data-submenu]`)
     const toggle = dropdown.locator(`[data-dropdown-toggle]`)
 
     // Click pins open, mouse leave doesn't close

--- a/tests/vitest/CmdPalette.svelte.test.ts
+++ b/tests/vitest/CmdPalette.svelte.test.ts
@@ -166,6 +166,68 @@ test.each([
   expect(document.activeElement).toBe(doc_query(`dialog input[autocomplete]`))
 })
 
+function restore_show_modal(original_show_modal: PropertyDescriptor | undefined): void {
+  if (original_show_modal) {
+    Object.defineProperty(HTMLDialogElement.prototype, `showModal`, original_show_modal)
+  } else Reflect.deleteProperty(HTMLDialogElement.prototype, `showModal`)
+}
+
+test(`opens a labelled modal dialog`, async () => {
+  const original_show_modal = Object.getOwnPropertyDescriptor(
+    HTMLDialogElement.prototype,
+    `showModal`,
+  )
+  const show_modal = vi.fn(function showModal(this: HTMLDialogElement) {
+    this.setAttribute(`open`, ``)
+  })
+  HTMLDialogElement.prototype.showModal = show_modal
+  const props = $state({
+    actions: mock_actions,
+    aria_label: `Run command`,
+    open: true,
+    fade_duration: 0,
+  })
+
+  try {
+    mount(CmdPalette, { target: document.body, props })
+    await tick()
+
+    const dialog = doc_query<HTMLDialogElement>(`dialog`)
+    expect(dialog.getAttribute(`aria-label`)).toBe(`Run command`)
+    expect(show_modal).toHaveBeenCalledTimes(1)
+  } finally {
+    restore_show_modal(original_show_modal)
+  }
+})
+
+test.each([`throws`, `unavailable`] as const)(
+  `falls back to open attribute when showModal is %s`,
+  async (show_modal_state) => {
+    const original_show_modal = Object.getOwnPropertyDescriptor(
+      HTMLDialogElement.prototype,
+      `showModal`,
+    )
+    if (show_modal_state === `throws`) {
+      HTMLDialogElement.prototype.showModal = vi.fn(() => {
+        throw new Error(`showModal failed`)
+      })
+    } else {
+      Reflect.deleteProperty(HTMLDialogElement.prototype, `showModal`)
+    }
+    const props = $state({ actions: mock_actions, open: true, fade_duration: 0 })
+
+    try {
+      mount(CmdPalette, { target: document.body, props })
+      await tick()
+
+      const dialog = doc_query<HTMLDialogElement>(`dialog`)
+      expect(dialog.hasAttribute(`open`)).toBe(true)
+    } finally {
+      restore_show_modal(original_show_modal)
+    }
+  },
+)
+
 test(`handles action selection and execution`, () => {
   const actions_with_spies = mock_actions.map(({ label }) => ({
     label,
@@ -679,7 +741,7 @@ test(`mixed grouped and ungrouped actions render correctly`, async () => {
   // Should have one group header for File group (header includes count like "File (2)")
   const group_headers = document.querySelectorAll(`dialog ul.options li.group-header`)
   expect(group_headers.length).toBe(1)
-  expect(group_headers[0].textContent?.trim()).toMatch(/^File/)
+  expect(group_headers[0].textContent?.trim()).toMatch(/^File/u)
 
   // All 4 actions should be rendered
   const action_items = document.querySelectorAll(

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1025,6 +1025,34 @@ test.each([
   expect(JSON.parse(submitted_value)).toEqual(options)
 })
 
+test(`formSerialize customizes chip-mode form values`, async () => {
+  const form = document.createElement(`form`)
+  form.addEventListener(`submit`, (event) => event.preventDefault())
+  document.body.append(form)
+
+  try {
+    const field_name = `serialized choices`
+    const options = [`Red`, `Green`]
+    mount(MultiSelect, {
+      target: form,
+      props: {
+        options,
+        name: field_name,
+        formSerialize: (selected: Option[]) => selected.map(String).join(`|`),
+      },
+    })
+
+    for (const _ of options) {
+      doc_query<HTMLElement>(`ul.options li`).click()
+      await tick()
+    }
+
+    expect(new FormData(form).get(field_name)).toBe(`Red|Green`)
+  } finally {
+    form.remove()
+  }
+})
+
 test(`toggling required after invalid form submission allows submitting`, async () => {
   // https://github.com/janosh/svelte-multiselect/issues/285
   const form = document.createElement(`form`)
@@ -1173,7 +1201,7 @@ describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
 
     input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `ArrowDown`, bubbles: true }))
     await tick()
-    expect(input.getAttribute(`aria-activedescendant`)).toMatch(/^my-select-opt-/)
+    expect(input.getAttribute(`aria-activedescendant`)).toMatch(/^my-select-opt-/u)
   })
 
   test(`aria-label can be passed via rest props for accessible name`, () => {
@@ -2380,26 +2408,26 @@ describe(`arrow key navigation between selected items`, () => {
     expect(highlighted().length).toBe(0)
   })
 
-  test(`highlighted pill gets aria-activedescendant on input`, async () => {
+  test(`highlighted pill does not set aria-activedescendant`, async () => {
     const input = setup()
     expect(input.getAttribute(`aria-activedescendant`)).toBeFalsy()
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
-    const active_id = input.getAttribute(`aria-activedescendant`)
-    expect(active_id).toBeTruthy()
-    // the id should match the highlighted <li>'s id
     const highlighted_li = document.querySelector(`ul.selected > li.highlighted`)
-    expect(highlighted_li?.id).toBe(active_id)
+    expect(highlighted_li).toBeInstanceOf(HTMLLIElement)
+    expect(input.getAttribute(`aria-activedescendant`)).toBeFalsy()
   })
 
-  test(`aria-activedescendant clears when highlight clears`, async () => {
+  test(`aria-activedescendant remains clear when highlight clears`, async () => {
     const input = setup()
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
-    expect(input.getAttribute(`aria-activedescendant`)).toBeTruthy()
+    expect(highlighted().length).toBe(1)
+    expect(input.getAttribute(`aria-activedescendant`)).toBeFalsy()
     input.dispatchEvent(press(`Escape`))
     await tick()
     // should revert to null/undefined (no active dropdown option either since dropdown closed)
+    expect(highlighted().length).toBe(0)
     expect(input.getAttribute(`aria-activedescendant`)).toBeFalsy()
   })
 
@@ -2407,7 +2435,7 @@ describe(`arrow key navigation between selected items`, () => {
     setup()
     const items = selected_items()
     for (let idx = 0; idx < items.length; idx++) {
-      expect(items[idx]?.id).toMatch(/-selected-\d+$/)
+      expect(items[idx]?.id).toMatch(/-selected-\d+$/u)
     }
     // ids should be unique
     const ids = [...items].map((li) => li.id)
@@ -5066,8 +5094,8 @@ describe(`binding update event count`, () => {
 
 describe(`CSS static analysis`, () => {
   const component_source = readFileSync(`src/lib/MultiSelect.svelte`, `utf-8`)
-  const css = component_source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? ``
-  const options_block = css.match(/:where\(ul\.options\)\s*\{([\s\S]*?)\}/)?.[1]
+  const css = component_source.match(/<style>([\s\S]*?)<\/style>/u)?.[1] ?? ``
+  const options_block = css.match(/:where\(ul\.options\)\s*\{([\s\S]*?)\}/u)?.[1]
 
   const props = [
     `--sms-border`,
@@ -5085,55 +5113,57 @@ describe(`CSS static analysis`, () => {
   ]
 
   test.each(props)(`%s uses light-dark()`, (prop) => {
-    expect(css).toMatch(new RegExp(`${prop.replaceAll(`-`, `[-]`)}[^;]*light-dark\\(`))
+    expect(css).toMatch(
+      new RegExp(`${prop.replaceAll(`-`, `[-]`)}[^;]*light-dark\\(`, `u`),
+    )
   })
 
   test(`::highlight uses light-dark()`, () => {
-    expect(css).toMatch(/::highlight\(sms-search-matches\)[\s\S]*?light-dark\(/)
+    expect(css).toMatch(/::highlight\(sms-search-matches\)[\s\S]*?light-dark\(/u)
   })
 
   test(`dropdown highlight query uses effective filter text`, () => {
     expect(component_source).toMatch(
-      /highlight_matches\(\{\s*query:\s*effective_filter_text,/,
+      /highlight_matches\(\{\s*query:\s*effective_filter_text,/u,
     )
   })
 
   test(`--sms-active-color fallbacks use light-dark()`, () => {
     expect(
-      css.match(/--sms-active-color,\s*light-dark\(/g)?.length,
+      css.match(/--sms-active-color,\s*light-dark\(/gu)?.length,
     ).toBeGreaterThanOrEqual(2)
   })
 
   test(`default-icon buttons enforce circle via min-height: 0 + overflow: hidden`, () => {
     const default_icon_block = css.match(
-      /:is\(div\.multiselect button\.default-icon\)\s*\{([\s\S]*?)\}/,
+      /:is\(div\.multiselect button\.default-icon\)\s*\{([\s\S]*?)\}/u,
     )?.[1]
     expect(default_icon_block).toBeTruthy()
-    expect(default_icon_block).toMatch(/min-height:\s*0/)
-    expect(default_icon_block).toMatch(/overflow:\s*hidden/)
+    expect(default_icon_block).toMatch(/min-height:\s*0/u)
+    expect(default_icon_block).toMatch(/overflow:\s*hidden/u)
   })
 
   test(`options dropdown has border with light-dark default`, () => {
     expect(options_block).toBeTruthy()
-    expect(options_block).toMatch(/--sms-options-border,\s*1px solid light-dark\(/)
+    expect(options_block).toMatch(/--sms-options-border,\s*1px solid light-dark\(/u)
     expect(options_block).toMatch(
-      /border-width:\s*var\(--sms-options-border-width,\s*1px\)/,
+      /border-width:\s*var\(--sms-options-border-width,\s*1px\)/u,
     )
   })
 
   test(`options dropdown bg contrasts with typical page bg`, () => {
     expect(options_block).toBeTruthy()
-    expect(options_block).toMatch(/--sms-options-bg,\s*light-dark\(#fcfcfc/)
+    expect(options_block).toMatch(/--sms-options-bg,\s*light-dark\(#fcfcfc/u)
   })
 
   test(`custom-snippet remove-all overrides circular defaults`, () => {
     const custom_remove_all = css.match(
-      /:is\(div\.multiselect button\.remove-all:not\(\.default-icon\)\)\s*\{([\s\S]*?)\}/,
+      /:is\(div\.multiselect button\.remove-all:not\(\.default-icon\)\)\s*\{([\s\S]*?)\}/u,
     )?.[1]
     expect(custom_remove_all).toBeTruthy()
-    expect(custom_remove_all).toMatch(/border-radius:\s*3pt/)
-    expect(custom_remove_all).toMatch(/aspect-ratio:\s*auto/)
-    expect(custom_remove_all).toMatch(/padding:\s*0 2pt/)
+    expect(custom_remove_all).toMatch(/border-radius:\s*3pt/u)
+    expect(custom_remove_all).toMatch(/aspect-ratio:\s*auto/u)
+    expect(custom_remove_all).toMatch(/padding:\s*0 2pt/u)
   })
 })
 
@@ -5754,7 +5784,7 @@ describe(`option grouping feature`, () => {
         expect(header.getAttribute(`role`)).toBe(expected_role)
         expect(header.getAttribute(`tabindex`)).toBe(expected_tabindex)
         expect(header.hasAttribute(`aria-expanded`)).toBe(has_aria_expanded)
-        expect(header.getAttribute(`aria-label`)).toMatch(/^Group: /)
+        expect(header.getAttribute(`aria-label`)).toMatch(/^Group: /u)
       })
 
       // For collapsible, also verify aria-expanded toggles on click
@@ -7820,7 +7850,7 @@ describe(`parse_paste`, () => {
       {
         options: [`existing`],
         allowUserOptions: true,
-        parse_paste: (text: string) => text.split(/[,\s]+/).filter(Boolean),
+        parse_paste: (text: string) => text.split(/[,\s]+/u).filter(Boolean),
       },
       `new1,new2,new3`,
     )

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -16,7 +16,7 @@ describe(`Nav`, () => {
   }
   const query_dropdown_elements = () => {
     const dropdown = doc_query(`.dropdown`)
-    const dropdown_menu = dropdown.querySelector<HTMLElement>(`div:last-child`)
+    const dropdown_menu = dropdown.querySelector<HTMLElement>(`[data-submenu]`)
     return { dropdown, dropdown_menu }
   }
 
@@ -71,8 +71,8 @@ describe(`Nav`, () => {
     expect(panel_id).toBeTypeOf(`string`)
     expect(menu.id).toBe(panel_id)
     expect(panel_id?.startsWith(`nav-menu-`)).toBe(true)
-    expect(menu.getAttribute(`role`)).toBe(`menu`)
-    expect(menu.getAttribute(`tabindex`)).toBe(`0`)
+    expect(menu.getAttribute(`role`)).toBeNull()
+    expect(menu.getAttribute(`tabindex`)).toBeNull()
 
     await click(button)
     expect(button.getAttribute(`aria-expanded`)).toBe(`true`)
@@ -211,8 +211,7 @@ describe(`Nav`, () => {
     expect(toggle?.getAttribute(`aria-expanded`)).toBe(`false`)
     expect(toggle?.getAttribute(`aria-haspopup`)).toBe(`true`)
 
-    // Dropdown menu is the last div inside .dropdown
-    const dropdown_menu = dropdown.querySelector(`div:last-child`)
+    const dropdown_menu = dropdown.querySelector(`[data-submenu]`)
     const hrefs = Array.from(dropdown_menu?.querySelectorAll(`a`) ?? []).map((link) =>
       link.getAttribute(`href`),
     )
@@ -326,7 +325,7 @@ describe(`Nav`, () => {
     expect(trigger?.getAttribute(`href`)).toBe(href)
     expect(trigger?.textContent?.trim()).toBe(label)
     const menu_links = Array.from(
-      dropdown.querySelector(`div:last-child`)?.querySelectorAll(`a`) ?? [],
+      dropdown.querySelector(`[data-submenu]`)?.querySelectorAll(`a`) ?? [],
     ).map((link) => link.getAttribute(`href`))
     expect(menu_links).toEqual(children)
   })
@@ -346,7 +345,7 @@ describe(`Nav`, () => {
     })
 
     const [dropdown1, dropdown2] = Array.from(document.querySelectorAll(`.dropdown`))
-    const menu1 = dropdown1.querySelector<HTMLElement>(`div:last-child`)
+    const menu1 = dropdown1.querySelector<HTMLElement>(`[data-submenu]`)
     const toggle1 = dropdown1.querySelector<HTMLElement>(`[data-dropdown-toggle]`)
 
     // aria-expanded toggles correctly on toggle button
@@ -364,7 +363,7 @@ describe(`Nav`, () => {
     // Multiple dropdowns work independently
     const toggle2 = dropdown2.querySelector<HTMLElement>(`[data-dropdown-toggle]`)
     await click(toggle1)
-    const menu2 = dropdown2.querySelector<HTMLElement>(`div:last-child`)
+    const menu2 = dropdown2.querySelector<HTMLElement>(`[data-submenu]`)
     expect(menu1?.classList.contains(`visible`)).toBe(true)
     expect(menu2?.classList.contains(`visible`)).toBe(false)
 
@@ -488,27 +487,25 @@ describe(`Nav`, () => {
     expect(links[2].getAttribute(`href`)).toBe(`/contact`)
   })
 
-  test(`dropdown accessibility: role and aria-label attributes`, () => {
+  test(`dropdown accessibility uses native navigation links and labelled toggles`, () => {
     mount(Nav, {
       target: document.body,
       props: { routes: [[`/docs`, [`/docs`, `/docs/intro`]]] },
     })
 
     const dropdown = doc_query(`.dropdown`)
-    // Check dropdown menu (last div) has role="menu"
     const dropdown_menu = dropdown.querySelector(`div:last-child`)
-    expect(dropdown_menu?.getAttribute(`role`)).toBe(`menu`)
+    expect(dropdown.getAttribute(`role`)).toBeNull()
+    expect(dropdown_menu?.getAttribute(`role`)).toBeNull()
 
-    // Check dropdown links have role="menuitem"
     const dropdown_links = Array.from(dropdown_menu?.querySelectorAll(`a`) ?? [])
     for (const link of dropdown_links) {
-      expect(link.getAttribute(`role`)).toBe(`menuitem`)
+      expect(link.getAttribute(`role`)).toBeNull()
     }
 
-    // Check toggle button has aria-label
     const toggle_button = doc_query(`[data-dropdown-toggle]`)
     const aria_label = toggle_button.getAttribute(`aria-label`)
-    expect(aria_label).toMatch(/Toggle.*submenu/)
+    expect(aria_label).toMatch(/Toggle.*submenu/u)
   })
 
   // NavRouteObject format (unique tests only; separators, disabled, align covered by dedicated describes)

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -450,7 +450,7 @@ describe(`tooltip`, () => {
     // MutationObserver callbacks don't fire in happy-dom, so we test setup/cleanup/ownership.
     beforeEach(() => vi.useFakeTimers())
 
-    it(`tracks tooltip ownership via _owner property`, () => {
+    it(`tracks tooltip ownership via owner_element property`, () => {
       const element = create_element()
       element.title = `test`
       mock_bounds(element)
@@ -459,7 +459,7 @@ describe(`tooltip`, () => {
 
       const tooltip_el = document.querySelector(`.custom-tooltip`)
       expect(tooltip_el).toBeInstanceOf(HTMLElement)
-      expect(Reflect.get(tooltip_el ?? {}, `_owner`)).toBe(element)
+      expect(Reflect.get(tooltip_el ?? {}, `owner_element`)).toBe(element)
     })
 
     it.each([
@@ -715,7 +715,7 @@ describe(`tooltip`, () => {
       trigger_tooltip(element)
       const tooltip_el = document.querySelector(`.custom-tooltip`)
       expect(tooltip_el?.getAttribute(`role`)).toBe(`tooltip`)
-      expect(tooltip_el?.id).toMatch(/^tooltip-/)
+      expect(tooltip_el?.id).toMatch(/^tooltip-/u)
       expect(element.getAttribute(`aria-describedby`)).toBe(tooltip_el?.id)
 
       element.dispatchEvent(new MouseEvent(`mouseleave`, { bubbles: true }))
@@ -742,10 +742,10 @@ describe(`tooltip`, () => {
       [`allow_html: false uses textContent`, false, `<b>bold</b>`, `<b>bold</b>`],
       [`allow_html: true uses innerHTML`, true, `<b>bold</b>`, `bold`],
       [
-        `allow_html: undefined (default) uses innerHTML`,
+        `allow_html: undefined (default) uses textContent`,
         undefined,
         `<b>bold</b>`,
-        `bold`,
+        `<b>bold</b>`,
       ],
     ])(`%s`, (_desc, allow_html, content, expected_text) => {
       const element = create_element()
@@ -764,7 +764,7 @@ describe(`tooltip`, () => {
       [`skipped when allow_html: false`, false, `Plain`, 0, `Plain`],
     ])(`sanitize_html %s`, (_desc, allow_html, title, call_count, expected_text) => {
       const sanitizer = vi.fn((html: string) =>
-        html.replaceAll(/<script[^>]*>.*?<\/script>/gi, ``),
+        html.replaceAll(/<script[^>]*>.*?<\/script>/giu, ``),
       )
       const element = create_element()
       element.title = title
@@ -809,8 +809,8 @@ describe(`tooltip`, () => {
       const tooltip_css = find_tooltip_css(css_texts)
       expect(tooltip_css).toBeDefined()
       expect(tooltip_css).not.toContain(`color-scheme`)
-      expect(tooltip_css).toMatch(/background-color:.*light-dark\(\s*#f5f5f7,\s*#2a2a2e/)
-      expect(tooltip_css).toMatch(/\bcolor:.*light-dark\(\s*#222,\s*#eee/)
+      expect(tooltip_css).toMatch(/background-color:.*light-dark\(\s*#f5f5f7,\s*#2a2a2e/u)
+      expect(tooltip_css).toMatch(/\bcolor:.*light-dark\(\s*#222,\s*#eee/u)
 
       const arrow_borders = set_prop_values.filter(
         (entry) =>
@@ -820,7 +820,7 @@ describe(`tooltip`, () => {
       )
       expect(arrow_borders.length).toBeGreaterThan(0)
       for (const entry of arrow_borders) {
-        expect(entry).toMatch(/light-dark\(\s*#f5f5f7,\s*#2a2a2e/)
+        expect(entry).toMatch(/light-dark\(\s*#f5f5f7,\s*#2a2a2e/u)
       }
     })
 

--- a/tests/vitest/live-examples/highlighter.test.ts
+++ b/tests/vitest/live-examples/highlighter.test.ts
@@ -140,11 +140,11 @@ describe(`starry_night_highlighter`, () => {
     [`md`, `# Hello`],
   ])(`highlights %s code`, (lang, code) => {
     const result = starry_night_highlighter(code, lang)
-    const escaped_lang = lang.replaceAll(/[+]/g, `\\$&`)
+    const escaped_lang = lang.replaceAll(/[+]/gu, `\\$&`)
     expect(result).toMatch(
       new RegExp(
         `^<pre class="highlight highlight-${escaped_lang}"><code>.*</code></pre>$`,
-        `s`,
+        `su`,
       ),
     )
     // Verify actual syntax highlighting produces spans (not just wrapper)
@@ -156,7 +156,7 @@ describe(`starry_night_highlighter`, () => {
       `normalizes %s to lowercase`,
       (lang) => {
         const result = starry_night_highlighter(`const x = 1`, lang)
-        expect(result).toMatch(/^<pre class="highlight highlight-[a-z]+"><code>/)
+        expect(result).toMatch(/^<pre class="highlight highlight-[a-z]+"><code>/u)
         expect(result).not.toContain(lang) // Should use lowercase version
       },
     )

--- a/tests/vitest/live-examples/mdsvex-transform.test.ts
+++ b/tests/vitest/live-examples/mdsvex-transform.test.ts
@@ -247,7 +247,7 @@ describe(`script block injection`, () => {
   test(`creates new script block when none exists`, () => {
     const tree = create_tree([create_code_node(`svelte`, `<div>Test</div>`, `example`)])
     remark()(tree, create_file())
-    expect(find_script_node(tree)).toMatch(/<script>[\s\S]*<\/script>/)
+    expect(find_script_node(tree)).toMatch(/<script>[\s\S]*<\/script>/u)
   })
 
   test(`adds imports to existing script block`, () => {

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -13,10 +13,10 @@ import { describe, expect, test, vi } from 'vite-plus/test'
 describe(`get_uuid`, () => {
   // RFC 4122 v4: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx (y = 8/9/a/b)
   const uuid_v4_regex =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu
   // UUID format without strict version/variant requirements
   const uuid_format_regex =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu
 
   function with_fallback<T>(fn: () => T): T {
     const original = globalThis.crypto?.randomUUID?.bind(globalThis.crypto)


### PR DESCRIPTION
- Tighten MultiSelect, CmdPalette, Nav, and tooltip accessibility/security behavior, including CmdPalette's new `aria_label` prop.
- Add `formSerialize` for chip-mode form submissions, clarify that `options` is optional with `loadOptions`, and document form submission behavior.
- Run CI on Node.js 24, update dev dependencies, and add package smoke coverage that packages and builds a tiny Svelte fixture from published exports.
- Clean stale contributor docs and demo fixture metadata.