### PR TITLE
Fix tooltip, focus, and shortcut edge cases

### DIFF
--- a/src/lib/CmdPalette.svelte
+++ b/src/lib/CmdPalette.svelte
@@ -15,7 +15,7 @@
   import { fade } from 'svelte/transition'
   import MultiSelect from './MultiSelect.svelte'
   import type { MultiSelectProps } from './types'
-  import { matches_shortcut } from './utils'
+  import { matches_shortcut, split_shortcut } from './utils'
 
   // MultiSelect's option snippet param (option + idx/selected/active/disabled)
   type OptionSnippetParams = Parameters<
@@ -123,7 +123,7 @@
     arrowright: `→`,
   }
   const format_shortcut = (shortcut: string): string[] =>
-    shortcut.split(`+`).map((part) => {
+    split_shortcut(shortcut).map((part) => {
       const key_segment = part.trim().toLowerCase()
       // title-case unknown multi-char segments, upper-case single chars (empty stays empty)
       const title_case = key_segment.charAt(0).toUpperCase() + key_segment.slice(1)

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -935,12 +935,34 @@
     onopen?.({ event })
   }
 
+  let suppress_next_focus_open = false
+
+  function focus_input_without_open(only_if_internal = false) {
+    const active_element = document.activeElement
+    const focus_is_internal =
+      active_element instanceof Node &&
+      (outerDiv?.contains(active_element) || ul_options?.contains(active_element))
+    if (!input || active_element === input || (only_if_internal && !focus_is_internal))
+      return
+    suppress_next_focus_open = true
+    try {
+      input.focus()
+    } finally {
+      suppress_next_focus_open = false
+    }
+  }
+
   function close_dropdown(event: Event, retain_focus = false) {
     if (!open) return
+    const retain_active_option = retain_focus && !option_msg_is_active
     open = false
     show_all_input_options = false
-    if (!retain_focus) input?.blur()
-    if (!retain_focus) activeIndex = null
+    if (retain_focus) {
+      focus_input_without_open()
+      tick().then(() => focus_input_without_open(true))
+    } else input?.blur()
+    if (!retain_active_option) activeIndex = null
+    option_msg_is_active = false
     onclose?.({ event })
   }
 
@@ -1365,7 +1387,7 @@
 
   const handle_input_focus: FocusEventHandler<HTMLInputElement> = (event) => {
     highlighted_idx = null
-    open_dropdown(event)
+    if (!suppress_next_focus_open) open_dropdown(event)
     onfocus?.(event)
   }
 
@@ -1382,7 +1404,7 @@
 
     input.focus = (focus_options?: FocusOptions) => {
       orig_focus(focus_options)
-      if (!disabled && !open) {
+      if (!suppress_next_focus_open && !disabled && !open) {
         open_dropdown(new FocusEvent(`focus`, { bubbles: true }))
       }
     }

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -954,16 +954,19 @@
 
   function close_dropdown(event: Event, retain_focus = false) {
     if (!open) return
-    const retain_active_option = retain_focus && !option_msg_is_active
+    const focus_before_onclose = document.activeElement
     open = false
     show_all_input_options = false
-    if (retain_focus) {
-      focus_input_without_open()
-      tick().then(() => focus_input_without_open(true))
-    } else input?.blur()
-    if (!retain_active_option) activeIndex = null
+    if (!retain_focus) input?.blur()
+    activeIndex = null
     option_msg_is_active = false
     onclose?.({ event })
+    const active_element = document.activeElement
+    const focus_changed_by_onclose = active_element !== focus_before_onclose
+    if (retain_focus && !focus_changed_by_onclose) {
+      focus_input_without_open()
+      tick().then(() => focus_input_without_open(true))
+    }
   }
 
   function clear_validity() {

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -633,7 +633,7 @@ export const tooltip =
           arrow,
           placement,
           arrow_px,
-          `var(--tooltip-bg, light-dark(#f5f5f7, #2a2a2e))`,
+          `var(--tooltip-bg, light-dark(#fff, #2a2a2e))`,
         )
 
         const border_arrow = tooltip_el.querySelector<HTMLElement>(
@@ -835,7 +835,7 @@ export const tooltip =
           // light-dark() inherits the page's color-scheme (defaults to light if unset)
           tooltip_el.style.cssText = `
           position: absolute; z-index: 9999; opacity: 0; display: inline-block;
-          background-color: var(--tooltip-bg, light-dark(#f5f5f7, #2a2a2e)); color: var(--text-color, light-dark(#222, #eee)); border: var(--tooltip-border, none);
+          background-color: var(--tooltip-bg, light-dark(#fff, #2a2a2e)); color: var(--text-color, light-dark(#222, #eee)); border: var(--tooltip-border, 1px solid light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.18)));
           padding: var(--tooltip-padding, 2px 6px); border-radius: var(--tooltip-radius, 5pt); font-size: var(--tooltip-font-size, 0.8rem); line-height: 1.4;
           max-width: var(--tooltip-max-width, 280px); overflow-wrap: break-word; text-wrap: balance; pointer-events: none;
           filter: var(--tooltip-shadow, drop-shadow(0 2px 8px rgba(0,0,0,0.25))); transition: opacity 0.15s ease-out;
@@ -843,12 +843,16 @@ export const tooltip =
 
           // Apply custom styles if provided (these will override base styles due to CSS specificity)
           if (options.style) {
-            // Parse and apply custom styles as individual properties for better control
-            const custom_styles = options.style.split(`;`).filter((style) => style.trim())
-            custom_styles.forEach((style) => {
-              const [property, value] = style.split(`:`).map((part) => part.trim())
-              if (property && value) tooltip_el.style.setProperty(property, value)
-            })
+            const custom_style = document.createElement(`div`).style
+            custom_style.cssText = options.style
+            for (let idx = 0; idx < custom_style.length; idx++) {
+              const property = custom_style.item(idx)
+              tooltip_el.style.setProperty(
+                property,
+                custom_style.getPropertyValue(property),
+                custom_style.getPropertyPriority(property),
+              )
+            }
           }
 
           // Wrap content in a span for reactive content updates

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -626,10 +626,8 @@ export const tooltip =
         const tooltip_styles = getComputedStyle(tooltip_el)
         const default_arrow_color = `var(--tooltip-bg, light-dark(#fff, #2a2a2e))`
         const tooltip_bg = tooltip_styles.backgroundColor.trim()
-        const is_transparent = (color: string) =>
-          !color ||
-          color === `transparent` ||
-          /rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*0\s*\)/u.test(color)
+        const transparent_colors = new Set([``, `transparent`, `rgba(0, 0, 0, 0)`])
+        const is_transparent = (color: string) => transparent_colors.has(color.trim())
         const arrow_size_raw = tooltip_styles
           .getPropertyValue(`--tooltip-arrow-size`)
           .trim()

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -624,6 +624,12 @@ export const tooltip =
         if (!arrow) return
 
         const tooltip_styles = getComputedStyle(tooltip_el)
+        const default_arrow_color = `var(--tooltip-bg, light-dark(#fff, #2a2a2e))`
+        const tooltip_bg = tooltip_styles.backgroundColor.trim()
+        const is_transparent = (color: string) =>
+          !color ||
+          color === `transparent` ||
+          /rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*0\s*\)/u.test(color)
         const arrow_size_raw = tooltip_styles
           .getPropertyValue(`--tooltip-arrow-size`)
           .trim()
@@ -633,7 +639,7 @@ export const tooltip =
           arrow,
           placement,
           arrow_px,
-          `var(--tooltip-bg, light-dark(#fff, #2a2a2e))`,
+          is_transparent(tooltip_bg) ? default_arrow_color : tooltip_bg,
         )
 
         const border_arrow = tooltip_el.querySelector<HTMLElement>(
@@ -643,11 +649,7 @@ export const tooltip =
 
         const border_color = tooltip_styles.borderTopColor
         const border_width_num = Number.parseFloat(tooltip_styles.borderTopWidth || `0`)
-        const is_transparent =
-          !border_color ||
-          border_color === `transparent` ||
-          /rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*0\s*\)/u.test(border_color)
-        const has_border = !is_transparent && border_width_num > 0
+        const has_border = !is_transparent(border_color) && border_width_num > 0
         if (!has_border) {
           border_arrow.remove()
           return

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -107,7 +107,7 @@ export function matches_shortcut(
   return (
     event.key.toLowerCase() === key &&
     event.ctrlKey === ctrl &&
-    event.shiftKey === shift &&
+    (event.shiftKey === shift || (key === `+` && !shift)) &&
     event.altKey === alt &&
     event.metaKey === meta
   )

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -69,6 +69,16 @@ export function get_style(
   return css_str
 }
 
+export function split_shortcut(shortcut: string): string[] {
+  const parts = shortcut
+    .toLowerCase()
+    .split(`+`)
+    .map((part) => part.trim())
+
+  if (parts.at(-1) === `` && parts.at(-2) === ``) parts.splice(-2, 2, `+`)
+  return parts
+}
+
 // Parse shortcut string into modifier+key parts
 export function parse_shortcut(shortcut: string): {
   key: string
@@ -77,10 +87,7 @@ export function parse_shortcut(shortcut: string): {
   alt: boolean
   meta: boolean
 } {
-  const parts = shortcut
-    .toLowerCase()
-    .split(`+`)
-    .map((part) => part.trim())
+  const parts = split_shortcut(shortcut)
   const key = parts.pop() ?? ``
   const ctrl = parts.includes(`ctrl`)
   const shift = parts.includes(`shift`)

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -1,16 +1,31 @@
 // deno-lint-ignore-file no-await-in-loop
 import { foods, languages, octicons } from '$site/options'
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
+
+async function goto_persistent(page: Page): Promise<void> {
+  await page.goto(`/persistent`)
+  await expect(page.locator(`#languages input[autocomplete]`)).toBeVisible()
+  const store_binding_input = page.locator(
+    `#store-binding input[placeholder='Select colors...']`,
+  )
+  await expect(store_binding_input).toBeVisible()
+  await page.waitForFunction(() => {
+    const input_el = document.querySelector<HTMLInputElement>(
+      `#store-binding input[placeholder='Select colors...']`,
+    )
+    return input_el && !String(input_el.focus).includes(`[native code]`)
+  })
+}
 
 // Issue #309: Array cloning by reactive wrappers (stores, Superforms) caused infinite loops
 // https://github.com/janosh/svelte-multiselect/issues/309
 test(`array cloning infinite loop prevention (issue #309)`, async ({ page }) => {
-  await page.goto(`/persistent`, { waitUntil: `networkidle` })
+  await goto_persistent(page)
 
-  const dropdown = page.locator(`#store-binding ul.options`)
-  await page.click(`#store-binding input[placeholder='Select colors...']`)
-  await expect(dropdown).toBeVisible()
-  await dropdown.locator(`text=Red`).click()
+  const input = page.locator(`#store-binding input[placeholder='Select colors...']`)
+  await input.focus()
+  await input.press(`ArrowDown`)
+  await input.press(`Enter`)
 
   const status = page.locator(`#store-binding-status`)
   await expect(status.locator(`text=✅ Fixed`)).toBeVisible()
@@ -126,9 +141,10 @@ test.describe(`multiselect`, () => {
   test(`retains its selected state on page reload when bound to localStorage`, async ({
     page,
   }) => {
-    await page.goto(`/persistent`, { waitUntil: `networkidle` })
+    await goto_persistent(page)
     await page.evaluate(() => sessionStorage.clear())
-    await page.reload({ waitUntil: `networkidle` })
+    await page.reload()
+    await expect(page.locator(`#languages input[autocomplete]`)).toBeVisible()
 
     const selected = page.locator(`#languages ul.selected`)
     await expect(selected).toContainText(`Python`)
@@ -146,7 +162,7 @@ test.describe(`multiselect`, () => {
 
 // https://github.com/janosh/svelte-multiselect/issues/176
 test(`browser drag reorders selected options`, async ({ page }) => {
-  await page.goto(`/persistent`, { waitUntil: `networkidle` })
+  await goto_persistent(page)
   const selected = page.locator(`#languages ul.selected`)
   await expect(selected).toHaveText(`1  Python 2  TypeScript 3  C 4  Haskell`)
 

--- a/tests/vitest/CmdPalette.svelte.test.ts
+++ b/tests/vitest/CmdPalette.svelte.test.ts
@@ -790,6 +790,12 @@ const option_labels = () =>
     li.textContent?.trim(),
   )
 
+const shortcut_kbd_parts = () =>
+  Array.from(
+    document.querySelectorAll(`li[role='option'] .cmd-shortcut kbd`),
+    (kbd) => kbd.textContent,
+  )
+
 const press_ctrl_shift = (key: string) =>
   globalThis.dispatchEvent(
     new KeyboardEvent(`keydown`, { key, ctrlKey: true, shiftKey: true }),
@@ -811,17 +817,27 @@ test(`renders shortcut kbd hints and descriptions in options`, async () => {
   })
   await tick()
 
-  const kbd_parts = Array.from(
-    document.querySelectorAll(`li[role='option'] .cmd-shortcut kbd`),
-    (kbd) => kbd.textContent,
-  )
-  expect(kbd_parts).toEqual([`Ctrl`, `⇧`, `S`])
+  expect(shortcut_kbd_parts()).toEqual([`Ctrl`, `⇧`, `S`])
   expect(doc_query(`.cmd-description`).textContent).toBe(`Write buffer to disk`)
   // action without shortcut renders no kbd
   const quit_li = Array.from(document.querySelectorAll(`li[role='option']`)).find((li) =>
     li.textContent?.includes(`quit`),
   )
   expect(quit_li?.querySelector(`kbd`)).toBeNull()
+})
+
+test(`renders plus-key shortcut hints`, async () => {
+  mount(CmdPalette, {
+    target: document.body,
+    props: {
+      open: true,
+      fade_duration: 0,
+      actions: [{ label: `zoom in`, action: vi.fn(), shortcut: `ctrl++` }],
+    },
+  })
+  await tick()
+
+  expect(shortcut_kbd_parts()).toEqual([`Ctrl`, `+`])
 })
 
 test(`plain actions without shortcut/description use default option rendering`, async () => {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3895,13 +3895,23 @@ test.each([true, false, `if-mobile`, `retain-focus`] as const)(
 const retain_focus_keydown = (key: string) =>
   new KeyboardEvent(`keydown`, { key, bubbles: true })
 
+async function type_retain_focus_input(input_el: HTMLInputElement, value: string) {
+  input_el.value = value
+  input_el.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+  await tick()
+}
+
+const mount_retain_focus = (props: Partial<MultiSelectProps> = {}) =>
+  mount(MultiSelect, {
+    target: document.body,
+    props: { closeDropdownOnSelect: `retain-focus`, open: true, ...props },
+  })
+
 test.each([
   {
     reopen_method: `typing`,
     reopen_action: async (input_el: HTMLInputElement) => {
-      input_el.value = `r`
-      input_el.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
-      await tick()
+      await type_retain_focus_input(input_el, `r`)
       return doc_query(`ul.options > li`).textContent?.trim()
     },
     expected_option: `React`,
@@ -3918,14 +3928,7 @@ test.each([
 ] as const)(
   `closeDropdownOnSelect='retain-focus' reopens on $reopen_method after keyboard selection`,
   async ({ reopen_action, expected_option }) => {
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        options: [`Svelte`, `Solid`, `React`],
-        closeDropdownOnSelect: `retain-focus`,
-        open: true,
-      },
-    })
+    mount_retain_focus({ options: [`Svelte`, `Solid`, `React`] })
 
     const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
     const dropdown = doc_query(`ul.options`)
@@ -3944,6 +3947,77 @@ test.each([
     expect(reopened_option).toBe(expected_option)
   },
 )
+
+test(`closeDropdownOnSelect='retain-focus' clears active create message after creating an option`, async () => {
+  mount_retain_focus({
+    options: [`apple`, `banana`, `cherry`],
+    allowUserOptions: true,
+  })
+
+  const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const dropdown = doc_query(`ul.options`)
+  input_el.focus()
+  await type_retain_focus_input(input_el, `app`)
+  input_el.dispatchEvent(retain_focus_keydown(`ArrowDown`))
+  await tick()
+  input_el.dispatchEvent(retain_focus_keydown(`ArrowDown`))
+  await tick()
+
+  expect(doc_query(`ul.options li.user-msg`).classList).toContain(`active`)
+
+  input_el.dispatchEvent(retain_focus_keydown(`Enter`))
+  await tick()
+
+  expect(dropdown.classList).toContain(`hidden`)
+  expect(document.activeElement).toBe(input_el)
+
+  await type_retain_focus_input(input_el, `b`)
+
+  expect(dropdown.classList).not.toContain(`hidden`)
+  expect(doc_query(`ul.options > li:not(.user-msg)`).textContent?.trim()).toBe(`banana`)
+  expect(doc_query(`ul.options li.user-msg`).classList).not.toContain(`active`)
+  expect(input_el.getAttribute(`aria-activedescendant`) ?? ``).not.toMatch(/user-msg/u)
+})
+
+test(`closeDropdownOnSelect='retain-focus' restores input focus after keyboard select all`, async () => {
+  mount_retain_focus({
+    options: [`Apple`, `Banana`],
+    selectAllOption: true,
+  })
+
+  const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const dropdown = doc_query(`ul.options`)
+  const select_all_el = doc_query(`ul.options > li.select-all`)
+  select_all_el.focus()
+  select_all_el.dispatchEvent(retain_focus_keydown(`Enter`))
+  await tick()
+
+  expect(dropdown.classList).toContain(`hidden`)
+  expect(document.activeElement).toBe(input_el)
+
+  await type_retain_focus_input(input_el, `z`)
+
+  expect(dropdown.classList).not.toContain(`hidden`)
+  expect(doc_query(`ul.options li.user-msg`).textContent?.trim()).toBe(
+    `No matching options`,
+  )
+})
+
+test(`closeDropdownOnSelect='retain-focus' does not override onclose focus`, async () => {
+  const external_button = document.createElement(`button`)
+  document.body.append(external_button)
+
+  mount_retain_focus({
+    options: [`Apple`, `Banana`],
+    selectAllOption: true,
+    onclose: () => external_button.focus(),
+  })
+
+  doc_query(`ul.options > li.select-all`).dispatchEvent(retain_focus_keydown(`Enter`))
+  await tick()
+
+  expect(document.activeElement).toBe(external_button)
+})
 
 test(`closeDropdownOnSelect='retain-focus' works correctly with maxSelect`, async () => {
   mount(MultiSelect, {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3923,7 +3923,7 @@ test.each([
       await tick()
       return doc_query(`ul.options > li.active`).textContent?.trim()
     },
-    expected_option: `React`,
+    expected_option: `Solid`,
   },
 ] as const)(
   `closeDropdownOnSelect='retain-focus' reopens on $reopen_method after keyboard selection`,
@@ -4003,21 +4003,34 @@ test(`closeDropdownOnSelect='retain-focus' restores input focus after keyboard s
   )
 })
 
-test(`closeDropdownOnSelect='retain-focus' does not override onclose focus`, async () => {
-  const external_button = document.createElement(`button`)
-  document.body.append(external_button)
+test.each([
+  {
+    focus_target: `external`,
+    attach_button: (button: HTMLButtonElement) => document.body.append(button),
+  },
+  {
+    focus_target: `internal`,
+    attach_button: (button: HTMLButtonElement) =>
+      doc_query(`div.multiselect`).append(button),
+  },
+])(
+  `closeDropdownOnSelect='retain-focus' does not override $focus_target onclose focus`,
+  async ({ attach_button }) => {
+    const focus_button = document.createElement(`button`)
+    focus_button.tabIndex = 0
+    mount_retain_focus({
+      options: [`Apple`, `Banana`],
+      selectAllOption: true,
+      onclose: () => focus_button.focus(),
+    })
+    attach_button(focus_button)
 
-  mount_retain_focus({
-    options: [`Apple`, `Banana`],
-    selectAllOption: true,
-    onclose: () => external_button.focus(),
-  })
+    doc_query(`ul.options > li.select-all`).dispatchEvent(retain_focus_keydown(`Enter`))
+    await tick()
 
-  doc_query(`ul.options > li.select-all`).dispatchEvent(retain_focus_keydown(`Enter`))
-  await tick()
-
-  expect(document.activeElement).toBe(external_button)
-})
+    expect(document.activeElement).toBe(focus_button)
+  },
+)
 
 test(`closeDropdownOnSelect='retain-focus' works correctly with maxSelect`, async () => {
   mount(MultiSelect, {

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -754,8 +754,11 @@ describe(`tooltip`, () => {
       const tooltip_css = find_tooltip_css(css_texts)
       expect(tooltip_css).toBeDefined()
       expect(tooltip_css).not.toContain(`color-scheme`)
-      expect(tooltip_css).toMatch(/background-color:.*light-dark\(\s*#f5f5f7,\s*#2a2a2e/u)
+      expect(tooltip_css).toMatch(/background-color:.*light-dark\(\s*#fff,\s*#2a2a2e/u)
       expect(tooltip_css).toMatch(/\bcolor:.*light-dark\(\s*#222,\s*#eee/u)
+      expect(tooltip_css).toMatch(
+        /border:.*var\(--tooltip-border,\s*1px solid light-dark\(\s*rgba\(0,\s*0,\s*0,\s*0\.12\),\s*rgba\(255,\s*255,\s*255,\s*0\.18\)/u,
+      )
 
       const arrow_borders = set_prop_values.filter(
         (entry) =>
@@ -765,7 +768,7 @@ describe(`tooltip`, () => {
       )
       expect(arrow_borders.length).toBeGreaterThan(0)
       for (const entry of arrow_borders) {
-        expect(entry).toMatch(/light-dark\(\s*#f5f5f7,\s*#2a2a2e/u)
+        expect(entry).toMatch(/light-dark\(\s*#fff,\s*#2a2a2e/u)
       }
     })
 
@@ -787,6 +790,26 @@ describe(`tooltip`, () => {
       )
       const tooltip_css = find_tooltip_css(css_texts)
       expect(tooltip_css).toContain(`var(--tooltip-bg,`)
+    })
+
+    it(`custom --tooltip-border overrides default border`, () => {
+      const { css_texts, restore } = capture_style_writes()
+      try {
+        const element = create_element()
+        element.title = `custom border`
+        element.style.setProperty(`--tooltip-border`, `2px solid red`)
+        mock_bounds(element)
+        setup_tooltip(element, { delay: 0 })
+        trigger_tooltip(element)
+      } finally {
+        restore()
+      }
+
+      expect(
+        doc_query(`.custom-tooltip`).style.getPropertyValue(`--tooltip-border`),
+      ).toBe(`2px solid red`)
+      const tooltip_css = find_tooltip_css(css_texts)
+      expect(tooltip_css).toContain(`var(--tooltip-border,`)
     })
 
     it(`updates visible tooltip content when tooltip attributes change`, () => {
@@ -852,6 +875,21 @@ describe(`tooltip`, () => {
       expect(tooltip_el.style.color).toBe(`blue`)
       expect(tooltip_el.style.getPropertyValue(`invalid`)).toBe(``)
       expect(tooltip_el.style.getPropertyValue(`empty`)).toBe(``)
+    })
+
+    it(`preserves custom style values containing colons`, () => {
+      const element = create_element()
+      element.title = `custom style url`
+      mock_bounds(element)
+      setup_tooltip(element, {
+        delay: 0,
+        style: `background-image: url("https://example.com/tooltip.svg")`,
+      })
+
+      trigger_tooltip(element)
+      expect(doc_query(`.custom-tooltip`).style.backgroundImage).toContain(
+        `https://example.com/tooltip.svg`,
+      )
     })
   })
 })

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -891,6 +891,32 @@ describe(`tooltip`, () => {
         `https://example.com/tooltip.svg`,
       )
     })
+
+    it(`uses custom style background-color for tooltip arrow fill`, () => {
+      const { set_prop_values, restore } = capture_style_writes()
+      try {
+        const element = create_element()
+        element.title = `custom arrow fill`
+        mock_bounds(element)
+        setup_tooltip(element, {
+          delay: 0,
+          style: `background-color: red`,
+        })
+        trigger_tooltip(element)
+      } finally {
+        restore()
+      }
+
+      const arrow_borders = set_prop_values.filter(
+        (entry) =>
+          entry.startsWith(`border-`) &&
+          entry.includes(`solid`) &&
+          !entry.includes(`transparent`),
+      )
+      expect(
+        arrow_borders.some((entry) => /\b(?:red|rgb\(255,\s*0,\s*0\))/u.test(entry)),
+      ).toBe(true)
+    })
   })
 })
 

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -7,6 +7,8 @@ import {
   get_uuid,
   has_group,
   is_object,
+  matches_shortcut,
+  parse_shortcut,
 } from '$lib/utils'
 import { describe, expect, test, vi } from 'vite-plus/test'
 
@@ -122,6 +124,25 @@ describe(`get_style`, () => {
     expect(console.error).toHaveBeenCalledWith(
       `MultiSelect: Invalid key=invalid_key for get_style`,
     )
+  })
+})
+
+describe(`keyboard shortcut parsing`, () => {
+  test.each([
+    [`+`, { key: `+`, ctrl: false, shift: false, alt: false, meta: false }],
+    [`ctrl++`, { key: `+`, ctrl: true, shift: false, alt: false, meta: false }],
+    [`ctrl+shift++`, { key: `+`, ctrl: true, shift: true, alt: false, meta: false }],
+    [`ctrl+`, { key: ``, ctrl: true, shift: false, alt: false, meta: false }],
+  ])(`parse_shortcut(%j)`, (shortcut, expected) => {
+    expect(parse_shortcut(shortcut)).toEqual(expected)
+  })
+
+  test.each([
+    [`ctrl++`, { key: `+`, ctrlKey: true }, true],
+    [`ctrl+`, { key: `+`, ctrlKey: true }, false],
+  ])(`matches_shortcut(%j) with plus key`, (shortcut, event_init, expected) => {
+    const event = new KeyboardEvent(`keydown`, event_init)
+    expect(matches_shortcut(event, shortcut)).toBe(expected)
   })
 })
 

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -139,6 +139,8 @@ describe(`keyboard shortcut parsing`, () => {
 
   test.each([
     [`ctrl++`, { key: `+`, ctrlKey: true }, true],
+    [`ctrl++`, { key: `+`, ctrlKey: true, shiftKey: true }, true],
+    [`ctrl+shift++`, { key: `+`, ctrlKey: true }, false],
     [`ctrl+`, { key: `+`, ctrlKey: true }, false],
   ])(`matches_shortcut(%j) with plus key`, (shortcut, event_init, expected) => {
     const event = new KeyboardEvent(`keydown`, event_init)


### PR DESCRIPTION
- Improve tooltip contrast defaults, add a default border, and preserve valid custom style values containing colons.
- Fix retain-focus dropdown close paths so active create messages are cleared and keyboard select-all restores input focus without stealing consumer-managed focus.
- Support `+` as a keyboard shortcut key in parsing and command palette shortcut hints.