### PR TITLE
Simplify Vite/Svelte setup and tighten tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     }
   },
   "overrides": {
+    "esrap": "2.2.11",
     "svelte": "$svelte"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,23 +59,24 @@
     "changelog": "npx tsx https://github.com/janosh/workflows/raw/refs/heads/main/scripts/make-release-notes.ts"
   },
   "devDependencies": {
-    "@playwright/test": "^1.60.0",
+    "@janosh/vite-config": "github:janosh/dotfiles",
+    "@playwright/test": "^1.61.0",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.64.0",
+    "@sveltejs/kit": "^2.66.0",
     "@sveltejs/package": "2.5.8",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@types/node": "^25.9.2",
-    "@vitest/coverage-v8": "^4.1.8",
+    "@types/node": "^26.0.0",
+    "@vitest/coverage-v8": "^4.1.9",
     "@wooorm/starry-night": "^3.10.0",
-    "acorn": "^8.16.0",
-    "happy-dom": "^20.10.2",
+    "acorn": "^8.17.0",
+    "happy-dom": "^20.10.6",
     "mdsvex": "^0.12.7",
-    "svelte": "^5.56.3",
+    "svelte": "5.56.2",
     "svelte-toc": "^0.7.0",
     "typescript": "6.0.3",
     "vite": "^8.0.16",
-    "vite-plus": "0.1.24",
-    "vitest": "^4.1.8"
+    "vite-plus": "0.2.1",
+    "vitest": "^4.1.9"
   },
   "peerDependencies": {
     "@wooorm/starry-night": "^3.0.0",

--- a/readme.md
+++ b/readme.md
@@ -1087,6 +1087,7 @@ Minimal example that changes the background color of the options dropdown:
   - `padding: var(--sms-options-padding, 0)`
   - `margin: var(--sms-options-margin, 6pt 0 0 0)`
 - `div.multiselect > ul.options > li`
+  - `padding: var(--sms-options-li-padding, 3pt 1ex)`: Padding of each option in the dropdown list.
   - `scroll-margin: var(--sms-options-scroll-margin, 100px)`: Top/bottom margin to keep between dropdown list items and top/bottom screen edge when auto-scrolling list to keep items in view.
 - `div.multiselect > ul.options > li.selected`
   - `background: var(--sms-li-selected-plain-bg, light-dark(rgba(0, 123, 255, 0.1), rgba(100, 180, 255, 0.2)))`: Background of selected list items in options pane.

--- a/src/lib/CmdPalette.svelte
+++ b/src/lib/CmdPalette.svelte
@@ -153,8 +153,11 @@
 
   function close_if_outside(event: MouseEvent) {
     const target = event.target
-    if (!target || !(target instanceof HTMLElement)) return
-    if (open && !dialog?.contains(target) && !target.closest(`ul.options`)) {
+    if (!open || !(target instanceof HTMLElement)) return
+    // backdrop clicks on a modal dialog have target === dialog, so close unless the click
+    // is on this palette's MultiSelect (scoped inside the dialog) or its (portalled) options
+    const in_palette = dialog?.contains(target) && target.closest(`div.multiselect`)
+    if (!in_palette && !target.closest(`ul.options`)) {
       open = false
     }
   }
@@ -211,6 +214,7 @@
       --sms-width="min(20em, 90vw)"
       --sms-max-width="none"
       --sms-placeholder-color="lightgray"
+      --sms-padding="3pt"
       --sms-options-margin="1px 0"
       --sms-options-border-radius="0 0 1ex 1ex"
     />
@@ -254,7 +258,7 @@
     bottom: auto;
     margin: 0 auto;
     border: none;
-    padding: 0;
+    padding: var(--cmd-dialog-padding, 6pt);
     background-color: transparent;
     display: flex;
     /* Let command results/popovers escape the dialog; default clipping hides suggestions. */

--- a/src/lib/CmdPalette.svelte
+++ b/src/lib/CmdPalette.svelte
@@ -155,9 +155,15 @@
     const target = event.target
     if (!open || !(target instanceof HTMLElement)) return
     // backdrop clicks on a modal dialog have target === dialog, so close unless the click
-    // is on this palette's MultiSelect (scoped inside the dialog) or its (portalled) options
-    const in_palette = dialog?.contains(target) && target.closest(`div.multiselect`)
-    if (!in_palette && !target.closest(`ul.options`)) {
+    // is on this palette's MultiSelect (scoped inside the dialog) or its options list
+    const in_palette = Boolean(
+      dialog?.contains(target) && target.closest(`div.multiselect`),
+    )
+    const listbox_id = input?.getAttribute(`aria-controls`)
+    const options = listbox_id
+      ? document.querySelector(`#${CSS.escape(listbox_id)}`)
+      : null
+    if (!in_palette && !options?.contains(target)) {
       open = false
     }
   }

--- a/src/lib/CmdPalette.svelte
+++ b/src/lib/CmdPalette.svelte
@@ -156,16 +156,15 @@
     if (!open || !(target instanceof HTMLElement)) return
     // backdrop clicks on a modal dialog have target === dialog, so close unless the click
     // is on this palette's MultiSelect (scoped inside the dialog) or its options list
-    const in_palette = Boolean(
-      dialog?.contains(target) && target.closest(`div.multiselect`),
-    )
+    if (dialog?.contains(target) && target.closest(`div.multiselect`)) return
     const listbox_id = input?.getAttribute(`aria-controls`)
-    const options = listbox_id
-      ? document.querySelector(`#${CSS.escape(listbox_id)}`)
-      : null
-    if (!in_palette && !options?.contains(target)) {
-      open = false
+    if (
+      listbox_id &&
+      document.querySelector(`#${CSS.escape(listbox_id)}`)?.contains(target)
+    ) {
+      return
     }
+    open = false
   }
 
   function trigger_action_and_close({ option }: { option: Action }) {

--- a/src/lib/CodeExample.svelte
+++ b/src/lib/CodeExample.svelte
@@ -115,6 +115,7 @@
     opacity: 1;
     max-height: var(--code-example-pre-max-height, 80vh);
     overflow-x: auto;
+    overflow-y: auto;
     padding: var(--code-example-pre-padding, 1ex 1em);
     margin: var(--code-example-pre-margin, 1em 0 0 0);
   }

--- a/src/lib/FileDetails.svelte
+++ b/src/lib/FileDetails.svelte
@@ -77,7 +77,10 @@
 
   // Infer language from title (may contain HTML like <code>foo.ts</code>)
   function lang_from_title(title: string): string | undefined {
-    const ext = title.replaceAll(/<[^>]*>/gu, ``).match(/\.(\w+)$/u)?.[1]?.toLowerCase()
+    const ext = title
+      .replaceAll(/<[^>]*>/gu, ``)
+      .match(/\.(?<ext>\w+)$/u)
+      ?.groups?.ext?.toLowerCase()
     return ext ? ext_to_lang[ext] ?? ext : undefined
   }
 

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -962,12 +962,12 @@
   }
 
   const can_show_create_msg = $derived(
-    show_input_user_msg && !!allowUserOptions && !!resolved_create_msg &&
+    show_input_user_msg && Boolean(allowUserOptions) && Boolean(resolved_create_msg) &&
       !load_options_pending,
   )
   const can_show_no_match_msg = $derived(
-    show_input_user_msg && navigable_options.length === 0 && !!noMatchingOptionsMsg &&
-      !load_options_pending,
+    show_input_user_msg && navigable_options.length === 0 &&
+      Boolean(noMatchingOptionsMsg) && !load_options_pending,
   )
 
   // Check if a user message (create option, duplicate warning, no match) is visible
@@ -1039,13 +1039,14 @@
     if (disabled) return // Block all keyboard handling when disabled
 
     // Check keyboard shortcuts first (before other key handling)
-    const shortcut_actions: Array<{
+    const shortcut_actions: {
       key: keyof typeof effective_shortcuts
       condition: () => boolean
       action: () => void
-    }> = [
+    }[] = [
       { key: `select_all`, condition: () =>
-        !!selectAllOption && navigable_options.length > 0 && maxSelect !== 1,
+        selectAllOption !== false && selectAllOption !== `` &&
+          navigable_options.length > 0 && maxSelect !== 1,
         action: () => select_all(event) },
       { key: `clear_all`, condition: () =>
         !input_display && selected.length > 0 && !searchText,
@@ -2223,7 +2224,7 @@
     position: fixed;
   }
   :where(ul.options > li) {
-    padding: 3pt 1ex;
+    padding: var(--sms-options-li-padding, 3pt 1ex);
     cursor: pointer;
     scroll-margin: var(--sms-options-scroll-margin, 100px);
     border-left: 1px solid transparent;

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -195,7 +195,7 @@
     // e.g. /tc-periodic-v2 should not match /tc-periodic
     const pathname = page?.url.pathname
     const exact_match = pathname === path
-    const prefix_match = pathname?.startsWith(path + `/`)
+    const prefix_match = pathname?.startsWith(`${path}/`)
     return exact_match || prefix_match ? `page` : undefined
   }
 

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1,9 +1,6 @@
 import type { Attachment } from 'svelte/attachments'
 import { fuzzy_match_indices, get_uuid } from './utils'
 
-// Re-export get_uuid for backwards compatibility
-export { get_uuid }
-
 // Type definitions for CSS highlight API (experimental)
 declare global {
   interface CSS {

--- a/src/lib/heading-anchors.ts
+++ b/src/lib/heading-anchors.ts
@@ -7,8 +7,10 @@
 // Avoid matching inside src={...} attributes by requiring these specific contexts
 // Note: [^>]* for attributes won't match if an attribute value contains > (e.g., data-foo="a>b")
 // This edge case is rare in practice and would require significantly more complex parsing
-const heading_regex_line_start = /^(\s*)<(h[1-6])([^>]*)>([\s\S]*?)<\/\2>/gimu
-const heading_regex_after_tag = /(>)(\s*)<(h[1-6])([^>]*)>([\s\S]*?)<\/\3>/giu
+const heading_regex_line_start =
+  /^(?<indent>\s*)<(?<tag>h[1-6])(?<attrs>[^>]*)>(?<inner>[\s\S]*?)<\/\k<tag>>/gimu
+const heading_regex_after_tag =
+  /(?<gt>>)(?<space>\s*)<(?<tag>h[1-6])(?<attrs>[^>]*)>(?<inner>[\s\S]*?)<\/\k<tag>>/giu
 
 // Remove Svelte expressions handling nested braces (e.g., {fn({a: 1})})
 // Treats unmatched } as literal text to avoid dropping content
@@ -42,7 +44,7 @@ export function heading_ids() {
 
       const process_heading = (attrs: string, inner: string): string | null => {
         // Skip if already has an id (use ^|\s to avoid matching data-id, aria-id, etc.)
-        if (/(^|\s)id\s*=/u.test(attrs)) return null
+        if (/(?:^|\s)id\s*=/u.test(attrs)) return null
 
         const text = strip_svelte_expressions(inner.replaceAll(/<[^>]+>/gu, ``)).trim()
         if (!text) return null

--- a/src/lib/live-examples/highlighter.ts
+++ b/src/lib/live-examples/highlighter.ts
@@ -3,8 +3,6 @@ import { common, createStarryNight } from '@wooorm/starry-night'
 import source_svelte from '@wooorm/starry-night/source.svelte'
 import { escape_html_text, hast_to_html } from './hast.ts'
 
-export { hast_to_html }
-
 // Escape characters that would be interpreted as Svelte template syntax
 const escape_svelte = (html: string): string =>
   html.replaceAll(`{`, `&#123;`).replaceAll(`}`, `&#125;`)

--- a/src/lib/live-examples/index.ts
+++ b/src/lib/live-examples/index.ts
@@ -1,6 +1,7 @@
 // Live examples - transforms ```svelte example code blocks into rendered components
 // with syntax highlighting and live preview
-export { hast_to_html, starry_night, starry_night_highlighter } from './highlighter.ts'
+export { hast_to_html } from './hast.ts'
+export { starry_night, starry_night_highlighter } from './highlighter.ts'
 export {
   default as mdsvex_transform,
   EXAMPLE_COMPONENT_PREFIX,

--- a/src/lib/live-examples/mdsvex-transform.ts
+++ b/src/lib/live-examples/mdsvex-transform.ts
@@ -1,7 +1,8 @@
 // Remark plugin - transforms ```svelte example code blocks into rendered components
 import { Buffer } from 'node:buffer'
 import path from 'node:path'
-import { hast_to_html, starry_night } from './highlighter.ts'
+import { hast_to_html } from './hast.ts'
+import { starry_night } from './highlighter.ts'
 
 // Base64 encode to prevent preprocessors from modifying the content
 const to_base64 = (src: string): string => Buffer.from(src, `utf-8`).toString(`base64`)
@@ -14,15 +15,15 @@ const encode_escapes = (src: string) =>
 // Note: These patterns handle common cases but may have edge cases with nested
 // comments containing </script> strings or complex attribute syntax
 const RE_SCRIPT_START =
-  /<script(?:\s+?[a-zA-Z]+(=(?:["']){0,1}[a-zA-Z0-9]+(?:["']){0,1}){0,1})*\s*?>/u
-const RE_SCRIPT_BLOCK = /(<script[\s\S]*?>)([\s\S]*?)(<\/script>)/gu
-const RE_STYLE_BLOCK = /(<style[\s\S]*?>)([\s\S]*?)(<\/style>)/gu
+  /<script(?:\s+?[a-zA-Z]+(?:=(?:["']){0,1}[a-zA-Z0-9]+(?:["']){0,1}){0,1})*\s*?>/u
+const RE_SCRIPT_BLOCK = /<script[\s\S]*?>[\s\S]*?<\/script>/gu
+const RE_STYLE_BLOCK = /<style[\s\S]*?>[\s\S]*?<\/style>/gu
 
 // Parses key=value pairs from a string. Supports strings (with escaped quotes),
 // numbers, booleans, and arrays. Note: nested structures in arrays are not supported.
 // Bare values (key=foo, key=true, key=-1.5) are captured greedily so invalid JSON
 // throws a parse error instead of silently splitting into two bare-word keys.
-const RE_PARSE_META = /(\w+="(?:[^"\\]|\\.)*"|\w+=\[[^\]]*\]|\w+=[^\s"[\]]+|\w+)/gu
+const RE_PARSE_META = /(?:\w+="(?:[^"\\]|\\.)*"|\w+=\[[^\]]*\]|\w+=[^\s"[\]]+|\w+)/gu
 
 export const EXAMPLE_MODULE_PREFIX = `___live_example___`
 export const EXAMPLE_COMPONENT_PREFIX = `LiveExample___`
@@ -87,7 +88,7 @@ function remark(options: RemarkOptions = {}): RemarkTransformer {
   const { defaults = {} } = options
 
   return function transformer(tree: RemarkTree, file: RemarkFile): void {
-    const examples: Array<{ csr?: boolean; wrapper_alias: string }> = []
+    const examples: { csr?: boolean; wrapper_alias: string }[] = []
     // Track wrapper imports to avoid duplicates and generate unique aliases
     const wrapper_aliases = new Map<string, string>() // wrapper key -> alias name
 

--- a/src/lib/live-examples/mdsvex-transform.ts
+++ b/src/lib/live-examples/mdsvex-transform.ts
@@ -14,8 +14,7 @@ const encode_escapes = (src: string) =>
 // Regex to find <script> block in svelte
 // Note: These patterns handle common cases but may have edge cases with nested
 // comments containing </script> strings or complex attribute syntax
-const RE_SCRIPT_START =
-  /<script(?:\s+?[a-zA-Z]+(?:=(?:["']){0,1}[a-zA-Z0-9]+(?:["']){0,1}){0,1})*\s*?>/u
+const RE_SCRIPT_START = /<script\b(?:[^<>"']|"[^"]*"|'[^']*')*>/u
 const RE_SCRIPT_BLOCK = /<script[\s\S]*?>[\s\S]*?<\/script>/gu
 const RE_STYLE_BLOCK = /<style[\s\S]*?>[\s\S]*?<\/style>/gu
 

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -109,7 +109,7 @@ export default function live_examples_plugin(
 
       // Skip derived module requests (CSS, scripts) - let vite-plugin-svelte handle them.
       // Must check BEFORE virtual_files lookup to avoid returning Svelte source for CSS.
-      if (/type=(style|script|module)/u.test(query)) return undefined
+      if (/type=(?<type>style|script|module)/u.test(query)) return undefined
 
       const src = virtual_files.get(base_id)
       if (src !== undefined) return src

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,7 +9,13 @@ let uuid_counter = 0
 export function get_uuid(): string {
   if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
   const hex = (Date.now().toString(16) + (uuid_counter++).toString(16)).padStart(32, `0`)
-  return hex.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/u, `$1-$2-$3-$4-$5`)
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join(`-`)
 }
 
 // Type guard for checking if a value is a non-null object

--- a/src/site/Confetti.svelte
+++ b/src/site/Confetti.svelte
@@ -17,7 +17,7 @@
       emoji: emojis[idx % emojis.length],
       x: Math.random() * 100,
       y: -20 - Math.random() * 100,
-      r: 0.1 + Math.random() * 1,
+      r: 0.1 + Math.random(),
     })).toSorted((conf_a, conf_b) => conf_a.r - conf_b.r),
   )
   let frame_id: number | undefined

--- a/svelte.config.ts
+++ b/svelte.config.ts
@@ -1,4 +1,5 @@
 import adapter from '@sveltejs/adapter-static'
+import type { Config } from '@sveltejs/kit'
 import { mdsvex } from 'mdsvex'
 import pkg from './package.json' with { type: 'json' }
 import { heading_ids } from './src/lib/heading-anchors.ts'
@@ -20,8 +21,6 @@ const remarkPlugins = [
     },
   ],
 ]
-
-import type { Config } from '@sveltejs/kit'
 
 const config: Config = {
   extensions: [`.svelte`, `.md`],

--- a/svelte.config.ts
+++ b/svelte.config.ts
@@ -26,6 +26,8 @@ const config: Config = {
   extensions: [`.svelte`, `.md`],
 
   compilerOptions: {
+    // TODO: Remove after bumping past the Svelte 5.48-5.56 regression that emits
+    // state_referenced_locally for valid local bindings.
     warningFilter: (warning) => warning.code !== `state_referenced_locally`,
   },
 

--- a/tests/vitest/CmdPalette.svelte.test.ts
+++ b/tests/vitest/CmdPalette.svelte.test.ts
@@ -117,7 +117,9 @@ test.each([
     await tick()
 
     expect(props.open).toBe(should_open)
-    expect(!!document.querySelector(`dialog`)).toBe(should_open)
+    expect(document.querySelector(`dialog`)).toEqual(
+      should_open ? expect.any(HTMLDialogElement) : null,
+    )
 
     if (should_open) {
       expect(document.activeElement).toBe(doc_query(`dialog input[autocomplete]`))
@@ -146,7 +148,9 @@ test.each([
     await tick()
 
     expect(props.open).toBe(!should_close)
-    expect(!!document.querySelector(`dialog`)).toBe(!should_close)
+    expect(document.querySelector(`dialog`)).toEqual(
+      should_close ? null : expect.any(HTMLDialogElement),
+    )
   },
 )
 
@@ -253,63 +257,103 @@ test(`handles action selection and execution`, () => {
   expect(props.open).toBe(false)
 })
 
-test(`handles click outside to close dialog`, async () => {
+test.each([
+  [`page body`, () => document.body],
+  // showModal() backdrop clicks dispatch with the dialog element itself as the target,
+  // so a naive dialog.contains(target) check would wrongly keep the palette open
+  [`modal backdrop (target === dialog)`, () => doc_query<HTMLDialogElement>(`dialog`)],
+])(`closes dialog on outside click: %s`, async (_label, get_target) => {
   const props = $state({ open: true, actions: mock_actions, fade_duration: 0 })
   mount(CmdPalette, { target: document.body, props })
+  await tick()
 
-  document.body.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+  get_target().dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
   await tick()
 
   expect(props.open).toBe(false)
-  expect(document.querySelector(`dialog`)).toBe(null)
+  expect(document.querySelector(`dialog`)).toBeNull()
 })
 
-test(`does not close dialog when clicking on portalled options`, async () => {
+test.each([
+  [`input wrapper`, `dialog div.multiselect`],
+  [`search input`, `dialog div.multiselect input[autocomplete]`],
+  [`options list`, `dialog ul.options`],
+])(`keeps dialog open when clicking palette %s`, async (_label, selector) => {
   const props = $state({ open: true, actions: mock_actions, fade_duration: 0 })
   mount(CmdPalette, { target: document.body, props })
   await tick()
 
-  // Create a mock portalled options element
-  const portalled_options = document.createElement(`ul`)
-  portalled_options.className = `options`
-  portalled_options.innerHTML = `<li>Option 1</li><li>Option 2</li>`
-  document.body.append(portalled_options)
-
-  // Click on the portalled options
-  const option_li = portalled_options.querySelector(`li`)
-  option_li?.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+  doc_query(selector).dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
   await tick()
 
-  // Dialog should still be open
   expect(props.open).toBe(true)
-  expect(document.querySelector(`dialog`)).not.toBe(null)
-
-  // Clean up
-  portalled_options.remove()
+  expect(document.querySelector(`dialog`)).toBeInstanceOf(HTMLDialogElement)
 })
 
-test(`!target.closest('ul.options') prevents premature closure`, async () => {
+test(`non-modal fallback closes on click of an unrelated page multiselect`, async () => {
+  const original_show_modal = Object.getOwnPropertyDescriptor(
+    HTMLDialogElement.prototype,
+    `showModal`,
+  )
+  // force the non-modal fallback so outside clicks land on real page elements (with a
+  // modal dialog they'd hit the backdrop instead, which is covered above)
+  HTMLDialogElement.prototype.showModal = vi.fn(() => {
+    throw new Error(`showModal unavailable`)
+  })
+  const other_multiselect = document.createElement(`div`)
+  other_multiselect.className = `multiselect`
+  document.body.append(other_multiselect)
   const props = $state({ open: true, actions: mock_actions, fade_duration: 0 })
-  mount(CmdPalette, { target: document.body, props })
-  await tick()
 
-  // Create nested ul.options structure to test closest() logic
-  const container = document.createElement(`div`)
-  container.innerHTML = `
-    <ul class="options">
-      <li><span>Nested option</span></li>
-    </ul>
-  `
-  document.body.append(container)
+  try {
+    mount(CmdPalette, { target: document.body, props })
+    await tick()
 
-  // Click on nested span inside ul.options
-  const span = container.querySelector(`span`)
-  span?.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
-  await tick()
+    other_multiselect.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+    await tick()
 
-  // Dialog should remain open due to !target.closest('ul.options') check
-  expect(props.open).toBe(true)
+    expect(props.open).toBe(false)
+  } finally {
+    other_multiselect.remove()
+    restore_show_modal(original_show_modal)
+  }
 })
+
+// clicks on portalled ul.options (rendered outside the dialog) must keep the palette open
+// via the target.closest('ul.options') check, both on a direct <li> and a nested descendant
+test.each([
+  [
+    `direct li child`,
+    `<ul class="options"><li>Option 1</li><li>Option 2</li></ul>`,
+    `li`,
+  ],
+  [
+    `nested element inside li`,
+    `<div><ul class="options"><li><span>Nested option</span></li></ul></div>`,
+    `span`,
+  ],
+])(
+  `keeps dialog open when clicking portalled options: %s`,
+  async (_label, html, click_selector) => {
+    const props = $state({ open: true, actions: mock_actions, fade_duration: 0 })
+    mount(CmdPalette, { target: document.body, props })
+    await tick()
+
+    const container = document.createElement(`div`)
+    container.innerHTML = html
+    document.body.append(container)
+
+    container
+      .querySelector(click_selector)
+      ?.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+    await tick()
+
+    expect(props.open).toBe(true)
+    expect(document.querySelector(`dialog`)).not.toBeNull()
+
+    container.remove()
+  },
+)
 
 test(`applies custom styles and props correctly`, async () => {
   const custom_class = `my-custom-class`
@@ -367,20 +411,6 @@ test.each([{ scenario: `empty actions array`, actions: [], should_have_options: 
     }
   },
 )
-
-test(`opens dialog with trigger key when closed`, async () => {
-  const props = $state({ open: false, actions: mock_actions, fade_duration: 0 })
-  mount(CmdPalette, { target: document.body, props })
-
-  expect(props.open).toBe(false)
-
-  // Trigger key should open dialog when closed
-  globalThis.dispatchEvent(new KeyboardEvent(`keydown`, { key: `k`, metaKey: true }))
-  await tick()
-
-  expect(props.open).toBe(true)
-  expect(document.querySelector(`dialog`)).toBeInstanceOf(HTMLDialogElement)
-})
 
 test(`ignores non-trigger events when dialog is closed`, async () => {
   const props = $state({ open: false, actions: mock_actions, fade_duration: 0 })
@@ -600,8 +630,8 @@ test(`handles bindable props correctly`, async () => {
   })
   mount(CmdPalette, { target: document.body, props })
 
-  expect(props.dialog).toBe(null)
-  expect(props.input).toBe(null)
+  expect(props.dialog).toBeNull()
+  expect(props.input).toBeNull()
 
   props.open = true
   await tick()
@@ -625,39 +655,6 @@ test(`handles action execution with different label types`, () => {
   expect(doc_query(`dialog ul.options li`)?.textContent).toContain(`simple action`)
 })
 
-test(`handles custom dialog styles`, () => {
-  const custom_style = `border: 2px solid red; padding: 10px;`
-  mount(CmdPalette, {
-    target: document.body,
-    props: {
-      open: true,
-      actions: mock_actions,
-      dialog_style: custom_style,
-      fade_duration: 0,
-    },
-  })
-
-  const dialog = doc_query<HTMLDialogElement>(`dialog`)
-  expect(dialog.style.border).toBe(`2px solid red`)
-  expect(dialog.style.padding).toBe(`10px`)
-})
-
-test(`handles custom placeholder text`, () => {
-  const custom_placeholder = `Search for actions...`
-  mount(CmdPalette, {
-    target: document.body,
-    props: {
-      open: true,
-      actions: mock_actions,
-      placeholder: custom_placeholder,
-      fade_duration: 0,
-    },
-  })
-
-  const input = doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
-  expect(input.placeholder).toBe(custom_placeholder)
-})
-
 // Grouping tests
 const grouped_actions = [
   { label: `New File`, action: vi.fn(), group: `File` },
@@ -675,7 +672,7 @@ test(`renders grouped actions with group headers`, async () => {
 
   // Check that group headers are rendered
   const group_headers = document.querySelectorAll(`dialog ul.options li.group-header`)
-  expect(group_headers.length).toBe(2)
+  expect(group_headers).toHaveLength(2)
 
   // Check group header text contains group names (headers include count like "File (2)")
   const header_texts = [...group_headers].map((header) => header.textContent?.trim())
@@ -686,7 +683,7 @@ test(`renders grouped actions with group headers`, async () => {
   const action_items = document.querySelectorAll(
     `dialog ul.options li:not(.group-header)`,
   )
-  expect(action_items.length).toBe(4)
+  expect(action_items).toHaveLength(4)
 })
 
 test(`ungrouped actions continue to work without group headers`, async () => {
@@ -698,39 +695,47 @@ test(`ungrouped actions continue to work without group headers`, async () => {
 
   // No group headers should be rendered for ungrouped actions
   const group_headers = document.querySelectorAll(`dialog ul.options li.group-header`)
-  expect(group_headers.length).toBe(0)
+  expect(group_headers).toHaveLength(0)
 
   // All actions should still be rendered
   const action_items = document.querySelectorAll(`dialog ul.options li`)
-  expect(action_items.length).toBe(mock_actions.length)
+  expect(action_items).toHaveLength(mock_actions.length)
 })
 
-test(`collapsibleGroups prop enables collapse functionality`, async () => {
-  // Start with File group already collapsed to verify prop passthrough
-  mount(CmdPalette, {
-    target: document.body,
-    props: {
-      open: true,
-      actions: grouped_actions,
-      collapsibleGroups: true,
-      collapsedGroups: new Set([`File`]),
-      fade_duration: 0,
-    },
-  })
-  await tick()
+test.each([
+  [`File`, `New File`],
+  [`Edit`, `Copy`],
+])(
+  `collapsedGroups collapses the %s group, hiding its options`,
+  async (collapsed_group, hidden_label) => {
+    mount(CmdPalette, {
+      target: document.body,
+      props: {
+        open: true,
+        actions: grouped_actions,
+        collapsibleGroups: true,
+        collapsedGroups: new Set([collapsed_group]),
+        fade_duration: 0,
+      },
+    })
+    await tick()
 
-  // Check aria-expanded attribute on group header to verify collapsibleGroups works
-  const file_header = [
-    ...document.querySelectorAll(`dialog ul.options li.group-header`),
-  ].find((header) => header.textContent?.includes(`File`))
-  expect(file_header?.getAttribute(`aria-expanded`)).toBe(`false`)
+    // collapsed group's header reports aria-expanded=false
+    const header = [
+      ...document.querySelectorAll(`dialog ul.options li.group-header`),
+    ].find((el) => el.textContent?.includes(collapsed_group))
+    expect(header?.getAttribute(`aria-expanded`)).toBe(`false`)
 
-  // File options should not be rendered when collapsed
-  const new_file_option = [...document.querySelectorAll(`dialog ul.options li`)].find(
-    (li) => li.textContent?.includes(`New File`),
-  )
-  expect(new_file_option).toBeUndefined()
-})
+    // its options are not rendered; only the other group's 2 options remain
+    const hidden_option = [...document.querySelectorAll(`dialog ul.options li`)].find(
+      (li) => li.textContent?.includes(hidden_label),
+    )
+    expect(hidden_option).toBeUndefined()
+    expect(
+      document.querySelectorAll(`dialog ul.options li:not(.group-header)`),
+    ).toHaveLength(2)
+  },
+)
 
 test(`groupSelectAll prop enables group selection in command palette`, async () => {
   mount(CmdPalette, {
@@ -746,7 +751,7 @@ test(`groupSelectAll prop enables group selection in command palette`, async () 
 
   // Group headers should have select-all functionality when enabled
   const group_headers = document.querySelectorAll(`dialog ul.options li.group-header`)
-  expect(group_headers.length).toBe(2)
+  expect(group_headers).toHaveLength(2)
 })
 
 test(`mixed grouped and ungrouped actions render correctly`, async () => {
@@ -764,35 +769,14 @@ test(`mixed grouped and ungrouped actions render correctly`, async () => {
 
   // Should have one group header for File group (header includes count like "File (2)")
   const group_headers = document.querySelectorAll(`dialog ul.options li.group-header`)
-  expect(group_headers.length).toBe(1)
+  expect(group_headers).toHaveLength(1)
   expect(group_headers[0].textContent?.trim()).toMatch(/^File/u)
 
   // All 4 actions should be rendered
   const action_items = document.querySelectorAll(
     `dialog ul.options li:not(.group-header)`,
   )
-  expect(action_items.length).toBe(4)
-})
-
-test(`collapsedGroups prop controls which groups start collapsed`, async () => {
-  // Test that Edit group can also be collapsed
-  mount(CmdPalette, {
-    target: document.body,
-    props: {
-      open: true,
-      actions: grouped_actions,
-      collapsibleGroups: true,
-      collapsedGroups: new Set([`Edit`]),
-      fade_duration: 0,
-    },
-  })
-  await tick()
-
-  // Edit group is collapsed, so only File group options (2) should be rendered
-  const visible_options = document.querySelectorAll(
-    `dialog ul.options li:not(.group-header)`,
-  )
-  expect(visible_options.length).toBe(2)
+  expect(action_items).toHaveLength(4)
 })
 
 // dropdown option labels in display order (used by shortcut/recents tests below)

--- a/tests/vitest/CmdPalette.svelte.test.ts
+++ b/tests/vitest/CmdPalette.svelte.test.ts
@@ -319,19 +319,11 @@ test(`non-modal fallback closes on click of an unrelated page multiselect`, asyn
   }
 })
 
-// clicks on portalled ul.options (rendered outside the dialog) must keep the palette open
-// via the target.closest('ul.options') check, both on a direct <li> and a nested descendant
+// clicks on this palette's portalled ul.options (rendered outside the dialog)
+// must keep the palette open, both on a direct <li> and a nested descendant
 test.each([
-  [
-    `direct li child`,
-    `<ul class="options"><li>Option 1</li><li>Option 2</li></ul>`,
-    `li`,
-  ],
-  [
-    `nested element inside li`,
-    `<div><ul class="options"><li><span>Nested option</span></li></ul></div>`,
-    `span`,
-  ],
+  [`direct li child`, `<li>Option 1</li><li>Option 2</li>`, `li`],
+  [`nested element inside li`, `<li><span>Nested option</span></li>`, `span`],
 ])(
   `keeps dialog open when clicking portalled options: %s`,
   async (_label, html, click_selector) => {
@@ -339,13 +331,19 @@ test.each([
     mount(CmdPalette, { target: document.body, props })
     await tick()
 
+    const input = doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
+    const real_listbox_id = input.getAttribute(`aria-controls`)
+    if (!real_listbox_id) throw new Error(`Palette input has no aria-controls listbox id`)
+    const listbox_id = `${real_listbox_id}-portalled`
+    input.setAttribute(`aria-controls`, listbox_id)
+
     const container = document.createElement(`div`)
-    container.innerHTML = html
+    container.innerHTML = `<ul class="options" id="${listbox_id}">${html}</ul>`
     document.body.append(container)
 
-    container
-      .querySelector(click_selector)
-      ?.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+    doc_query(`#${listbox_id} ${click_selector}`).dispatchEvent(
+      new MouseEvent(`click`, { bubbles: true }),
+    )
     await tick()
 
     expect(props.open).toBe(true)
@@ -354,6 +352,30 @@ test.each([
     container.remove()
   },
 )
+
+test(`closes dialog when clicking an unrelated portalled options list`, async () => {
+  const props = $state({ open: true, actions: mock_actions, fade_duration: 0 })
+  mount(CmdPalette, { target: document.body, props })
+  await tick()
+
+  const other_options = document.createElement(`ul`)
+  other_options.id = `unrelated-options`
+  other_options.className = `options`
+  other_options.innerHTML = `<li>Other option</li>`
+  document.body.append(other_options)
+
+  try {
+    doc_query(`#unrelated-options li`).dispatchEvent(
+      new MouseEvent(`click`, { bubbles: true }),
+    )
+    await tick()
+
+    expect(props.open).toBe(false)
+    expect(document.querySelector(`dialog`)).toBeNull()
+  } finally {
+    other_options.remove()
+  }
+})
 
 test(`applies custom styles and props correctly`, async () => {
   const custom_class = `my-custom-class`

--- a/tests/vitest/CodeExample.test.ts
+++ b/tests/vitest/CodeExample.test.ts
@@ -1,6 +1,7 @@
-import { CodeExample, CopyButton } from '$lib'
 import { mount, tick, unmount } from 'svelte'
 import { expect, test } from 'vite-plus/test'
+import CodeExample from '$lib/CodeExample.svelte'
+import CopyButton from '$lib/CopyButton.svelte'
 import { doc_query } from './index'
 
 const [id, src] = [`uniq-id`, `some code`]
@@ -10,6 +11,15 @@ const mount_global_copy_button = (props: Record<string, unknown> = {}) =>
     target: document.body,
     props: { global: true, ...props },
   })
+
+const append_code_block = (text: string) => {
+  const pre = document.createElement(`pre`)
+  const code = document.createElement(`code`)
+  code.textContent = text
+  pre.append(code)
+  document.body.append(pre)
+  return pre
+}
 
 test(`CodeExample toggles class .open on <pre> on button click`, async () => {
   const meta = { collapsible: true, id }
@@ -21,14 +31,21 @@ test(`CodeExample toggles class .open on <pre> on button click`, async () => {
 
   const toggle_button = doc_query<HTMLButtonElement>(`nav > button`)
   expect(toggle_button.textContent).toContain(`View code`)
-  expect(document.querySelector(`pre.open`)).toBeNull()
+  const pre_closed = doc_query<HTMLPreElement>(`pre`)
+  const closed_style = getComputedStyle(pre_closed)
+  expect(pre_closed.classList.contains(`open`)).toBe(false)
+  expect(closed_style.maxHeight).toBe(`0`)
+  expect(closed_style.overflow).toBe(`hidden`)
 
   toggle_button.click()
   await tick()
 
   const pre = doc_query<HTMLPreElement>(`pre.open`)
+  const open_style = getComputedStyle(pre)
   expect(pre).toBeInstanceOf(HTMLElement)
   expect(doc_query(`pre.open > code`).textContent).toBe(src)
+  expect(open_style.overflowX).toBe(`auto`)
+  expect(open_style.overflowY).toBe(`auto`)
   expect(toggle_button.textContent).toContain(`Close`)
 })
 
@@ -38,38 +55,28 @@ test(`renders a <pre> with the src`, () => {
   expect(doc_query(`pre > code`).textContent).toBe(src)
 })
 
-test(`renders links in nav when repl is provided`, () => {
-  const meta = { collapsible: true, repl: `https://svelte.dev/playground` }
-  mount(CodeExample, { target: document.body, props: { src, meta } })
-
-  const repl_link = document.querySelector(`nav a[href="${meta.repl}"]`)
-  expect(repl_link).toBeInstanceOf(HTMLAnchorElement)
-  expect(repl_link?.getAttribute(`target`)).toBe(`_blank`)
-})
-
-test(`renders GitHub link when github and repo are provided`, () => {
-  const meta = {
-    collapsible: true,
-    github: true,
-    repo: `https://github.com/janosh/svelte-multiselect`,
-    file: `src/lib/CodeExample.svelte`,
-  }
-  mount(CodeExample, { target: document.body, props: { src, meta } })
-
-  const github_link = document.querySelector(`nav a[href*="github.com"]`)
-  expect(github_link).toBeInstanceOf(HTMLAnchorElement)
-  expect(github_link?.getAttribute(`target`)).toBe(`_blank`)
-})
-
-test(`collapsed pre has no padding or margin to avoid layout space leak`, () => {
-  const meta = { collapsible: true, id }
+test.each([
+  [
+    `REPL`,
+    { collapsible: true, repl: `https://svelte.dev/playground` },
+    `nav a[href="https://svelte.dev/playground"]`,
+  ],
+  [
+    `GitHub`,
+    {
+      collapsible: true,
+      github: true,
+      repo: `https://github.com/janosh/svelte-multiselect`,
+      file: `src/lib/CodeExample.svelte`,
+    },
+    `nav a[href*="github.com"]`,
+  ],
+] as const)(`renders %s link in nav`, (_label, meta, selector) => {
   mount(CodeExample, { target: document.body, props: { meta, src } })
 
-  const pre = doc_query<HTMLPreElement>(`pre`)
-  expect(pre.classList.contains(`open`)).toBe(false)
-  const style = getComputedStyle(pre)
-  expect(style.maxHeight).toBe(`0`)
-  expect(style.overflow).toBe(`hidden`)
+  const link = doc_query<HTMLAnchorElement>(selector)
+  expect(link).toBeInstanceOf(HTMLAnchorElement)
+  expect(link.getAttribute(`target`)).toBe(`_blank`)
 })
 
 test.each([`typescript`, `css`, `python`])(
@@ -92,20 +99,10 @@ test(`lang-label is omitted when meta.lang is unset`, () => {
 })
 
 test(`dynamically added pre > code elements get copy buttons applied`, async () => {
-  // Mount a CopyButton with global enabled to activate MutationObserver
   const copy_button_component = mount_global_copy_button()
-
-  // Create a new pre > code element dynamically
-  const new_pre = document.createElement(`pre`)
-  const new_code = document.createElement(`code`)
-  new_code.textContent = `dynamically added code`
-  new_pre.append(new_code)
-
-  // Add it to the DOM
-  document.body.append(new_pre)
+  const new_pre = append_code_block(`dynamically added code`)
   await tick()
 
-  // Verify that a copy button was added to the new pre element
   const copy_button = new_pre.querySelector(`button`)
   expect(copy_button).toBeInstanceOf(HTMLButtonElement)
   expect(copy_button?.style.position).toBe(`absolute`)
@@ -113,26 +110,16 @@ test(`dynamically added pre > code elements get copy buttons applied`, async () 
 })
 
 test(`prevents duplicate copy buttons when as !== button`, async () => {
-  // Mount a CopyButton with global enabled and as='a' to test duplicate prevention
   const copy_button_component = mount_global_copy_button({ as: `a` })
-
-  // Create a pre > code element
-  const pre = document.createElement(`pre`)
-  const code = document.createElement(`code`)
-  code.textContent = `test code`
-  pre.append(code)
-  document.body.append(pre)
+  const pre = append_code_block(`test code`)
   await tick()
 
-  // Verify only one copy button (anchor) was created
   const copy_buttons = pre.querySelectorAll(`a[data-sms-copy]`)
   expect(copy_buttons).toHaveLength(1)
 
-  // Trigger MutationObserver again by modifying the pre element
   pre.setAttribute(`data-test`, `modified`)
   await tick()
 
-  // Verify no duplicate was created
   const copy_buttons_after = pre.querySelectorAll(`a[data-sms-copy]`)
   expect(copy_buttons_after).toHaveLength(1)
   void unmount(copy_button_component)

--- a/tests/vitest/FileDetails.svelte.test.ts
+++ b/tests/vitest/FileDetails.svelte.test.ts
@@ -11,9 +11,9 @@ test(`FileDetails renders files in ordered list with titles and contents`, () =>
   mount(FileDetails, { target: document.body, props: { files } })
 
   // Check structure: ordered list with details elements
-  expect(doc_query(`ol`).children.length).toBe(2)
-  expect(document.querySelectorAll(`li > details`).length).toBe(2)
-  expect(document.querySelectorAll(`summary`).length).toBe(2)
+  expect(doc_query(`ol`).children).toHaveLength(2)
+  expect(document.querySelectorAll(`li > details`)).toHaveLength(2)
+  expect(document.querySelectorAll(`summary`)).toHaveLength(2)
 
   // Check titles and contents
   const summaries = document.querySelectorAll(`summary`)
@@ -140,7 +140,8 @@ test(`toggle all button opens, closes, and handles partial open state`, async ()
   expect(all_closed()).toBe(true) // closed all
 
   // partial open state: clicking closes all
-  details[0].open = details[1].open = true
+  details[0].open = true
+  details[1].open = true
   btn.click()
   expect(all_closed()).toBe(true)
 })
@@ -212,7 +213,7 @@ test(`node refs are trimmed when files are removed to prevent memory leaks`, asy
   await tick()
 
   // All 3 files should have node refs
-  expect(document.querySelectorAll(`details`).length).toBe(3)
+  expect(document.querySelectorAll(`details`)).toHaveLength(3)
   for (const file of reactive_files) {
     expect(file.node).toBeInstanceOf(HTMLDetailsElement)
   }
@@ -227,8 +228,8 @@ test(`node refs are trimmed when files are removed to prevent memory leaks`, asy
   await tick()
 
   // Only 2 files should remain with valid node refs
-  expect(document.querySelectorAll(`details`).length).toBe(2)
-  expect(reactive_files.length).toBe(2)
+  expect(document.querySelectorAll(`details`)).toHaveLength(2)
+  expect(reactive_files).toHaveLength(2)
   for (const file of reactive_files) {
     expect(file.node).toBeInstanceOf(HTMLDetailsElement)
   }

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -306,7 +306,7 @@ test(`value is null when maxSelect=1 and no option is preselected`, () => {
     props: { options: [1, 2, 3], maxSelect: 1 },
   })
 
-  expect(select.value).toBe(null)
+  expect(select.value).toBeNull()
 })
 
 test.each([[null], [1]])(`2-way binding of value updates selected`, async (maxSelect) => {
@@ -316,13 +316,13 @@ test.each([[null], [1]])(`2-way binding of value updates selected`, async (maxSe
   })
 
   // On init, value stays null (no unnecessary sync from null to []). See issue #369.
-  expect(select.value).toEqual(null)
+  expect(select.value).toBeNull()
 
   await tick()
   if (maxSelect === 1) {
     select.value = 2
     await tick()
-    expect(select.value).toEqual(2)
+    expect(select.value).toBe(2)
     expect(select.selected).toEqual([2])
   } else {
     select.value = [1, 2]
@@ -473,7 +473,7 @@ describe(`selectedDisplay=input`, () => {
     expect(input.value).toBe(`Reddish`)
     expect(select.searchText).toBe(`Reddish`)
     expect(select.selected).toEqual([])
-    expect(select.value).toBe(null)
+    expect(select.value).toBeNull()
   })
 
   test(`typing exact option label does not auto-select without explicit commit`, async () => {
@@ -487,7 +487,7 @@ describe(`selectedDisplay=input`, () => {
 
     expect(select.searchText).toBe(`Red`)
     expect(select.selected).toEqual([])
-    expect(select.value).toBe(null)
+    expect(select.value).toBeNull()
   })
 
   test(`programmatic value update and clear syncs visible input text`, async () => {
@@ -516,7 +516,7 @@ describe(`selectedDisplay=input`, () => {
     expect(select.selected).toEqual([])
   })
 
-  const reopen_cases: Array<[string, (input: HTMLInputElement) => Promise<void>]> = [
+  const reopen_cases: [string, (input: HTMLInputElement) => Promise<void>][] = [
     [`caret click`, click_expand_icon],
     [
       `input focus`,
@@ -618,7 +618,7 @@ describe(`selectedDisplay=input`, () => {
     expect(document.querySelector(`ul.options > li.selected`)).toBeNull()
     expect(select.searchText).toBe(`Bl`)
     expect(select.selected).toEqual([])
-    expect(select.value).toBe(null)
+    expect(select.value).toBeNull()
 
     await click_expand_icon()
 
@@ -659,7 +659,7 @@ describe(`selectedDisplay=input`, () => {
     expect(option_labels()).toEqual(color_options)
     expect(document.querySelector(`ul.options li.user-msg`)).toBeNull()
     expect(select.selected).toEqual([])
-    expect(select.value).toBe(null)
+    expect(select.value).toBeNull()
 
     await click_expand_icon()
 
@@ -727,7 +727,7 @@ describe(`selectedDisplay=input`, () => {
     expect(input.value).toBe(`Re`)
     expect(select.searchText).toBe(`Re`)
     expect(select.selected).toEqual([])
-    expect(select.value).toBe(null)
+    expect(select.value).toBeNull()
     expect(document.querySelectorAll(`ul.selected > li.highlighted`)).toHaveLength(0)
     expect(input.getAttribute(`aria-activedescendant`)).toBeNull()
   })
@@ -1091,7 +1091,7 @@ test(`invalid=true gives top-level div class 'invalid' and input attribute of 'a
   option_li.click()
   await tick()
 
-  expect(input.getAttribute(`aria-invalid`)).toBe(null)
+  expect(input.getAttribute(`aria-invalid`)).toBeNull()
 
   // assert div.multiselect no longer has invalid class
   expect(multiselect.classList.contains(`invalid`)).toBe(false)
@@ -1243,7 +1243,7 @@ describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
     const options = document.querySelectorAll<HTMLLIElement>(
       `ul.options > li[role="option"]`,
     )
-    expect(options.length).toBe(3)
+    expect(options).toHaveLength(3)
 
     options.forEach((option, idx) => {
       expect(option.getAttribute(`aria-posinset`)).toBe(`${idx + 1}`)
@@ -1621,7 +1621,7 @@ test(`remove all button removes all selected options and is visible only if more
     props: { options: [1, 2, 3], selected: [1, 2, 3] },
   })
   let selected_ul = doc_query(`ul.selected`)
-  expect(selected_ul.textContent?.trim()).toEqual(`1 2 3`)
+  expect(selected_ul.textContent?.trim()).toBe(`1 2 3`)
 
   const remove_all_btn_selector = `button[title='Remove all']`
   let remove_all_btn = document.querySelector<HTMLButtonElement>(remove_all_btn_selector)
@@ -1636,7 +1636,7 @@ test(`remove all button removes all selected options and is visible only if more
   }
 
   selected_ul = doc_query(`ul.selected`)
-  expect(selected_ul.textContent?.trim()).toEqual(``)
+  expect(selected_ul.textContent?.trim()).toBe(``)
   document.body.innerHTML = `` // Clean up for next mount
 
   // Scenario 2: Single item selected, button is not visible
@@ -1710,7 +1710,7 @@ test(`can't select disabled options`, async () => {
 
   const selected_ul = doc_query(`ul.selected`)
 
-  expect(selected_ul.textContent?.trim()).toEqual(`2 3`)
+  expect(selected_ul.textContent?.trim()).toBe(`2 3`)
 })
 
 test.each([2, 5, 10])(
@@ -2275,7 +2275,7 @@ describe(`arrow key navigation between selected items`, () => {
     expect(is_highlighted(2)).toBe(true)
     input.dispatchEvent(press(`ArrowRight`)) // clears
     await tick()
-    expect(highlighted().length).toBe(0)
+    expect(highlighted()).toHaveLength(0)
   })
 
   test(`Backspace removes highlighted item and highlight stays at same index`, async () => {
@@ -2284,7 +2284,7 @@ describe(`arrow key navigation between selected items`, () => {
     input.dispatchEvent(press(`ArrowLeft`)) // Green (idx 1)
     input.dispatchEvent(press(`Backspace`))
     await tick()
-    expect(selected_items().length).toBe(2)
+    expect(selected_items()).toHaveLength(2)
     expect(selected_items()[0]?.textContent).toContain(`Red`)
     expect(selected_items()[1]?.textContent).toContain(`Blue`)
     // highlight should stay at idx 1 (Blue), not jump to idx 0 (Red)
@@ -2299,21 +2299,21 @@ describe(`arrow key navigation between selected items`, () => {
     await tick()
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
-    expect(highlighted().length).toBe(0)
+    expect(highlighted()).toHaveLength(0)
   })
 
   test(`ArrowLeft is no-op with no selected items`, async () => {
     const input = setup([])
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
-    expect(highlighted().length).toBe(0)
+    expect(highlighted()).toHaveLength(0)
   })
 
   test(`ArrowRight is no-op without prior highlight`, async () => {
     const input = setup()
     input.dispatchEvent(press(`ArrowRight`))
     await tick()
-    expect(highlighted().length).toBe(0)
+    expect(highlighted()).toHaveLength(0)
   })
 
   test(`Backspace without highlight removes last item`, async () => {
@@ -2331,7 +2331,7 @@ describe(`arrow key navigation between selected items`, () => {
     for (let step = 0; step < 3; step++) input.dispatchEvent(press(`ArrowLeft`))
     input.dispatchEvent(press(`Backspace`))
     await tick()
-    expect(selected_items().length).toBe(2)
+    expect(selected_items()).toHaveLength(2)
     expect(is_highlighted(0)).toBe(true)
     expect(selected_items()[0]?.textContent).toContain(`Green`)
   })
@@ -2341,8 +2341,8 @@ describe(`arrow key navigation between selected items`, () => {
     input.dispatchEvent(press(`ArrowLeft`))
     input.dispatchEvent(press(`Backspace`))
     await tick()
-    expect(selected_items().length).toBe(0)
-    expect(highlighted().length).toBe(0)
+    expect(selected_items()).toHaveLength(0)
+    expect(highlighted()).toHaveLength(0)
   })
 
   test.each([`Escape`, `ArrowDown`, `ArrowUp`, `Tab`, `Enter`, `a`])(
@@ -2351,10 +2351,10 @@ describe(`arrow key navigation between selected items`, () => {
       const input = setup()
       input.dispatchEvent(press(`ArrowLeft`))
       await tick()
-      expect(highlighted().length).toBe(1)
+      expect(highlighted()).toHaveLength(1)
       input.dispatchEvent(press(key))
       await tick()
-      expect(highlighted().length).toBe(0)
+      expect(highlighted()).toHaveLength(0)
     },
   )
 
@@ -2370,7 +2370,7 @@ describe(`arrow key navigation between selected items`, () => {
       .at(-1)
       ?.click()
     await tick()
-    expect(highlighted().length).toBe(0)
+    expect(highlighted()).toHaveLength(0)
   })
 
   test(`remove-all button clears highlight`, async () => {
@@ -2382,8 +2382,8 @@ describe(`arrow key navigation between selected items`, () => {
     expect(is_highlighted(0)).toBe(true)
     doc_query(`button.remove-all`).click()
     await tick()
-    expect(selected_items().length).toBe(1)
-    expect(highlighted().length).toBe(0)
+    expect(selected_items()).toHaveLength(1)
+    expect(highlighted()).toHaveLength(0)
   })
 
   test(`consecutive Backspace removals track highlight correctly`, async () => {
@@ -2393,12 +2393,12 @@ describe(`arrow key navigation between selected items`, () => {
     input.dispatchEvent(press(`ArrowLeft`)) // idx 0 (Red)
     input.dispatchEvent(press(`Backspace`)) // remove Red, highlight stays at 0
     await tick()
-    expect(selected_items().length).toBe(2)
+    expect(selected_items()).toHaveLength(2)
     expect(selected_items()[0]?.textContent).toContain(`Green`)
     expect(is_highlighted(0)).toBe(true)
     input.dispatchEvent(press(`Backspace`)) // remove Green, highlight stays at 0
     await tick()
-    expect(selected_items().length).toBe(1)
+    expect(selected_items()).toHaveLength(1)
     expect(selected_items()[0]?.textContent).toContain(`Blue`)
     expect(is_highlighted(0)).toBe(true)
   })
@@ -2410,7 +2410,7 @@ describe(`arrow key navigation between selected items`, () => {
     input.dispatchEvent(press(`ArrowLeft`)) // idx 2 (second Red)
     input.dispatchEvent(press(`Backspace`))
     await tick()
-    expect(selected_items().length).toBe(2)
+    expect(selected_items()).toHaveLength(2)
     // first Red (idx 0) should survive, Blue (idx 1) should survive
     expect(selected_items()[0]?.textContent).toContain(`Red`)
     expect(selected_items()[1]?.textContent).toContain(`Blue`)
@@ -2420,11 +2420,11 @@ describe(`arrow key navigation between selected items`, () => {
     const input = setup()
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
-    expect(highlighted().length).toBe(1)
+    expect(highlighted()).toHaveLength(1)
     input.blur()
     input.focus()
     await tick()
-    expect(highlighted().length).toBe(0)
+    expect(highlighted()).toHaveLength(0)
   })
 
   test(`external selected shrink clamps highlighted_idx`, async () => {
@@ -2441,7 +2441,7 @@ describe(`arrow key navigation between selected items`, () => {
     // externally shrink to 2 items — idx 2 is out of bounds
     props.selected = [`Red`, `Green`]
     await tick()
-    expect(selected_items().length).toBe(2)
+    expect(selected_items()).toHaveLength(2)
     // $effect should clamp to last valid index (1)
     expect(is_highlighted(1)).toBe(true)
   })
@@ -2455,10 +2455,10 @@ describe(`arrow key navigation between selected items`, () => {
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
-    expect(highlighted().length).toBe(1)
+    expect(highlighted()).toHaveLength(1)
     props.selected = []
     await tick()
-    expect(highlighted().length).toBe(0)
+    expect(highlighted()).toHaveLength(0)
   })
 
   test(`highlighted pill does not set aria-activedescendant`, async () => {
@@ -2475,20 +2475,20 @@ describe(`arrow key navigation between selected items`, () => {
     const input = setup()
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
-    expect(highlighted().length).toBe(1)
+    expect(highlighted()).toHaveLength(1)
     expect(input.getAttribute(`aria-activedescendant`)).toBeNull()
     input.dispatchEvent(press(`Escape`))
     await tick()
     // should revert to null/undefined (no active dropdown option either since dropdown closed)
-    expect(highlighted().length).toBe(0)
+    expect(highlighted()).toHaveLength(0)
     expect(input.getAttribute(`aria-activedescendant`)).toBeNull()
   })
 
   test(`each selected <li> has a stable id`, () => {
     setup()
     const items = selected_items()
-    for (let idx = 0; idx < items.length; idx++) {
-      expect(items[idx]?.id).toMatch(/-selected-\d+$/u)
+    for (const item of items) {
+      expect(item.id).toMatch(/-selected-\d+$/u)
     }
     // ids should be unique
     const ids = [...items].map((li) => li.id)
@@ -3684,11 +3684,9 @@ test.each([true, false, `if-mobile`] as const)(
       expect(dropdown.classList.contains(`hidden`), state).toBe(should_be_closed)
       // focus tracking is reliable only for the close path in happy-dom
       if (should_be_closed) {
-        expect(document.activeElement === input_el).toBe(false)
+        expect(document.activeElement).not.toBe(input_el)
       } else {
-        expect(
-          document.activeElement === input_el || document.activeElement === document.body,
-        ).toBe(true)
+        expect([input_el, document.body]).toContain(document.activeElement)
       }
 
       if (closeDropdownOnSelect === `if-mobile`) {
@@ -3707,7 +3705,7 @@ test.each([true, false, `if-mobile`] as const)(
         await tick()
         // On mobile (when closeDropdownOnSelect = 'if-mobile'), dropdown should close, input should lose focus
         expect(dropdown.classList).toContain(`hidden`) // Now it should be closed
-        expect(document.activeElement === input_el).toBe(false)
+        expect(document.activeElement).not.toBe(input_el)
       }
     } finally {
       globalThis.innerWidth = original_inner_width
@@ -4230,8 +4228,8 @@ describe(`loadOptions feature`, () => {
   type LoadResult = { options: string[]; hasMore: boolean }
 
   function deferred_load() {
-    const resolvers: Array<(val: LoadResult) => void> = []
-    const rejectors: Array<(err: Error) => void> = []
+    const resolvers: ((val: LoadResult) => void)[] = []
+    const rejectors: ((err: Error) => void)[] = []
     const fn = vi.fn(
       () =>
         new Promise<LoadResult>((resolve, reject) => {
@@ -5159,9 +5157,10 @@ describe(`binding update event count`, () => {
 
 describe(`CSS static analysis`, () => {
   const component_source = readFileSync(`src/lib/MultiSelect.svelte`, `utf-8`)
-  const css = /<style>([\s\S]*?)<\/style>/u.exec(component_source)?.[1] ?? ``
-  const get_css_block = (pattern: RegExp) => pattern.exec(css)?.[1] ?? ``
-  const options_block = get_css_block(/:where\(ul\.options\)\s*\{([\s\S]*?)\}/u)
+  const css =
+    /<style>(?<style>[\s\S]*?)<\/style>/u.exec(component_source)?.groups?.style ?? ``
+  const get_css_block = (pattern: RegExp) => pattern.exec(css)?.groups?.block ?? ``
+  const options_block = get_css_block(/:where\(ul\.options\)\s*\{(?<block>[\s\S]*?)\}/u)
 
   const props = [
     `--sms-border`,
@@ -5202,7 +5201,7 @@ describe(`CSS static analysis`, () => {
 
   test(`default-icon buttons enforce circle via min-height: 0 + overflow: hidden`, () => {
     const default_icon_block = get_css_block(
-      /:is\(div\.multiselect button\.default-icon\)\s*\{([\s\S]*?)\}/u,
+      /:is\(div\.multiselect button\.default-icon\)\s*\{(?<block>[\s\S]*?)\}/u,
     )
     expect(default_icon_block).toMatch(/min-height:\s*0/u)
     expect(default_icon_block).toMatch(/overflow:\s*hidden/u)
@@ -5221,7 +5220,7 @@ describe(`CSS static analysis`, () => {
 
   test(`custom-snippet remove-all overrides circular defaults`, () => {
     const custom_remove_all = get_css_block(
-      /:is\(div\.multiselect button\.remove-all:not\(\.default-icon\)\)\s*\{([\s\S]*?)\}/u,
+      /:is\(div\.multiselect button\.remove-all:not\(\.default-icon\)\)\s*\{(?<block>[\s\S]*?)\}/u,
     )
     expect(custom_remove_all).toMatch(/border-radius:\s*3pt/u)
     expect(custom_remove_all).toMatch(/aspect-ratio:\s*auto/u)
@@ -5368,7 +5367,7 @@ describe(`option grouping feature`, () => {
     const after_expand_options = document.querySelectorAll(
       `ul.options > li:not(.group-header)`,
     )
-    expect(after_expand_options.length).toBe(initial_count)
+    expect(after_expand_options).toHaveLength(initial_count)
   })
 
   test(`groupSelectAll adds select all button to group headers`, async () => {
@@ -5648,12 +5647,12 @@ describe(`option grouping feature`, () => {
     [
       `Genre`,
       undefined,
-      (opts: Array<{ group?: string }>) => opts.every((o) => o.group !== `Genre`),
+      (opts: { group?: string }[]) => opts.every((o) => o.group !== `Genre`),
     ],
     [
       `Key`,
       2,
-      (opts: Array<{ group?: string }>) =>
+      (opts: { group?: string }[]) =>
         opts.length === 2 && opts.every((o) => o.group !== `Key`),
     ],
   ] as const)(
@@ -5718,7 +5717,7 @@ describe(`option grouping feature`, () => {
     await tick()
 
     const after_space = document.querySelectorAll(`ul.options > li:not(.group-header)`)
-    expect(after_space.length).toBe(initial_count)
+    expect(after_space).toHaveLength(initial_count)
   })
 
   test(`groupSelectAll skips disabled options`, async () => {
@@ -7449,7 +7448,7 @@ describe(`history / undo-redo`, () => {
     await tick() // Select first option so there's something to undo
     document.querySelector<HTMLElement>(`ul.options > li`)?.click()
     await tick()
-    expect(selected.length).toBe(1)
+    expect(selected).toHaveLength(1)
 
     // Use autocomplete input (the interactive one), not the hidden form-control
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
@@ -7459,7 +7458,7 @@ describe(`history / undo-redo`, () => {
     )
     await tick()
 
-    expect(selected.length).toBe(should_undo ? 0 : 1)
+    expect(selected).toHaveLength(should_undo ? 0 : 1)
   })
 
   test.each([
@@ -7695,7 +7694,7 @@ describe(`case-variant labels (issue #391)`, () => {
   ])(`renders all $desc with case-variant labels`, ({ options }) => {
     mount(MultiSelect, { target: document.body, props: { options } })
     const items = document.querySelectorAll(`ul.options > li`)
-    expect(items.length).toBe(3)
+    expect(items).toHaveLength(3)
   })
 
   test(`can select multiple case-variant options`, async () => {
@@ -7719,7 +7718,7 @@ describe(`case-variant labels (issue #391)`, () => {
       await tick()
     }
 
-    expect(selected.length).toBe(3)
+    expect(selected).toHaveLength(3)
     expect(selected.map((opt) => opt.label)).toEqual([`pd`, `PD`, `Pd`])
   })
 })
@@ -7825,7 +7824,7 @@ describe(`duplicates prop variants`, () => {
 
     // Should show 2 remaining options (same label, different values)
     const visible_options = document.querySelectorAll(`ul.options > li`)
-    expect(visible_options.length).toBe(2) // Click second option - should work since it has different value
+    expect(visible_options).toHaveLength(2) // Click second option - should work since it has different value
     if (visible_options[0] instanceof HTMLElement) visible_options[0].click()
     await tick()
 

--- a/tests/vitest/ThemeToggle.test.ts
+++ b/tests/vitest/ThemeToggle.test.ts
@@ -3,21 +3,9 @@ import { mount, tick } from 'svelte'
 import { beforeEach, expect, test, vi } from 'vite-plus/test'
 import { doc_query } from './index.ts'
 
-// happy-dom's localStorage may lack standard methods — provide a minimal shim
-const storage = new Map<string, string>()
-Object.defineProperty(globalThis, `localStorage`, {
-  value: {
-    getItem: (key: string) => storage.get(key) ?? null,
-    setItem: (key: string, val: string) => storage.set(key, val),
-    removeItem: (key: string) => storage.delete(key),
-    clear: () => storage.clear(),
-  },
-  writable: true,
-})
-
 beforeEach(() => {
   vi.restoreAllMocks()
-  storage.clear()
+  localStorage.clear()
   document.documentElement.style.colorScheme = ``
   delete document.documentElement.dataset.theme
 })
@@ -28,7 +16,7 @@ const mount_theme_toggle = async () => {
   return doc_query<HTMLButtonElement>(`button`)
 }
 
-const expect_applied_theme = (effective: `light` | `dark`) => {
+const expectAppliedTheme = (effective: `light` | `dark`) => {
   expect(document.documentElement.style.colorScheme).toBe(effective)
   expect(document.documentElement.dataset.theme).toBe(effective)
 }
@@ -52,7 +40,7 @@ test.each([
   async ({ storage_key, stored, effective }) => {
     localStorage.setItem(storage_key, stored)
     await mount_theme_toggle()
-    expect_applied_theme(effective)
+    expectAppliedTheme(effective)
   },
 )
 
@@ -66,33 +54,33 @@ test(`gracefully degrades when localStorage throws`, async () => {
 
   const button = await mount_theme_toggle()
   expect(button.style.visibility).toBe(`visible`)
-  expect_applied_theme(`light`)
+  expectAppliedTheme(`light`)
 
   button.click()
   await tick()
-  expect_applied_theme(`dark`)
+  expectAppliedTheme(`dark`)
 })
 
 test(`click cycles through light -> system -> dark -> light`, async () => {
   localStorage.setItem(`theme`, `light`)
   const button = await mount_theme_toggle()
-  expect_applied_theme(`light`)
+  expectAppliedTheme(`light`)
 
   // light -> system (resolves to light via mock with matches: false)
   button.click()
   await tick()
   expect(localStorage.getItem(`theme`)).toBe(`system`)
-  expect_applied_theme(`light`)
+  expectAppliedTheme(`light`)
 
   // system -> dark
   button.click()
   await tick()
   expect(localStorage.getItem(`theme`)).toBe(`dark`)
-  expect_applied_theme(`dark`)
+  expectAppliedTheme(`dark`)
 
   // dark -> light
   button.click()
   await tick()
   expect(localStorage.getItem(`theme`)).toBe(`light`)
-  expect_applied_theme(`light`)
+  expectAppliedTheme(`light`)
 })

--- a/tests/vitest/ThemeToggle.test.ts
+++ b/tests/vitest/ThemeToggle.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, expect, test, vi } from 'vite-plus/test'
 import { doc_query } from './index.ts'
 
 beforeEach(() => {
-  vi.restoreAllMocks()
   localStorage.clear()
   document.documentElement.style.colorScheme = ``
   delete document.documentElement.dataset.theme
@@ -45,10 +44,10 @@ test.each([
 )
 
 test(`gracefully degrades when localStorage throws`, async () => {
-  vi.spyOn(localStorage, `getItem`).mockImplementation(() => {
+  vi.spyOn(Storage.prototype, `getItem`).mockImplementation(() => {
     throw new DOMException(`storage disabled`)
   })
-  vi.spyOn(localStorage, `setItem`).mockImplementation(() => {
+  vi.spyOn(Storage.prototype, `setItem`).mockImplementation(() => {
     throw new DOMException(`storage disabled`)
   })
 

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -380,7 +380,7 @@ describe(`tooltip`, () => {
         current = child
       }
       setup_tooltip(parent)
-      expect(parent.querySelectorAll(`[data-original-title]`).length).toBe(5)
+      expect(parent.querySelectorAll(`[data-original-title]`)).toHaveLength(5)
     })
 
     it(`should not setup children added after initialization`, () => {
@@ -477,7 +477,9 @@ describe(`tooltip`, () => {
       const scroll_event = new Event(`scroll`, { bubbles: true })
       Object.defineProperty(scroll_event, `target`, { value: get_target() })
       globalThis.dispatchEvent(scroll_event)
-      expect(!!document.querySelector(`.custom-tooltip`)).toBe(should_persist)
+      expect(document.querySelector(`.custom-tooltip`)).toEqual(
+        should_persist ? expect.any(HTMLDivElement) : null,
+      )
     })
 
     it(`scroll from ancestor hides tooltip`, () => {
@@ -510,7 +512,7 @@ describe(`tooltip`, () => {
       trigger_tooltip(el1)
       trigger_tooltip(el2)
 
-      expect(document.querySelectorAll(`.custom-tooltip`).length).toBe(1)
+      expect(document.querySelectorAll(`.custom-tooltip`)).toHaveLength(1)
       expect(doc_query(`.custom-tooltip`).textContent).toContain(`tooltip2`)
     })
 
@@ -634,7 +636,9 @@ describe(`tooltip`, () => {
       expect(doc_query(`.custom-tooltip`)).toBeInstanceOf(HTMLElement)
 
       element.dispatchEvent(new MouseEvent(`mouseleave`, { bubbles: true }))
-      expect(!!document.querySelector(`.custom-tooltip`)).toBe(visible_after_leave)
+      expect(document.querySelector(`.custom-tooltip`)).toEqual(
+        visible_after_leave ? expect.any(HTMLDivElement) : null,
+      )
 
       if (delay_ms > 0) {
         vi.advanceTimersByTime(delay_ms)
@@ -682,7 +686,9 @@ describe(`tooltip`, () => {
       expect(doc_query(`.custom-tooltip`)).toBeInstanceOf(HTMLElement)
 
       document.dispatchEvent(new KeyboardEvent(`keydown`, { key }))
-      expect(!!document.querySelector(`.custom-tooltip`)).toBe(should_remain)
+      expect(document.querySelector(`.custom-tooltip`)).toEqual(
+        should_remain ? expect.any(HTMLDivElement) : null,
+      )
     })
 
     it.each([
@@ -697,7 +703,8 @@ describe(`tooltip`, () => {
       trigger_tooltip(element)
 
       const tooltip_el = doc_query(`.custom-tooltip`)
-      expect(!!tooltip_el.querySelector(`.custom-tooltip-arrow`)).toBe(expect_arrow)
+      const arrow = tooltip_el.querySelector(`.custom-tooltip-arrow`)
+      expect(arrow).toEqual(expect_arrow ? expect.any(HTMLDivElement) : null)
     })
 
     it(`manages aria-describedby on show/hide`, () => {

--- a/tests/vitest/heading-anchors.test.ts
+++ b/tests/vitest/heading-anchors.test.ts
@@ -191,7 +191,7 @@ describe(`heading_anchors attachment`, () => {
       )
       heading_anchors()(container)
       heading_anchors()(container) // call twice to test duplicate prevention
-      expect(container.querySelectorAll(anchor_selector).length).toBe(3)
+      expect(container.querySelectorAll(anchor_selector)).toHaveLength(3)
     })
   })
 
@@ -227,7 +227,9 @@ describe(`heading_anchors attachment`, () => {
     ])(`%s → matched: %s`, (_desc, html, id_sel, should_match) => {
       const container = create_container(html)
       heading_anchors()(container)
-      expect(!!document.querySelector(`${id_sel} ${anchor_selector}`)).toBe(should_match)
+      const anchor = document.querySelector(`${id_sel} ${anchor_selector}`)
+      if (should_match) expect(anchor).toBeInstanceOf(HTMLAnchorElement)
+      else expect(anchor).toBeNull()
     })
   })
 
@@ -305,8 +307,12 @@ describe(`heading_anchors attachment`, () => {
     ])(`selector %s`, (_desc, selector, html, sel1, match1, sel2, match2) => {
       const container = create_container(html)
       heading_anchors({ selector })(container)
-      expect(!!container.querySelector(`${sel1} ${anchor_selector}`)).toBe(match1)
-      expect(!!container.querySelector(`${sel2} ${anchor_selector}`)).toBe(match2)
+      const anchor1 = container.querySelector(`${sel1} ${anchor_selector}`)
+      const anchor2 = container.querySelector(`${sel2} ${anchor_selector}`)
+      if (match1) expect(anchor1).toBeInstanceOf(HTMLAnchorElement)
+      else expect(anchor1).toBeNull()
+      if (match2) expect(anchor2).toBeInstanceOf(HTMLAnchorElement)
+      else expect(anchor2).toBeNull()
     })
 
     it(`icon_svg customizes icon, default has aria-label`, () => {

--- a/tests/vitest/index.test.ts
+++ b/tests/vitest/index.test.ts
@@ -14,7 +14,6 @@ test(`default export from index.ts is same as component file`, () => {
 
 test(`src/lib/index.ts does not re-export attachments`, () => {
   for (const export_name of Object.keys(attachments)) {
-    if (export_name === `get_uuid`) continue // also public via $lib/utils
     expect(export_name in lib).toBe(false)
   }
 })

--- a/tests/vitest/live-examples/highlighter.test.ts
+++ b/tests/vitest/live-examples/highlighter.test.ts
@@ -1,9 +1,6 @@
 // Tests for starry-night syntax highlighter
-import {
-  hast_to_html,
-  starry_night,
-  starry_night_highlighter,
-} from '$lib/live-examples/highlighter'
+import { hast_to_html } from '$lib/live-examples/hast'
+import { starry_night, starry_night_highlighter } from '$lib/live-examples/highlighter'
 import { describe, expect, test } from 'vite-plus/test'
 
 describe(`starry_night.flagToScope`, () => {

--- a/tests/vitest/live-examples/mdsvex-transform.test.ts
+++ b/tests/vitest/live-examples/mdsvex-transform.test.ts
@@ -268,15 +268,22 @@ describe(`script block injection`, () => {
     expect(find_script_node(tree)).toMatch(/<script>[\s\S]*<\/script>/u)
   })
 
-  test(`adds imports to existing script block`, () => {
+  test.each([
+    [`plain script`, `<script>const existing = true</script>`],
+    [
+      `common attributes`,
+      `<script lang="ts" context="module" data-url=/api/foo-bar_1.2:run>const existing = true</script>`,
+    ],
+  ])(`adds imports to existing script block: %s`, (_label, script_block) => {
     const tree = create_tree([
-      { type: `html`, value: `<script>const existing = true</script>` },
+      { type: `html`, value: script_block },
       create_code_node(`svelte`, `<div>Test</div>`, `example`),
     ])
     remark()(tree, create_file())
-    const script = tree.children.find((n) => n.value?.includes(`const existing`))?.value
-    expect(script).toContain(`import Example_0`)
-    expect(script).toContain(`const existing`)
+    const script_nodes = tree.children.filter((node) => node.value?.startsWith(`<script`))
+    expect(script_nodes).toHaveLength(1)
+    expect(script_nodes[0].value).toContain(`import Example_0`)
+    expect(script_nodes[0].value).toContain(`const existing`)
   })
 
   test(`skips html nodes merely containing <script> mid-content`, () => {

--- a/tests/vitest/live-examples/mdsvex-transform.test.ts
+++ b/tests/vitest/live-examples/mdsvex-transform.test.ts
@@ -43,7 +43,7 @@ const find_script_node = (tree: TestTree): string | undefined => {
 
 // Get first example text value
 const get_example_value = (tree: TestTree): string => {
-  const node = tree.children[0] as { children?: Array<{ value?: string }> }
+  const node = tree.children[0] as { children?: { value?: string }[] }
   return node.children?.[0]?.value ?? ``
 }
 
@@ -380,8 +380,8 @@ describe(`output handling`, () => {
     const tree = create_tree([create_code_node(`svelte`, code, `example`)])
     remark()(tree, create_file())
     // extract the src={...} JS string literal and parse it as Svelte's compiler would
-    const match = /\n\s+src=\{(".*?[^\\]")\}/su.exec(get_example_value(tree))
+    const match = /\n\s+src=\{(?<src>".*?[^\\]")\}/su.exec(get_example_value(tree))
     expect(match).not.toBeNull()
-    expect(JSON.parse(match?.[1] ?? ``)).toBe(code)
+    expect(JSON.parse(match?.groups?.src ?? ``)).toBe(code)
   })
 })

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -1,12 +1,30 @@
 import { beforeAll, beforeEach, vi } from 'vite-plus/test'
 
-beforeEach(() => {
-  document.body.innerHTML = ``
+const storage = new Map<string, string>()
+
+Object.defineProperty(globalThis, `localStorage`, {
+  configurable: true,
+  writable: true,
+  value: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, val: string) => {
+      storage.set(key, val)
+    },
+    removeItem: (key: string) => {
+      storage.delete(key)
+    },
+    clear: () => storage.clear(),
+  },
 })
 
 beforeAll(() => {
   Element.prototype.animate = vi.fn().mockReturnValue({})
   Element.prototype.getAnimations = vi.fn().mockReturnValue([{}])
+})
+
+beforeEach(() => {
+  document.body.innerHTML = ``
+  storage.clear()
 })
 
 Object.defineProperty(globalThis, `matchMedia`, {

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -1,30 +1,13 @@
 import { beforeAll, beforeEach, vi } from 'vite-plus/test'
 
-const storage = new Map<string, string>()
-
-Object.defineProperty(globalThis, `localStorage`, {
-  configurable: true,
-  writable: true,
-  value: {
-    getItem: (key: string) => storage.get(key) ?? null,
-    setItem: (key: string, val: string) => {
-      storage.set(key, val)
-    },
-    removeItem: (key: string) => {
-      storage.delete(key)
-    },
-    clear: () => storage.clear(),
-  },
-})
-
 beforeAll(() => {
   Element.prototype.animate = vi.fn().mockReturnValue({})
   Element.prototype.getAnimations = vi.fn().mockReturnValue([{}])
 })
 
 beforeEach(() => {
+  vi.restoreAllMocks()
   document.body.innerHTML = ``
-  storage.clear()
 })
 
 Object.defineProperty(globalThis, `matchMedia`, {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,115 +1,16 @@
+import { config } from '@janosh/vite-config'
 import { sveltekit } from '@sveltejs/kit/vite'
-import { defineConfig } from 'vite-plus'
 import live_examples from './src/lib/live-examples/vite-plugin.ts'
 
-export default defineConfig({
-  // Skip all CSS polyfills — only target latest browsers
-  css: { lightningcss: { exclude: 0x1fffff } },
-  fmt: {
-    semi: false,
-    singleQuote: true,
-    printWidth: 90,
-  },
-  lint: {
-    plugins: [`oxc`, `typescript`, `unicorn`, `import`, `vitest`],
-    options: {
-      typeAware: true,
-      typeCheck: true,
-    },
-    categories: {
-      correctness: `error`,
-      suspicious: `error`,
-      perf: `error`,
-    },
-    ignorePatterns: [`build/`, `.svelte-kit/`, `package/`, `dist/`],
-    rules: {
-      // Extra rules not in the enabled categories
-      'no-console': [`error`, { allow: [`info`, `warn`, `error`] }],
-      'no-template-curly-in-string': `error`,
-      'no-constructor-return': `error`,
-      'default-param-last': `error`,
-      'guard-for-in': `error`,
-      'eslint-plugin-unicorn/prefer-array-find': `error`,
-      'eslint-plugin-unicorn/no-typeof-undefined': `error`,
-      'eslint-plugin-unicorn/prefer-optional-catch-binding': `error`,
-      'eslint-plugin-unicorn/no-length-as-slice-end': `error`,
-      'eslint-plugin-unicorn/prefer-node-protocol': `error`,
-      'eslint-plugin-unicorn/throw-new-error': `error`,
-      'eslint-plugin-unicorn/prefer-type-error': `error`,
-      'eslint-plugin-unicorn/prefer-date-now': `error`,
-      'eslint-plugin-unicorn/require-number-to-fixed-digits-argument': `error`,
-      'eslint-plugin-unicorn/no-useless-promise-resolve-reject': `error`,
-      'eslint-plugin-unicorn/custom-error-definition': `error`,
-      'eslint-plugin-import/no-duplicates': `error`,
-      '@typescript-eslint/no-non-null-assertion': `error`,
-      '@typescript-eslint/prefer-string-starts-ends-with': `error`,
-      '@typescript-eslint/prefer-readonly': `error`,
-      '@typescript-eslint/prefer-regexp-exec': `error`,
-      '@typescript-eslint/prefer-find': `error`,
-      '@typescript-eslint/no-deprecated': `error`,
-      '@typescript-eslint/no-misused-promises': `error`,
-      '@typescript-eslint/restrict-plus-operands': `error`,
-      '@typescript-eslint/no-dynamic-delete': `error`,
-      '@typescript-eslint/no-empty-object-type': `error`,
-      '@typescript-eslint/no-explicit-any': `error`,
-      '@typescript-eslint/no-import-type-side-effects': `error`,
-      '@typescript-eslint/no-invalid-void-type': `error`,
-      '@typescript-eslint/no-mixed-enums': `error`,
-      '@typescript-eslint/no-require-imports': `error`,
-      '@typescript-eslint/only-throw-error': `error`,
-      '@typescript-eslint/ban-ts-comment': `error`,
-      '@typescript-eslint/consistent-type-imports': `error`,
-      '@typescript-eslint/prefer-function-type': `error`,
-      '@typescript-eslint/prefer-includes': `error`,
-      '@typescript-eslint/prefer-optional-chain': `error`,
-      '@typescript-eslint/prefer-reduce-type-parameter': `error`,
-      '@typescript-eslint/prefer-ts-expect-error': `error`,
-      '@typescript-eslint/return-await': `error`,
-      '@typescript-eslint/switch-exhaustiveness-check': `error`,
-      '@typescript-eslint/unified-signatures': `error`,
-      'array-callback-return': `error`,
-      'prefer-object-has-own': `error`,
-      'eslint-plugin-promise/no-multiple-resolved': `error`,
-      'eslint-plugin-promise/no-return-in-finally': `error`,
-      'eslint-plugin-promise/param-names': `error`,
-      'eslint-plugin-promise/valid-params': `error`,
-      '@typescript-eslint/consistent-type-exports': `error`,
-      'eslint-plugin-unicorn/require-array-join-separator': `error`,
-      'no-useless-computed-key': `error`,
-      'eslint-plugin-vitest/prefer-strict-boolean-matchers': `error`,
-      'eslint-plugin-vitest/prefer-each': `error`,
-      'eslint-plugin-vitest/prefer-called-exactly-once-with': `error`,
-      'eslint-plugin-vitest/require-awaited-expect-poll': `error`,
-
-      '@typescript-eslint/no-unused-vars': [
-        `error`,
-        { argsIgnorePattern: `^_`, varsIgnorePattern: `^_` },
-      ],
-      'eslint-plugin-vitest/require-mock-type-parameters': `off`, // noisy without manual type annotations
-      // Svelte: oxlint can't see template usage or reactive patterns
-      'no-await-in-loop': `off`, // sequential await tick() in tests
-      'prefer-const': `off`, // `let` needed for $state/$derived/$bindable
-      '@typescript-eslint/no-unnecessary-condition': `off`, // reactive narrowing false positives
-      '@typescript-eslint/prefer-readonly-parameter-types': `off`, // noisy for DOM callbacks
-      'eslint-plugin-unicorn/consistent-function-scoping': `off`, // Svelte reactive closures
-      // DOM/any propagation — oxlint lacks DOM type stubs
-      // Pedantic rules too noisy for this codebase
-      'no-inline-comments': `off`,
-      'no-confusing-void-expression': `off`,
-      'strict-boolean-expressions': `off`, // truthiness checks are idiomatic
-      'max-lines-per-function': `off`,
-      'max-lines': `off`,
-      'eslint-plugin-vitest/no-conditional-expect': `off`, // parameterized tests use conditionals
-      'eslint-plugin-vitest/no-conditional-in-test': `off`, // parameterized tests use conditionals
-      'eslint-plugin-vitest/valid-expect': [`error`, { maxArgs: 2 }], // Vitest supports expect messages
-    },
-  },
+export default {
+  ...config, // shared lint/fmt/build from @janosh/vite-config (dotfiles)
   staged: {
     '*.{js,ts,svelte,html,css,md,json,yaml}': `vp check --fix`,
     '*.{ts,svelte}': `sh -c 'npx svelte-kit sync && npx svelte-check-rs --threshold error'`,
     '*.test.ts': `sh -c '! grep -E "(test|describe)\\.only\\(" "$@"' --`,
     '*': `codespell --ignore-words-list falsy --check-filenames`,
   },
+
   plugins: [sveltekit(), ...live_examples()],
 
   test: {
@@ -139,9 +40,4 @@ export default defineConfig({
   preview: {
     port: 3000,
   },
-
-  build: {
-    // Default cssTarget is chrome111 which doesn't support light-dark(),
-    cssTarget: `esnext`, // causing LightningCSS to polyfill it with broken space toggles
-  },
-})
+}


### PR DESCRIPTION
## Summary
- Simplifies local Vite/Svelte config wiring and test setup while preserving the existing release behavior.
- Trims redundant re-exports and tightens imports around attachments and live examples.
- Refactors focused tests and pins Svelte to `5.56.2` until upstream publishes the optional-parameter compiler fix in `5.56.4`.

## Component behavior
- Add CSS variables for dropdown-option padding and command-palette dialog padding.
- Make expanded code examples vertically scrollable and command-palette outside-click dismissal more reliable.
- Refine `MultiSelect` create/no-match timing and selection shortcuts.