### PR TITLE
Fix retain-focus dropdown behavior

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -916,8 +916,8 @@
     onchange?.({ option: option_removed, type: `remove` })
   }
 
-  function open_dropdown(event: Event) {
-    event.stopPropagation()
+  function open_dropdown(event: Event, focus_input = true, stop_propagation = true) {
+    if (stop_propagation) event.stopPropagation()
 
     if (disabled) return
     const clicked_expand_icon =
@@ -928,7 +928,7 @@
     }
     if (open) return
     open = true
-    if (!(event instanceof FocusEvent)) {
+    if (focus_input && !(event instanceof FocusEvent)) {
       // avoid double-focussing input when event that opened dropdown was already input FocusEvent
       input?.focus()
     }
@@ -1130,6 +1130,7 @@
       // on up/down arrow keys: update active option
       event.stopPropagation()
       event.preventDefault()
+      if (!open) open_dropdown(event, false)
       await handle_arrow_navigation(event.key === `ArrowUp` ? -1 : 1)
     }  // on backspace key: remove highlighted or last selected option
     else if (
@@ -1353,6 +1354,7 @@
 
   const handle_input_input = (event: Event) => {
     show_all_input_options = false
+    if (!open) open_dropdown(event, false, false)
     // Fallback for input events fired without beforeinput (e.g. some
     // programmatic value setters); bind:value has already synced searchText.
     if (input_committed_label !== null && searchText !== input_committed_label) {
@@ -1365,6 +1367,10 @@
     highlighted_idx = null
     open_dropdown(event)
     onfocus?.(event)
+  }
+
+  const prevent_retain_focus_blur = (event: MouseEvent) => {
+    if (closeDropdownOnSelect === `retain-focus`) event.preventDefault()
   }
 
   // Override input's focus method to ensure dropdown opens on programmatic focus
@@ -1831,6 +1837,7 @@
       bind:this={ul_options}
       style={ulOptionsStyle}
       onscroll={handle_options_scroll}
+      onmousedown={prevent_retain_focus_blur}
       onmousemove={() => (ignore_hover = false)}
     >
       {#if selectAllOption && effective_options.length > 0 && (maxSelect === null || maxSelect > 1)}

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -940,7 +940,7 @@
     open = false
     show_all_input_options = false
     if (!retain_focus) input?.blur()
-    activeIndex = null
+    if (!retain_focus) activeIndex = null
     onclose?.({ event })
   }
 

--- a/src/routes/(demos)/ui/+page.md
+++ b/src/routes/(demos)/ui/+page.md
@@ -29,6 +29,22 @@
 />
 ```
 
+### Retain Focus Picker
+
+```svelte example id="retain-focus"
+<script lang="ts">
+  import MultiSelect from '$lib'
+
+  const options = [`Svelte`, `Solid`, `React`]
+</script>
+
+<MultiSelect
+  {options}
+  closeDropdownOnSelect="retain-focus"
+  placeholder="Pick a framework"
+/>
+```
+
 This page is used for Playwright testing to ensure
 
 - the remove-all button

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -44,6 +44,29 @@ test.describe(`input`, () => {
     await expect(dropdown).toHaveClass(/hidden/u)
     await expect(dropdown).toBeHidden()
   })
+
+  // https://github.com/janosh/svelte-multiselect/issues/423
+  test(`retain-focus keeps input focused after mouse selection`, async ({ page }) => {
+    await page.goto(`/ui`, { waitUntil: `networkidle` })
+    const input = page.locator(`#retain-focus input[autocomplete]`)
+    const dropdown = page.locator(`#retain-focus ul.options`)
+
+    await input.click()
+    await expect(input).toBeFocused()
+    await expect(dropdown).toBeVisible()
+
+    await dropdown.getByRole(`option`, { name: `Svelte`, exact: true }).click()
+
+    await expect(dropdown).toBeHidden()
+    await expect(input).toBeFocused()
+
+    await page.keyboard.type(`r`)
+
+    await expect(dropdown).toBeVisible()
+    await expect(
+      dropdown.getByRole(`option`, { name: `React`, exact: true }),
+    ).toBeVisible()
+  })
 })
 
 test.describe(`multiselect`, () => {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3820,7 +3820,7 @@ test.each([
   },
 )
 
-test.each([true, false, `if-mobile`] as const)(
+test.each([true, false, `if-mobile`, `retain-focus`] as const)(
   `closeDropdownOnSelect=%s controls input focus and dropdown closing`,
   async (closeDropdownOnSelect) => {
     const original_inner_width = globalThis.innerWidth
@@ -3831,6 +3831,9 @@ test.each([true, false, `if-mobile`] as const)(
         props: { options: [1, 2, 3], closeDropdownOnSelect, open: true },
       })
 
+      const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      if (closeDropdownOnSelect === `retain-focus`) input_el.focus()
+
       // simulate selecting an option
       const first_option = doc_query(`ul.options > li`)
       first_option.click()
@@ -3839,6 +3842,7 @@ test.each([true, false, `if-mobile`] as const)(
       const is_desktop = globalThis.innerWidth > select.breakpoint
       const should_be_closed =
         closeDropdownOnSelect === true ||
+        closeDropdownOnSelect === `retain-focus` ||
         (closeDropdownOnSelect === `if-mobile` && !is_desktop)
 
       // count number of selected items
@@ -3847,7 +3851,6 @@ test.each([true, false, `if-mobile`] as const)(
 
       // check that dropdown is closed when closeDropdownOnSelect = true
       const dropdown = doc_query(`ul.options`)
-      const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
       const state = JSON.stringify({
         is_desktop,
         should_be_closed,
@@ -3857,7 +3860,9 @@ test.each([true, false, `if-mobile`] as const)(
 
       expect(dropdown.classList.contains(`hidden`), state).toBe(should_be_closed)
       // focus tracking is reliable only for the close path in happy-dom
-      if (should_be_closed) {
+      if (closeDropdownOnSelect === `retain-focus`) {
+        expect(document.activeElement).toBe(input_el)
+      } else if (should_be_closed) {
         expect(document.activeElement).not.toBe(input_el)
       } else {
         expect([input_el, document.body]).toContain(document.activeElement)
@@ -3887,26 +3892,58 @@ test.each([true, false, `if-mobile`] as const)(
   },
 )
 
-test(`closeDropdownOnSelect='retain-focus' retains input focus when dropdown closes after option selection`, async () => {
-  mount(MultiSelect, {
-    target: document.body,
-    props: {
-      options: [1, 2, 3],
-      closeDropdownOnSelect: `retain-focus`,
-      open: true,
+const retain_focus_keydown = (key: string) =>
+  new KeyboardEvent(`keydown`, { key, bubbles: true })
+
+test.each([
+  {
+    reopen_method: `typing`,
+    reopen_action: async (input_el: HTMLInputElement) => {
+      input_el.value = `r`
+      input_el.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await tick()
+      return doc_query(`ul.options > li`).textContent?.trim()
     },
-  })
+    expected_option: `React`,
+  },
+  {
+    reopen_method: `ArrowDown`,
+    reopen_action: async (input_el: HTMLInputElement) => {
+      input_el.dispatchEvent(retain_focus_keydown(`ArrowDown`))
+      await tick()
+      return doc_query(`ul.options > li.active`).textContent?.trim()
+    },
+    expected_option: `Solid`,
+  },
+] as const)(
+  `closeDropdownOnSelect='retain-focus' reopens on $reopen_method after keyboard selection`,
+  async ({ reopen_action, expected_option }) => {
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [`Svelte`, `Solid`, `React`],
+        closeDropdownOnSelect: `retain-focus`,
+        open: true,
+      },
+    })
 
-  const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
-  input_el.focus()
+    const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const dropdown = doc_query(`ul.options`)
+    input_el.focus()
+    input_el.dispatchEvent(retain_focus_keydown(`ArrowDown`))
+    await tick()
+    input_el.dispatchEvent(retain_focus_keydown(`Enter`))
+    await tick()
 
-  // select an option - should close dropdown but retain focus
-  doc_query(`ul.options > li`).click()
-  await tick()
+    expect(document.activeElement).toBe(input_el)
+    expect(dropdown.classList).toContain(`hidden`)
 
-  expect(document.activeElement).toBe(input_el)
-  expect(document.querySelectorAll(`ul.selected > li`)).toHaveLength(1)
-})
+    const reopened_option = await reopen_action(input_el)
+
+    expect(dropdown.classList).not.toContain(`hidden`)
+    expect(reopened_option).toBe(expected_option)
+  },
+)
 
 test(`closeDropdownOnSelect='retain-focus' works correctly with maxSelect`, async () => {
   mount(MultiSelect, {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3913,7 +3913,7 @@ test.each([
       await tick()
       return doc_query(`ul.options > li.active`).textContent?.trim()
     },
-    expected_option: `Solid`,
+    expected_option: `React`,
   },
 ] as const)(
   `closeDropdownOnSelect='retain-focus' reopens on $reopen_method after keyboard selection`,


### PR DESCRIPTION
- Fix `closeDropdownOnSelect='retain-focus'` so mouse selection keeps the input focused.
- Reopen the dropdown from retained focus when users type or press arrow keys after keyboard selection.
- Add Vitest and Playwright coverage for the issue #423 repro paths.

Fixes #423.