### PR TITLE
Customizable expand icon position, beforeInput snippet, chevron dropdown toggle

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -294,6 +294,12 @@ These are the core props you'll use in most cases:
 
    Controls duplicate detection. `false` (default) blocks exact duplicates. `true` allows selecting the same option multiple times. `'case-insensitive'` blocks case variants (e.g. "Apple" blocks "apple").
 
+1. ```ts
+   expandIconPosition: 'left' | 'right' | 'none' = 'left'
+   ```
+
+   Which side of the input to render the expand icon on, or `'none'` to hide it entirely (applies to both the default chevron and a custom `expandIcon` snippet). Clicking the icon toggles the dropdown.
+
 <!-- deno-fmt-ignore -->
 
 1. ```ts
@@ -801,12 +807,13 @@ These reflect internal component state:
 1. `#snippet children({ option, idx, type })`: Convenience snippet that applies to both dropdown options AND selected items. Use this when you want the same custom rendering for both. Takes precedence if `option` or `selectedItem` are not provided. `type` is `'selected'` when rendering a selected pill and `'option'` when rendering a dropdown item, allowing conditional styling/content by context.
 1. `#snippet spinner()`: Custom spinner component to display when in `loading` state. Receives no props.
 1. `#snippet disabledIcon()`: Custom icon to display inside the input when in `disabled` state. Receives no props. Use an empty `{#snippet disabledIcon()}{/snippet}` to remove the default disabled icon.
-1. `#snippet expandIcon({ open, disabled })`: Allows setting a custom icon to indicate to users that the Multiselect text input field is expandable into a dropdown list. `open` is `true` if the dropdown is visible and `false` if hidden. `disabled` reflects the component's disabled state.
+1. `#snippet expandIcon({ open, disabled })`: Allows setting a custom icon to indicate to users that the Multiselect text input field is expandable into a dropdown list. `open` is `true` if the dropdown is visible and `false` if hidden. `disabled` reflects the component's disabled state. Use the `expandIconPosition` prop to control which side of the input the icon renders on.
 1. `#snippet removeIcon({ option, isRemoveAll })`: Custom icon to display as remove button. Used both by per-option remove buttons (`isRemoveAll: false`, `option` is the item being removed) and the 'remove all' button (`isRemoveAll: true`, `option` is `undefined`).
 1. `#snippet userMsg({ searchText, msgType, msg })`: Displayed like a dropdown item when the list is empty and user is allowed to create custom options based on text input (or if the user's text input clashes with an existing option). Receives props:
    - `searchText`: The text user typed into search input.
    - `msgType: false | 'create' | 'dupe' | 'no-match'`: `'dupe'` means user input is a duplicate of an existing option. `'create'` means user is allowed to convert their input into a new option not previously in the dropdown. `'no-match'` means user input doesn't match any dropdown items and users are not allowed to create new options. `false` means none of the above.
    - `msg`: Will be `duplicateOptionMsg` or `createOptionMsg` (see [props](#🔣-props)) based on whether user input is a duplicate or can be created as new option. Note this snippet replaces the default UI for displaying these messages so the snippet needs to render them instead (unless purposely not showing a message).
+1. `#snippet beforeInput({ selected, disabled, invalid, id, placeholder, open, required, searchText })`: Placed before the selected chips and search input. For arbitrary content like a search icon or prefix badge.
 1. `#snippet afterInput({ selected, disabled, invalid, id, placeholder, open, required, searchText })`: Placed after the search input. For arbitrary content like icons or temporary messages. Can serve as a more dynamic, more customizable alternative to the `placeholder` prop.
 
 Example using several snippets:

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1278,8 +1278,7 @@
 
   let ul_options = $state<HTMLUListElement>()
 
-  // shared props for the beforeInput/afterInput snippets
-  const input_snippet_props = $derived({
+  const input_snippet_props = $derived({ // shared props for beforeInput/afterInput
     selected,
     disabled,
     invalid,

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -101,9 +101,11 @@
     ulSelectedStyle = null,
     ulOptionsStyle = null,
     expandIcon,
+    expandIconPosition = `left`,
     selectedItem,
     children,
     removeIcon,
+    beforeInput,
     afterInput,
     spinner,
     disabledIcon,
@@ -920,9 +922,9 @@
     if (disabled) return
     const clicked_expand_icon = event.target instanceof Element &&
       event.target.closest(`.expand-icon`)
-    if (clicked_expand_icon && input_display) {
-      if (open) return close_dropdown(event)
-      show_all_input_options = true
+    if (clicked_expand_icon) {
+      if (open) return close_dropdown(event) // expand icon toggles the dropdown
+      if (input_display) show_all_input_options = true
     }
     if (open) return
     open = true
@@ -1276,6 +1278,18 @@
 
   let ul_options = $state<HTMLUListElement>()
 
+  // shared props for the beforeInput/afterInput snippets
+  const input_snippet_props = $derived({
+    selected,
+    disabled,
+    invalid,
+    id,
+    placeholder: placeholder_text,
+    open,
+    required,
+    searchText,
+  })
+
   const handle_input_keydown: KeyboardEventHandler<HTMLInputElement> = (
     event,
   ) => {
@@ -1596,21 +1610,29 @@
       form_input?.setCustomValidity(msg)
     }}
   />
-  <span class="expand-icon" style="display: flex; align-items: center">
-    {#if expandIcon}
-      {@render expandIcon({ open, disabled })}
-    {:else}
-      <Icon
-        icon="ChevronExpand"
-        style="width: 15px; min-width: 1em; padding: 0 1pt; cursor: pointer"
-      />
-    {/if}
-  </span>
+  {#if expandIconPosition !== `none`}
+    <!-- order: 1 pushes icon past all other flex children (chips, input, remove-all) to the far right -->
+    <span
+      class="expand-icon"
+      style="display: flex; align-items: center"
+      style:order={expandIconPosition === `right` ? 1 : null}
+    >
+      {#if expandIcon}
+        {@render expandIcon({ open, disabled })}
+      {:else}
+        <Icon
+          icon="ChevronExpand"
+          style="width: 15px; min-width: 1em; padding: 0 1pt; cursor: pointer"
+        />
+      {/if}
+    </span>
+  {/if}
   <ul
     class="selected {ulSelectedClass}"
     aria-label="selected options"
     style={ulSelectedStyle}
   >
+    {@render beforeInput?.(input_snippet_props)}
     {#if !input_display}
       {#each selected as option, idx (duplicates ? `${key(option)}-${idx}` : key(option))}
         {@const selectedOptionStyle = [utils.get_style(option, `selected`), liSelectedStyle]
@@ -1698,16 +1720,7 @@
       {ontouchmove}
       {ontouchstart}
     />
-    {@render afterInput?.({
-        selected,
-        disabled,
-        invalid,
-        id,
-        placeholder: placeholder_text,
-        open,
-        required,
-        searchText,
-      })}
+    {@render afterInput?.(input_snippet_props)}
   </ul>
   {#if loading}
     {#if spinner}

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1566,6 +1566,19 @@
   {/if}
 {/snippet}
 
+{#snippet render_expand_icon()}
+  <span class="expand-icon" style="display: flex; align-items: center">
+    {#if expandIcon}
+      {@render expandIcon({ open, disabled })}
+    {:else}
+      <Icon
+        icon="ChevronExpand"
+        style="width: 15px; min-width: 1em; padding: 0 1pt; cursor: pointer"
+      />
+    {/if}
+  </span>
+{/snippet}
+
 <svelte:window
   onclick={on_click_outside}
   ontouchstart={on_click_outside}
@@ -1610,22 +1623,8 @@
       form_input?.setCustomValidity(msg)
     }}
   />
-  {#if expandIconPosition !== `none`}
-    <!-- order: 1 pushes icon past all other flex children (chips, input, remove-all) to the far right -->
-    <span
-      class="expand-icon"
-      style="display: flex; align-items: center"
-      style:order={expandIconPosition === `right` ? 1 : null}
-    >
-      {#if expandIcon}
-        {@render expandIcon({ open, disabled })}
-      {:else}
-        <Icon
-          icon="ChevronExpand"
-          style="width: 15px; min-width: 1em; padding: 0 1pt; cursor: pointer"
-        />
-      {/if}
-    </span>
+  {#if expandIconPosition === `left`}
+    {@render render_expand_icon()}
   {/if}
   <ul
     class="selected {ulSelectedClass}"
@@ -1722,6 +1721,9 @@
     />
     {@render afterInput?.(input_snippet_props)}
   </ul>
+  {#if expandIconPosition === `right`}
+    {@render render_expand_icon()}
+  {/if}
   {#if loading}
     {#if spinner}
       {@render spinner()}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -94,7 +94,8 @@ export type LoadOptions<T extends Option = Option> =
 
 export type FormSerialize<T extends Option = Option> = (selected: T[]) => string | null
 
-type AfterInputProps = Pick<
+// props passed to the beforeInput and afterInput snippets
+type InputSnippetProps = Pick<
   MultiSelectProps,
   | `selected`
   | `disabled`
@@ -124,13 +125,15 @@ export type GroupedOptions<T extends Option = Option> = {
 }
 
 export interface MultiSelectSnippets<T extends Option = Option> {
+  // custom icon indicating the input is expandable into a dropdown (position controlled by expandIconPosition prop)
   expandIcon?: Snippet<[{ open: boolean; disabled: boolean }]>
   selectedItem?: Snippet<[{ option: T; idx: number }]>
   children?: Snippet<[{ option: T; idx: number; type: `option` | `selected` }]>
   removeIcon?: Snippet<
     [{ option: T; isRemoveAll: false } | { option?: undefined; isRemoveAll: true }]
   >
-  afterInput?: Snippet<[AfterInputProps]>
+  beforeInput?: Snippet<[InputSnippetProps]>
+  afterInput?: Snippet<[InputSnippetProps]>
   spinner?: Snippet
   disabledIcon?: Snippet
   option?: Snippet<
@@ -178,6 +181,9 @@ export interface MultiSelectProps<T extends Option = Option>
   duplicateOptionMsg?: string
   // Controls duplicate detection: false (default, case-sensitive), true (allow all), 'case-insensitive' (block case variants)
   duplicates?: boolean | `case-insensitive`
+  // where to render the expand icon: left (default) or right of the input, or 'none' to hide it
+  // (https://github.com/janosh/svelte-multiselect/issues/419 and /issues/185)
+  expandIconPosition?: `left` | `right` | `none`
   // keepSelectedInDropdown controls whether selected options remain in dropdown: false (default),
   // 'plain' (left border and background color to differentiate selected options),
   // 'checkboxes' (each option is prefixed by a checkbox).

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -94,7 +94,7 @@ export type LoadOptions<T extends Option = Option> =
 
 export type FormSerialize<T extends Option = Option> = (selected: T[]) => string | null
 
-// props passed to the beforeInput and afterInput snippets
+// passed to beforeInput+afterInput snippets
 type InputSnippetProps<T extends Option = Option> = Pick<
   MultiSelectProps<T>,
   `selected` | `disabled` | `invalid` | `id` | `open` | `required` | `searchText`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,17 +95,10 @@ export type LoadOptions<T extends Option = Option> =
 export type FormSerialize<T extends Option = Option> = (selected: T[]) => string | null
 
 // props passed to the beforeInput and afterInput snippets
-type InputSnippetProps = Pick<
-  MultiSelectProps,
-  | `selected`
-  | `disabled`
-  | `invalid`
-  | `id`
-  | `placeholder`
-  | `open`
-  | `required`
-  | `searchText`
->
+type InputSnippetProps<T extends Option = Option> = Pick<
+  MultiSelectProps<T>,
+  `selected` | `disabled` | `invalid` | `id` | `open` | `required` | `searchText`
+> & { placeholder: string | null }
 type UserMsgProps = {
   searchText: string
   msgType: false | `dupe` | `create` | `no-match`
@@ -132,8 +125,8 @@ export interface MultiSelectSnippets<T extends Option = Option> {
   removeIcon?: Snippet<
     [{ option: T; isRemoveAll: false } | { option?: undefined; isRemoveAll: true }]
   >
-  beforeInput?: Snippet<[InputSnippetProps]>
-  afterInput?: Snippet<[InputSnippetProps]>
+  beforeInput?: Snippet<[InputSnippetProps<T>]>
+  afterInput?: Snippet<[InputSnippetProps<T>]>
   spinner?: Snippet
   disabledIcon?: Snippet
   option?: Snippet<
@@ -181,8 +174,7 @@ export interface MultiSelectProps<T extends Option = Option>
   duplicateOptionMsg?: string
   // Controls duplicate detection: false (default, case-sensitive), true (allow all), 'case-insensitive' (block case variants)
   duplicates?: boolean | `case-insensitive`
-  // where to render the expand icon: left (default) or right of the input, or 'none' to hide it
-  // (https://github.com/janosh/svelte-multiselect/issues/419 and /issues/185)
+  // Where to render the expand icon, or 'none' to hide it.
   expandIconPosition?: `left` | `right` | `none`
   // keepSelectedInDropdown controls whether selected options remain in dropdown: false (default),
   // 'plain' (left border and background color to differentiate selected options),

--- a/src/routes/(demos)/snippets/+page.md
+++ b/src/routes/(demos)/snippets/+page.md
@@ -40,6 +40,8 @@
 
 ### Simple HTML tag as `"removeIcon"` snippet
 
+This example also moves the expand icon to the right side of the input via `expandIconPosition="right"`.
+
 ```svelte example id="languages-2"
 <script lang="ts">
   import MultiSelect, { Icon } from '$lib'
@@ -55,6 +57,7 @@
   maxSelect={5}
   placeholder="What languages do you know?"
   selected={[`Python`, `TypeScript`, `Julia`]}
+  expandIconPosition="right"
   bind:open
 >
   {#snippet selectedItem({ option })}

--- a/src/routes/(demos)/snippets/+page.md
+++ b/src/routes/(demos)/snippets/+page.md
@@ -67,7 +67,7 @@ This example also moves the expand icon to the right side of the input via `expa
     <LanguageSnippet {option} style={selected ? `opacity: 0.6` : ``} />
   {/snippet}
   {#snippet expandIcon({ open: expandOpen, disabled })}
-    <button {disabled}>
+    <button type="button" {disabled}>
       <Icon icon={expandOpen ? `Collapse` : `Expand`} />
     </button>
   {/snippet}

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1378,6 +1378,51 @@ test(`expandIcon open toggles to true when dropdown opens`, async () => {
   expect(expand.dataset.open).toBe(`true`)
 })
 
+test.each([
+  [undefined, ``],
+  [`left`, ``],
+  [`right`, `1`],
+] as const)(
+  `expandIconPosition=%s renders expand icon with flex order '%s'`,
+  (position, expected_order) => {
+    mount(MultiSelect, {
+      target: document.body,
+      props: { options: [1, 2, 3], expandIconPosition: position },
+    })
+    expect(doc_query(`.expand-icon`).style.order).toBe(expected_order)
+  },
+)
+
+test(`expandIconPosition=none removes expand icon from DOM`, () => {
+  mount(MultiSelect, {
+    target: document.body,
+    props: { options: [1, 2, 3], expandIconPosition: `none` },
+  })
+  expect(document.querySelector(`.expand-icon`)).toBeNull()
+})
+
+test(`expand icon click toggles dropdown in chips mode`, async () => {
+  mount(MultiSelect, { target: document.body, props: { options: [1, 2, 3] } })
+
+  const click_expand = async () => {
+    doc_query(`.expand-icon`).dispatchEvent(new MouseEvent(`mouseup`, { bubbles: true }))
+    await tick()
+  }
+  const input = doc_query(`input[autocomplete]`)
+
+  await click_expand()
+  expect(input.getAttribute(`aria-expanded`)).toBe(`true`)
+
+  await click_expand()
+  expect(input.getAttribute(`aria-expanded`)).toBe(`false`)
+
+  // clicking elsewhere in the component while open should NOT close the dropdown
+  await click_expand()
+  doc_query(`div.multiselect`).dispatchEvent(new MouseEvent(`mouseup`, { bubbles: true }))
+  await tick()
+  expect(input.getAttribute(`aria-expanded`)).toBe(`true`)
+})
+
 test(`removeIcon snippet receives option for per-item and isRemoveAll flag`, async () => {
   mount(TestMultiSelectSnippets, {
     target: document.body,
@@ -1398,20 +1443,29 @@ test(`removeIcon snippet receives option for per-item and isRemoveAll flag`, asy
   expect(remove_spans[2].dataset.option).toBeUndefined()
 })
 
-test(`afterInput snippet receives searchText`, async () => {
+test(`beforeInput and afterInput snippets receive searchText and flank the input`, async () => {
   mount(TestMultiSelectSnippets, {
     target: document.body,
     props: { options: [1, 2, 3] },
   })
 
+  const before_input = doc_query(`.before-input-snippet`)
   const after_input = doc_query(`.after-input-snippet`)
+  expect(before_input.dataset.searchText).toBe(``)
   expect(after_input.dataset.searchText).toBe(``)
 
   const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  // beforeInput renders before the search input, afterInput after it
+  const precedes = (el_1: Element, el_2: Element) =>
+    Boolean(el_1.compareDocumentPosition(el_2) & Node.DOCUMENT_POSITION_FOLLOWING)
+  expect(precedes(before_input, input)).toBe(true)
+  expect(precedes(input, after_input)).toBe(true)
+
   input.value = `test`
   input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
   await tick()
 
+  expect(before_input.dataset.searchText).toBe(`test`)
   expect(after_input.dataset.searchText).toBe(`test`)
 })
 

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -21,6 +21,11 @@ const arrow_down = new KeyboardEvent(`keydown`, {
   bubbles: true,
 })
 const enter = new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true })
+const node_precedes = (first_element: Element, second_element: Element) =>
+  Boolean(
+    first_element.compareDocumentPosition(second_element) &
+    Node.DOCUMENT_POSITION_FOLLOWING,
+  )
 const console_methods = { error: console.error, warn: console.warn }
 afterEach(() => Object.assign(console, console_methods))
 
@@ -1379,26 +1384,36 @@ test(`expandIcon open toggles to true when dropdown opens`, async () => {
 })
 
 test.each([
-  [undefined, ``],
-  [`left`, ``],
-  [`right`, `1`],
+  [undefined, true],
+  [`left`, true],
+  [`right`, false],
 ] as const)(
-  `expandIconPosition=%s renders expand icon with flex order '%s'`,
-  (position, expected_order) => {
+  `expandIconPosition=%s places expand icon before selected list: %s`,
+  (position, icon_before_selected_list) => {
     mount(MultiSelect, {
       target: document.body,
       props: { options: [1, 2, 3], expandIconPosition: position },
     })
-    expect(doc_query(`.expand-icon`).style.order).toBe(expected_order)
+    const expand_icon = doc_query(`.expand-icon`)
+    const selected_list = doc_query(`ul.selected`)
+    expect(node_precedes(expand_icon, selected_list)).toBe(icon_before_selected_list)
   },
 )
 
-test(`expandIconPosition=none removes expand icon from DOM`, () => {
+test(`expandIconPosition=none removes default expand icon from DOM`, () => {
   mount(MultiSelect, {
     target: document.body,
     props: { options: [1, 2, 3], expandIconPosition: `none` },
   })
   expect(document.querySelector(`.expand-icon`)).toBeNull()
+})
+
+test(`expandIconPosition=none suppresses custom expandIcon snippet`, () => {
+  mount(TestMultiSelectSnippets, {
+    target: document.body,
+    props: { options: [1, 2, 3], expandIconPosition: `none` },
+  })
+  expect(document.querySelector(`.expand-snippet`)).toBeNull()
 })
 
 test(`expand icon click toggles dropdown in chips mode`, async () => {
@@ -1456,17 +1471,17 @@ test(`beforeInput and afterInput snippets receive searchText and flank the input
 
   const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
   // beforeInput renders before the search input, afterInput after it
-  const precedes = (el_1: Element, el_2: Element) =>
-    Boolean(el_1.compareDocumentPosition(el_2) & Node.DOCUMENT_POSITION_FOLLOWING)
-  expect(precedes(before_input, input)).toBe(true)
-  expect(precedes(input, after_input)).toBe(true)
+  expect(node_precedes(before_input, input)).toBe(true)
+  expect(node_precedes(input, after_input)).toBe(true)
 
   input.value = `test`
   input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
   await tick()
 
-  expect(before_input.dataset.searchText).toBe(`test`)
-  expect(after_input.dataset.searchText).toBe(`test`)
+  const before_input_after = doc_query(`.before-input-snippet`)
+  const after_input_after = doc_query(`.after-input-snippet`)
+  expect(before_input_after.dataset.searchText).toBe(`test`)
+  expect(after_input_after.dataset.searchText).toBe(`test`)
 })
 
 test(`filters dropdown to show only matching options when entering text`, async () => {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -21,11 +21,6 @@ const arrow_down = new KeyboardEvent(`keydown`, {
   bubbles: true,
 })
 const enter = new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true })
-const node_precedes = (first_element: Element, second_element: Element) =>
-  Boolean(
-    first_element.compareDocumentPosition(second_element) &
-    Node.DOCUMENT_POSITION_FOLLOWING,
-  )
 const console_methods = { error: console.error, warn: console.warn }
 afterEach(() => Object.assign(console, console_methods))
 
@@ -1383,36 +1378,30 @@ test(`expandIcon open toggles to true when dropdown opens`, async () => {
   expect(expand.dataset.open).toBe(`true`)
 })
 
-test.each([
-  [undefined, true],
-  [`left`, true],
-  [`right`, false],
-] as const)(
-  `expandIconPosition=%s places expand icon before selected list: %s`,
-  (position, icon_before_selected_list) => {
+test.each([undefined, `left`, `right`] as const)(
+  `expandIconPosition=%s places expand icon around selected list`,
+  (position) => {
     mount(MultiSelect, {
       target: document.body,
       props: { options: [1, 2, 3], expandIconPosition: position },
     })
     const expand_icon = doc_query(`.expand-icon`)
     const selected_list = doc_query(`ul.selected`)
-    expect(node_precedes(expand_icon, selected_list)).toBe(icon_before_selected_list)
+    if (position === `right`) expect(selected_list.nextElementSibling).toBe(expand_icon)
+    else expect(expand_icon.nextElementSibling).toBe(selected_list)
   },
 )
 
-test(`expandIconPosition=none removes default expand icon from DOM`, () => {
+test(`expandIconPosition=none suppresses default and custom expand icons`, () => {
   mount(MultiSelect, {
     target: document.body,
     props: { options: [1, 2, 3], expandIconPosition: `none` },
   })
-  expect(document.querySelector(`.expand-icon`)).toBeNull()
-})
-
-test(`expandIconPosition=none suppresses custom expandIcon snippet`, () => {
   mount(TestMultiSelectSnippets, {
     target: document.body,
     props: { options: [1, 2, 3], expandIconPosition: `none` },
   })
+  expect(document.querySelector(`.expand-icon`)).toBeNull()
   expect(document.querySelector(`.expand-snippet`)).toBeNull()
 })
 
@@ -1425,14 +1414,10 @@ test(`expand icon click toggles dropdown in chips mode`, async () => {
   }
   const input = doc_query(`input[autocomplete]`)
 
-  await click_expand()
-  expect(input.getAttribute(`aria-expanded`)).toBe(`true`)
-
-  await click_expand()
-  expect(input.getAttribute(`aria-expanded`)).toBe(`false`)
-
-  // clicking elsewhere in the component while open should NOT close the dropdown
-  await click_expand()
+  for (const expanded of [`true`, `false`, `true`]) {
+    await click_expand()
+    expect(input.getAttribute(`aria-expanded`)).toBe(expanded)
+  }
   doc_query(`div.multiselect`).dispatchEvent(new MouseEvent(`mouseup`, { bubbles: true }))
   await tick()
   expect(input.getAttribute(`aria-expanded`)).toBe(`true`)
@@ -1470,9 +1455,8 @@ test(`beforeInput and afterInput snippets receive searchText and flank the input
   expect(after_input.dataset.searchText).toBe(``)
 
   const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-  // beforeInput renders before the search input, afterInput after it
-  expect(node_precedes(before_input, input)).toBe(true)
-  expect(node_precedes(input, after_input)).toBe(true)
+  expect(before_input.nextElementSibling).toBe(input)
+  expect(input.nextElementSibling).toBe(after_input)
 
   input.value = `test`
   input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))

--- a/tests/vitest/TestMultiSelectSnippets.svelte
+++ b/tests/vitest/TestMultiSelectSnippets.svelte
@@ -13,6 +13,9 @@
     <span class="remove-snippet" data-option={option} data-is-remove-all={isRemoveAll}
     >✕</span>
   {/snippet}
+  {#snippet beforeInput({ searchText })}
+    <span class="before-input-snippet" data-search-text={searchText}>before</span>
+  {/snippet}
   {#snippet afterInput({ searchText })}
     <span class="after-input-snippet" data-search-text={searchText}>after</span>
   {/snippet}


### PR DESCRIPTION
- New `expandIconPosition: 'left' | 'right' | 'none' = 'left'` prop controls which side of the input the expand icon renders on, or hides it entirely. Implemented via CSS `order` on `span.expand-icon` so DOM order, click handling, and ARIA semantics stay unchanged. Replaces the `flex-row-reverse` Tailwind workaround from #419 and gives a discoverable alternative to the empty-snippet hack from #185.
- Clicking the expand icon now toggles the dropdown in chips mode too (previously the open-chevron click was a no-op outside `selectedDisplay="input"` mode). Mild behavior change, worth a release-notes mention.
- New `beforeInput` snippet mirroring `afterInput`, rendered before the selected chips and search input (e.g. for a search icon or prefix badge). Both snippets now share one `InputSnippetProps` type and props object.

Closes #419