### PR TITLE
Fix schemeless-page tooltip readability and support partial OptionStyle objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,11 +63,11 @@
     "@janosh/vite-config": "github:janosh/dotfiles",
     "@playwright/test": "^1.61.1",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.68.0",
+    "@sveltejs/kit": "^2.69.1",
     "@sveltejs/package": "2.5.8",
-    "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@types/node": "^26.0.1",
-    "@vitest/coverage-v8": "^4.1.9",
+    "@sveltejs/vite-plugin-svelte": "^7.1.4",
+    "@types/node": "^26.1.0",
+    "@vitest/coverage-v8": "^4.1.10",
     "@wooorm/starry-night": "^3.10.0",
     "acorn": "^8.17.0",
     "happy-dom": "^20.10.6",
@@ -75,9 +75,9 @@
     "svelte": "^5.56.4",
     "svelte-toc": "^0.7.0",
     "typescript": "6.0.3",
-    "vite": "^8.1.0",
-    "vite-plus": "0.2.1",
-    "vitest": "^4.1.9"
+    "vite": "^8.1.3",
+    "vite-plus": "0.2.2",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "@wooorm/starry-night": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@sveltejs/package": "2.5.8",
     "@sveltejs/vite-plugin-svelte": "^7.1.4",
     "@types/node": "^26.1.0",
-    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/coverage-v8": "4.1.9",
     "@wooorm/starry-night": "^3.10.0",
     "acorn": "^8.17.0",
     "happy-dom": "^20.10.6",
@@ -77,7 +77,7 @@
     "typescript": "6.0.3",
     "vite": "^8.1.3",
     "vite-plus": "0.2.2",
-    "vitest": "^4.1.10"
+    "vitest": "4.1.9"
   },
   "peerDependencies": {
     "@wooorm/starry-night": "^3.0.0",

--- a/readme.md
+++ b/readme.md
@@ -1057,7 +1057,7 @@ Minimal example that changes the background color of the options dropdown:
   - `border-radius: var(--sms-border-radius, 3pt)`
   - `padding: var(--sms-padding, 0 3pt)`
   - `background: var(--sms-bg, light-dark(white, #222226))`
-  - `color: var(--sms-text-color)`
+  - `color: var(--sms-text-color, light-dark(#222, #eee))`: Text color. Defaults to a theme-aware color paired with `--sms-bg` so the component stays readable on dark pages that never declare `color-scheme` (where `light-dark()` falls back to light). Set `--sms-text-color: inherit` to blend with the surrounding page instead.
   - `min-height: var(--sms-min-height, 22pt)`
   - `width: var(--sms-width)`
   - `max-width: var(--sms-max-width)`
@@ -1075,12 +1075,13 @@ Minimal example that changes the background color of the options dropdown:
 - `div.multiselect > ul.selected > li`
   - `background: var(--sms-selected-bg, light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)))`: Background of selected options.
   - `padding: var(--sms-selected-li-padding, 0 2pt 0 5pt)`: Padding of selected options.
-  - `color: var(--sms-selected-text-color, var(--sms-text-color))`: Text color for selected options.
+  - `color: var(--sms-selected-text-color, var(--sms-text-color, light-dark(#222, #eee)))`: Text color for selected options.
 - `ul.selected > li button:hover, button.remove-all:hover, button:focus`
   - `color: var(--sms-remove-btn-hover-color, inherit)`: Color of the remove-icon buttons for removing all or individual selected options when in `:focus` or `:hover` state.
   - `background: var(--sms-remove-btn-hover-bg, light-dark(rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.2)))`: Background for hovered remove buttons.
 - `div.multiselect > ul.options`
-  - `background: var(--sms-options-bg, light-dark(#fafafa, #222226))`: Background of dropdown list.
+  - `background: var(--sms-options-bg, light-dark(#fcfcfc, #222226))`: Background of dropdown list.
+  - `color: var(--sms-text-color, light-dark(#222, #eee))`: Text color of dropdown options. Paired with `--sms-options-bg` since the dropdown is portalled to `document.body` and no longer inherits the component's text color.
   - `max-height: var(--sms-options-max-height, 50vh)`: Maximum height of options dropdown.
   - `overscroll-behavior: var(--sms-options-overscroll, none)`: Whether scroll events bubble to parent elements when reaching the top/bottom of the options dropdown. See [MDN](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior).
   - `z-index: var(--sms-options-z-index, 3)`: Z-index for the dropdown options list.

--- a/src/lib/CmdPalette.svelte
+++ b/src/lib/CmdPalette.svelte
@@ -139,17 +139,16 @@
   )
 
   $effect(() => {
-    if (!dialog || !open || dialog.open) return
-    try {
-      dialog.showModal()
-    } catch {
-      // showModal missing (older DOM impls) or dialog not in document
-      dialog.setAttribute(`open`, ``)
+    if (!open) return
+    if (dialog && !dialog.open) {
+      try {
+        dialog.showModal()
+      } catch {
+        // showModal missing (older DOM impls) or dialog not in document
+        dialog.setAttribute(`open`, ``)
+      }
     }
-  })
-
-  $effect(() => {
-    if (open && input && document.activeElement !== input) input.focus()
+    if (input && document.activeElement !== input) input.focus()
   })
 
   function toggle(event: KeyboardEvent): boolean {

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -380,8 +380,7 @@
   let effective_options = $derived(loadOptions ? loaded_options : (options ?? []))
 
   let has_search_text = $derived(searchText.trim().length > 0)
-  // Cache selected keys and labels to avoid repeated .map() calls
-  let selected_keys = $derived(selected.map((opt) => key(opt)))
+  // Cache selected labels to avoid repeated .map() calls (keys are mapped once into the Set below)
   let selected_labels = $derived(selected.map((opt) => utils.get_label(opt)))
   let input_committed_label = $derived(
     input_display && selected[0] !== undefined ? `${utils.get_label(selected[0])}` : null,
@@ -426,7 +425,7 @@
     return open && load_options_has_more && search_changed
   })
   // Sets for O(1) lookups (used in template, has_user_msg, group_header_state, batch operations)
-  let selected_keys_set = $derived(new SvelteSet(selected_keys))
+  let selected_keys_set = $derived(new SvelteSet(selected.map((opt) => key(opt))))
   // String-normalized for consistent comparison (numeric labels like 123 match "123")
   let selected_labels_set = $derived(
     new SvelteSet(selected_labels.map((label) => `${label}`)),
@@ -997,17 +996,13 @@
     } else input?.focus()
   }
 
+  // user messages only show while the input has an active query and no fetch is pending
+  const user_msgs_eligible = $derived(show_input_user_msg && !load_options_pending)
   const can_show_create_msg = $derived(
-    show_input_user_msg &&
-      Boolean(allowUserOptions) &&
-      Boolean(resolved_create_msg) &&
-      !load_options_pending,
+    user_msgs_eligible && Boolean(allowUserOptions) && Boolean(resolved_create_msg),
   )
   const can_show_no_match_msg = $derived(
-    show_input_user_msg &&
-      navigable_options.length === 0 &&
-      Boolean(noMatchingOptionsMsg) &&
-      !load_options_pending,
+    user_msgs_eligible && navigable_options.length === 0 && Boolean(noMatchingOptionsMsg),
   )
 
   // Check if a user message (create option, duplicate warning, no match) is visible
@@ -1582,43 +1577,39 @@
 
   // Single effect handles initial load + search changes
   $effect(() => {
-    if (!load_options_config) return
+    const config = load_options_config
+    if (!config) return
+
+    let debounce_timer: ReturnType<typeof setTimeout> | undefined
+    const clear_loaded_batch = () => {
+      loaded_options = []
+      load_options_has_more = true
+    }
+    // debounce a fresh load so the UI doesn't refetch on every keystroke
+    const schedule_load = () => {
+      debounce_timer = setTimeout(() => load_dynamic_options(true), config.debounce_ms)
+    }
 
     // Reset state when dropdown closes so next open triggers fresh load
     if (!open) {
       load_request_id++
       load_options_last_search = null
-      loaded_options = []
-      load_options_has_more = true
+      clear_loaded_batch()
       load_options_loading = false
       return
     }
 
     const search = effective_filter_text
     const is_first_load = load_options_last_search === null
-    let debounce_timer: ReturnType<typeof setTimeout> | undefined
 
     if (is_first_load) {
-      if (load_options_config.on_open) {
-        // Load immediately on dropdown open
-        load_dynamic_options(true)
-      } else if (search) {
-        // onOpen=false but user typed - debounce and load
-        debounce_timer = setTimeout(
-          () => load_dynamic_options(true),
-          load_options_config.debounce_ms,
-        )
-      }
-      // If onOpen=false and no search text, do nothing (wait for user to type)
+      // Load immediately on open; if onOpen=false, wait to debounce until the user types
+      if (config.on_open) load_dynamic_options(true)
+      else if (search) schedule_load()
     } else if (search !== load_options_last_search) {
-      // Subsequent loads: debounce search changes
-      // Clear stale results immediately so UI doesn't show wrong results while loading
-      loaded_options = []
-      load_options_has_more = true
-      debounce_timer = setTimeout(
-        () => load_dynamic_options(true),
-        load_options_config.debounce_ms,
-      )
+      // Subsequent loads: clear stale results immediately, then debounce the new search
+      clear_loaded_batch()
+      schedule_load()
     }
     return () => {
       if (debounce_timer) clearTimeout(debounce_timer)
@@ -2103,7 +2094,11 @@
     width: var(--sms-width);
     max-width: var(--sms-max-width);
     padding: var(--sms-padding, 0 3pt);
-    color: var(--sms-text-color);
+    /* pair the default text color with the light-dark() background so the widget
+       stays readable on dark pages that never declare color-scheme (light-dark()
+       falls back to light there). Set --sms-text-color: inherit to blend with the
+       page instead. */
+    color: var(--sms-text-color, light-dark(#222, #eee));
     font-size: var(--sms-font-size, inherit);
     min-height: var(--sms-min-height, 22pt);
     margin: var(--sms-margin);
@@ -2144,7 +2139,7 @@
       light-dark(rgba(100, 120, 140, 0.15), rgba(120, 170, 255, 0.2))
     );
     padding: var(--sms-selected-li-padding, 0 2pt 0 5pt);
-    color: var(--sms-selected-text-color, var(--sms-text-color));
+    color: var(--sms-selected-text-color, var(--sms-text-color, light-dark(#222, #eee)));
   }
   :where(div.multiselect > ul.selected > li[draggable='true']) {
     cursor: grab;
@@ -2205,7 +2200,7 @@
     flex: 1; /* this + next line fix issue #12 https://git.io/JiDe3 */
     min-width: 2em;
     /* ensure input uses text color and not --sms-selected-text-color */
-    color: var(--sms-text-color);
+    color: var(--sms-text-color, light-dark(#222, #eee));
     font-size: inherit;
     cursor: inherit; /* needed for disabled state */
     border-radius: 0; /* reset ul.selected > li */
@@ -2257,6 +2252,9 @@
       visibility 0.2s;
     box-sizing: border-box;
     background: var(--sms-options-bg, light-dark(#fcfcfc, #222226));
+    /* pair text with the light-dark() background: when portalled the dropdown is
+       moved to document.body and no longer inherits div.multiselect's color */
+    color: var(--sms-text-color, light-dark(#222, #eee));
     max-height: var(--sms-options-max-height, 50vh);
     overscroll-behavior: var(--sms-options-overscroll, none);
     box-shadow: var(

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1308,6 +1308,8 @@
   const drop = (target_idx: number) => (event: DragEvent) => {
     if (!event.dataTransfer) return
     event.dataTransfer.dropEffect = `move`
+    // parseInt keeps NaN (a safe no-op reorder) for empty/foreign drag data; Number('') → 0 moves item 0
+    // oxlint-disable-next-line unicorn/prefer-number-coercion
     const start_idx = parseInt(event.dataTransfer.getData(`text/plain`), 10)
     const previous = [...selected]
     const new_selected = [...selected]

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1600,10 +1600,14 @@
     }
 
     const search = effective_filter_text
-    const is_first_load = load_options_last_search === null
+    // First load = nothing dispatched yet for this open: no completed search AND none in
+    // flight. Read loading via untrack so its synchronous set inside load_dynamic_options
+    // can't re-trigger this effect — otherwise keystrokes during the still-awaiting first
+    // fetch would fire repeated immediate loads instead of taking the debounce path.
+    const is_first_load =
+      load_options_last_search === null && !untrack(() => load_options_loading)
 
     if (is_first_load) {
-      // Load immediately on open; if onOpen=false, wait to debounce until the user types
       if (config.on_open) load_dynamic_options(true)
       else if (search) schedule_load()
     } else if (search !== load_options_last_search) {

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -107,19 +107,23 @@
     focused_item_index = -1
   }
 
+  // Query the submenu links / toggle button of the dropdown for a given route href
+  const dropdown_links = (href: string) =>
+    document.querySelectorAll<HTMLElement>(
+      `.dropdown[data-href="${CSS.escape(href)}"] [data-submenu] a`,
+    )
+  const dropdown_toggle = (href: string) =>
+    document.querySelector<HTMLButtonElement>(
+      `.dropdown[data-href="${CSS.escape(href)}"] [data-dropdown-toggle]`,
+    )
+
   function toggle_dropdown(href: string, focus_first = false) {
     const is_opening = pinned_dropdown !== href
     pinned_dropdown = is_opening ? href : null
     hovered_dropdown = is_opening ? href : null
     focused_item_index = is_opening && focus_first ? 0 : -1
     if (is_opening && focus_first) {
-      setTimeout(() => {
-        document
-          .querySelector<HTMLElement>(
-            `.dropdown[data-href="${CSS.escape(href)}"] [data-submenu] a`,
-          )
-          ?.focus()
-      }, 0)
+      setTimeout(() => dropdown_links(href)[0]?.focus(), 0)
     }
   }
 
@@ -165,11 +169,7 @@
         0,
         Math.min(sub_routes.length - 1, focused_item_index + direction),
       )
-      document
-        .querySelectorAll<HTMLElement>(
-          `.dropdown[data-href="${CSS.escape(href)}"] [data-submenu] a`,
-        )
-        ?.[focused_item_index]?.focus()
+      dropdown_links(href)[focused_item_index]?.focus()
     }
 
     // Open dropdown with ArrowDown when closed
@@ -183,11 +183,7 @@
     if (event.key === `Escape`) {
       event.preventDefault()
       close_menus()
-      document
-        .querySelector<HTMLButtonElement>(
-          `.dropdown[data-href="${CSS.escape(href)}"] [data-dropdown-toggle]`,
-        )
-        ?.focus()
+      dropdown_toggle(href)?.focus()
     }
   }
 

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -880,6 +880,30 @@ export const tooltip =
             if (value) tooltip_el.style.setProperty(css_var_name, value)
           }
 
+          // Pages that style themselves dark via CSS vars but never declare `color-scheme`
+          // resolve the default light-dark() background to LIGHT while the inherited
+          // --text-color may be near-white → unreadable tooltip. Follow the OS preference
+          // and pair the text color with it. Pages that declare a scheme keep control
+          // (see #405), as do triggers with custom --tooltip-bg or own --text-color.
+          // Read the scheme from document.body (inherits any root-declared scheme), not
+          // the trigger: the tooltip is appended to body, so a scheme on some container
+          // around the trigger never reaches it.
+          const body_styles = getComputedStyle(document.body)
+          const page_scheme = body_styles.colorScheme
+          if (!page_scheme || page_scheme === `normal`) {
+            const text_color = tooltip_el.style.getPropertyValue(`--text-color`)
+            // body (not documentElement) since the body-mounted tooltip inherits from
+            // body, which in turn inherits any :root-declared vars
+            const page_text_color = body_styles.getPropertyValue(`--text-color`).trim()
+            const trigger_overrides =
+              tooltip_el.style.getPropertyValue(`--tooltip-bg`) ||
+              (text_color && text_color !== page_text_color)
+            if (!trigger_overrides) {
+              tooltip_el.style.setProperty(`color-scheme`, `light dark`)
+              tooltip_el.style.setProperty(`--text-color`, `light-dark(#222, #eee)`)
+            }
+          }
+
           // Append early so we can read computed border styles for arrow border
           document.body.append(tooltip_el)
 

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -104,8 +104,7 @@ export const draggable =
       node.style.left = `${initial.left + dx}px`
       node.style.top = `${initial.top + dy}px`
 
-      // Only call callback if it exists (minimize overhead)
-      if (options.on_drag) options.on_drag(event)
+      options.on_drag?.(event)
     }
 
     function handle_mouseup(event: MouseEvent) {

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1,5 +1,11 @@
 import type { Attachment } from 'svelte/attachments'
 import { fuzzy_match_indices, get_uuid } from './utils'
+// Computed CSS lengths resolve to `<number>px`; strip the unit so Number() can coerce.
+// Empty and non-px values (e.g. `none`, `0.5rem`) yield NaN so callers can apply fallbacks.
+const css_px = (css_length: string): number => {
+  const trimmed = css_length.trim()
+  return trimmed ? Number(trimmed.replace(/px$/, ``)) : NaN
+}
 
 // Type definitions for CSS highlight API (experimental)
 declare global {
@@ -630,7 +636,7 @@ export const tooltip =
         const arrow_size_raw = tooltip_styles
           .getPropertyValue(`--tooltip-arrow-size`)
           .trim()
-        const arrow_size_num = Number.parseInt(arrow_size_raw || ``, 10)
+        const arrow_size_num = css_px(arrow_size_raw)
         const arrow_px = Number.isFinite(arrow_size_num) ? arrow_size_num : 6
         apply_triangle_style(
           arrow,
@@ -645,7 +651,7 @@ export const tooltip =
         if (!border_arrow) return
 
         const border_color = tooltip_styles.borderTopColor
-        const border_width_num = Number.parseFloat(tooltip_styles.borderTopWidth || `0`)
+        const border_width_num = css_px(tooltip_styles.borderTopWidth)
         const has_border = !is_transparent(border_color) && border_width_num > 0
         if (!has_border) {
           border_arrow.remove()
@@ -667,13 +673,12 @@ export const tooltip =
         requestAnimationFrame(() => {
           if (!document.body.contains(tooltip_el)) return
           const computed = getComputedStyle(tooltip_el)
-          const padding_h =
-            parseFloat(computed.paddingLeft) + parseFloat(computed.paddingRight)
+          const padding_h = css_px(computed.paddingLeft) + css_px(computed.paddingRight)
           const border_h =
-            parseFloat(computed.borderLeftWidth) + parseFloat(computed.borderRightWidth)
+            css_px(computed.borderLeftWidth) + css_px(computed.borderRightWidth)
           // Handle max-width: none as unbounded, fallback to 280 only for invalid values
           const max_width_raw = computed.maxWidth
-          const max_width_parsed = parseFloat(max_width_raw)
+          const max_width_parsed = css_px(max_width_raw)
           const max_width =
             max_width_raw === `none`
               ? Infinity
@@ -890,14 +895,15 @@ export const tooltip =
           const body_styles = getComputedStyle(document.body)
           const page_scheme = body_styles.colorScheme
           if (!page_scheme || page_scheme === `normal`) {
-            const text_color = tooltip_el.style.getPropertyValue(`--text-color`)
-            // body (not documentElement) since the body-mounted tooltip inherits from
-            // body, which in turn inherits any :root-declared vars
-            const page_text_color = body_styles.getPropertyValue(`--text-color`).trim()
-            const trigger_overrides =
-              tooltip_el.style.getPropertyValue(`--tooltip-bg`) ||
-              (text_color && text_color !== page_text_color)
-            if (!trigger_overrides) {
+            // A var counts as a per-trigger override only if it differs from the value
+            // inherited from body/:root (page-level styling shouldn't disable the
+            // fallback). Compare against body, not documentElement: the body-mounted
+            // tooltip inherits from body, which in turn inherits :root-declared vars.
+            const overrides_page = (css_var: string) => {
+              const value = tooltip_el.style.getPropertyValue(css_var)
+              return value && value !== body_styles.getPropertyValue(css_var).trim()
+            }
+            if (!overrides_page(`--tooltip-bg`) && !overrides_page(`--text-color`)) {
               tooltip_el.style.setProperty(`color-scheme`, `light dark`)
               tooltip_el.style.setProperty(`--text-color`, `light-dark(#222, #eee)`)
             }

--- a/src/lib/heading-anchors.ts
+++ b/src/lib/heading-anchors.ts
@@ -57,23 +57,25 @@ export function heading_ids() {
         seen_ids.set(base_id, count + 1)
         return count ? `${base_id}-${count}` : base_id
       }
-      // Pass 1: Match headings at start of line (for .svelte files)
-      result = result.replace(
-        heading_regex_line_start,
-        (match, indent, tag, attrs, inner) => {
-          const id = process_heading(String(attrs), String(inner))
-          return id ? `${indent}<${tag} id="${id}"${attrs}>${inner}</${tag}>` : match
-        },
-      )
-
-      // Pass 2: Match headings after closing tag (for mdsvex single-line output)
-      result = result.replace(
-        heading_regex_after_tag,
-        (match, gt, space, tag, attrs, inner) => {
-          const id = process_heading(String(attrs), String(inner))
-          return id ? `${gt}${space}<${tag} id="${id}"${attrs}>${inner}</${tag}>` : match
-        },
-      )
+      // Rewrite a matched heading with a slug id (or return it unchanged). Pass 1 matches
+      // at line start (.svelte files); pass 2 after a closing tag (mdsvex single-line output).
+      const build_heading = (
+        match: string,
+        prefix: string,
+        tag: string,
+        attrs: string,
+        inner: string,
+      ) => {
+        const id = process_heading(attrs, inner)
+        return id ? `${prefix}<${tag} id="${id}"${attrs}>${inner}</${tag}>` : match
+      }
+      result = result
+        .replace(heading_regex_line_start, (match, indent, tag, attrs, inner) =>
+          build_heading(match, indent, tag, attrs, inner),
+        )
+        .replace(heading_regex_after_tag, (match, gt, space, tag, attrs, inner) =>
+          build_heading(match, `${gt}${space}`, tag, attrs, inner),
+        )
 
       return { code: result }
     },
@@ -115,16 +117,11 @@ function add_anchor_to_heading(heading: Element, icon_svg: string = link_svg): v
 
 const is_heading = (element: Element): boolean => /^H[1-6]$/u.test(element.tagName)
 
-const get_default_headings = (node: Element): Element[] => {
-  const headings: Element[] = []
-  for (const child of Array.from(node.children)) {
-    if (is_heading(child)) headings.push(child)
-    for (const grandchild of Array.from(child.children)) {
-      if (is_heading(grandchild)) headings.push(grandchild)
-    }
-  }
-  return headings
-}
+const get_default_headings = (node: Element): Element[] =>
+  [...node.children].flatMap((child) => [
+    ...(is_heading(child) ? [child] : []),
+    ...[...child.children].filter(is_heading),
+  ])
 
 // Svelte 5 attachment that adds anchor links to headings within a container
 // Uses MutationObserver to handle dynamically added headings

--- a/src/lib/heading-anchors.ts
+++ b/src/lib/heading-anchors.ts
@@ -70,9 +70,7 @@ export function heading_ids() {
         return id ? `${prefix}<${tag} id="${id}"${attrs}>${inner}</${tag}>` : match
       }
       result = result
-        .replace(heading_regex_line_start, (match, indent, tag, attrs, inner) =>
-          build_heading(match, indent, tag, attrs, inner),
-        )
+        .replace(heading_regex_line_start, build_heading)
         .replace(heading_regex_after_tag, (match, gt, space, tag, attrs, inner) =>
           build_heading(match, `${gt}${space}`, tag, attrs, inner),
         )

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -26,15 +26,11 @@ export function scroll_into_view_if_needed_polyfill(
   centerIfNeeded: boolean = true,
 ): IntersectionObserver {
   const observer = new IntersectionObserver(([entry], obs) => {
-    const ratio = entry.intersectionRatio
-    if (ratio < 1) {
-      const place = ratio <= 0 && centerIfNeeded ? `center` : `nearest`
-      element.scrollIntoView({
-        block: place,
-        inline: place,
-      })
-    }
     obs.disconnect()
+    const ratio = entry.intersectionRatio
+    if (ratio >= 1) return
+    const place = ratio <= 0 && centerIfNeeded ? `center` : `nearest`
+    element.scrollIntoView({ block: place, inline: place })
   })
   observer.observe(element)
 

--- a/src/lib/live-examples/highlighter.ts
+++ b/src/lib/live-examples/highlighter.ts
@@ -31,12 +31,10 @@ export const starry_night = await create_starry_night()
 export function starry_night_highlighter(code: string, lang?: string | null): string {
   const lang_key = lang?.toLowerCase()
   const scope = lang_key ? starry_night.flagToScope(lang_key) : undefined
-  if (!scope) {
-    // Return escaped code if language not supported
-    const escaped = escape_svelte(escape_html_text(code))
-    return `<pre class="highlight"><code>${escaped}</code></pre>`
-  }
-  const tree = starry_night.highlight(code, scope)
-  const html = escape_svelte(hast_to_html(tree))
-  return `<pre class="highlight highlight-${lang_key}"><code>${html}</code></pre>`
+  // fall back to plain escaped code when the language is missing or unsupported
+  const html = scope
+    ? escape_svelte(hast_to_html(starry_night.highlight(code, scope)))
+    : escape_svelte(escape_html_text(code))
+  const class_name = scope ? `highlight highlight-${lang_key}` : `highlight`
+  return `<pre class="${class_name}"><code>${html}</code></pre>`
 }

--- a/src/lib/live-examples/mdsvex-transform.ts
+++ b/src/lib/live-examples/mdsvex-transform.ts
@@ -4,9 +4,6 @@ import path from 'node:path'
 import { hast_to_html } from './hast.ts'
 import { starry_night } from './highlighter.ts'
 
-// Base64 encode to prevent preprocessors from modifying the content
-const to_base64 = (src: string): string => Buffer.from(src, `utf-8`).toString(`base64`)
-
 // Escape backticks and template literal syntax for embedding in template literals
 const encode_escapes = (src: string) =>
   src.replaceAll(`\``, `\\\``).replaceAll(`\${`, `\\$\{`)
@@ -87,7 +84,8 @@ function remark(options: RemarkOptions = {}): RemarkTransformer {
   const { defaults = {} } = options
 
   return function transformer(tree: RemarkTree, file: RemarkFile): void {
-    const examples: { csr?: boolean; wrapper_alias: string }[] = []
+    // csr flag per live example (index = component index); drives the import loop below
+    const example_csr: (boolean | undefined)[] = []
     // Track wrapper imports to avoid duplicates and generate unique aliases
     const wrapper_aliases = new Map<string, string>() // wrapper key -> alias name
 
@@ -115,25 +113,25 @@ function remark(options: RemarkOptions = {}): RemarkTransformer {
       }
 
       const { csr, example, Wrapper } = meta
+      const scope = node.lang ? starry_night.flagToScope(node.lang) : undefined
 
       // find code blocks with `example` meta in supported languages
-      if (example && node.lang && starry_night.flagToScope(node.lang)) {
+      if (example && node.lang && scope) {
         const is_live = LIVE_LANGUAGES.has(node.lang)
         const wrapper_alias = is_live ? get_wrapper_alias(Wrapper ?? DEFAULT_WRAPPER) : ``
 
         const value = create_example_component(
           node.value ?? ``,
           meta,
-          is_live ? examples.length : -1, // -1 for code-only (no component import needed)
+          is_live ? example_csr.length : -1, // -1 for code-only (no component import needed)
           node.lang,
+          scope,
           is_live,
           wrapper_alias,
         )
 
         // Only track live examples for component imports
-        if (is_live) {
-          examples.push({ csr, wrapper_alias })
-        }
+        if (is_live) example_csr.push(csr)
 
         node.type = `paragraph`
         node.children = [{ type: `text`, value }]
@@ -161,8 +159,8 @@ function remark(options: RemarkOptions = {}): RemarkTransformer {
       }
     }
     // Add example component imports
-    for (const [idx, ex] of examples.entries()) {
-      if (!ex.csr) {
+    for (const [idx, csr] of example_csr.entries()) {
+      if (!csr) {
         scripts += `import ${EXAMPLE_COMPONENT_PREFIX}${idx} from "${EXAMPLE_MODULE_PREFIX}${idx}.svelte";\n`
       }
     }
@@ -220,12 +218,11 @@ function create_example_component(
   meta: RemarkMeta,
   index: number,
   lang: string,
+  scope: string,
   is_live: boolean,
   wrapper_alias: string,
 ): string {
   const code = format_code(value, meta)
-  const scope = starry_night.flagToScope(lang)
-  if (!scope) throw new Error(`Unsupported language: ${lang}`)
   const tree = starry_night.highlight(code, scope)
   // Convert newlines to &#10; to prevent bundlers from stripping whitespace
   const highlighted = hast_to_html(tree).replaceAll(`\n`, `&#10;`)
@@ -243,7 +240,8 @@ function create_example_component(
   // src={...} expression — escaping backticks/`${` on top of it would double-escape
   // and inject literal backslashes into the runtime src prop.
   const component = `${EXAMPLE_COMPONENT_PREFIX}${index}`
-  const base64_src = to_base64(value)
+  // base64-encode to prevent preprocessors from modifying the content
+  const base64_src = Buffer.from(value, `utf-8`).toString(`base64`)
   const escaped_src = JSON.stringify(code)
   const escaped_meta = encode_escapes(JSON.stringify({ ...meta, lang }))
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,9 +4,9 @@ import type { HTMLAttributes, HTMLInputAttributes } from 'svelte/elements'
 
 export type Option = string | number | ObjectOption
 
-// single CSS string or an object with keys 'option' and 'selected', each a string,
+// single CSS string or an object with optional 'option' and 'selected' keys,
 // which only apply to the dropdown list and list of selected options, respectively
-export type OptionStyle = string | { option: string; selected: string }
+export type OptionStyle = string | { option?: string; selected?: string }
 
 export type ObjectOption = {
   label: string | number // user-displayed text

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -55,18 +55,19 @@ export function get_style(
   let css_str = ``
   if (key !== null && key !== `selected` && key !== `option`) {
     console.error(`MultiSelect: Invalid key=${String(key)} for get_style`)
+    return css_str
   }
   if (typeof option === `object` && option.style) {
     if (typeof option.style === `string`) css_str = option.style
     if (typeof option.style === `object` && key) {
       if (key in option.style) css_str = option.style[key] ?? ``
-      else {
-        // partial style objects (e.g. only `selected`) are fine; only error when
-        // the object has keys but none of the known ones
-        const has_known_key = `option` in option.style || `selected` in option.style
-        if (!has_known_key && Object.keys(option.style).length > 0) {
-          console.error(`MultiSelect: invalid style object for option`, option)
-        }
+      // partial style objects (e.g. only `selected`) are fine; flag any keys
+      // other than the known ones, even when a valid key is also present
+      const has_unknown_key = Object.keys(option.style).some(
+        (style_key) => style_key !== `option` && style_key !== `selected`,
+      )
+      if (has_unknown_key) {
+        console.error(`MultiSelect: invalid style object for option`, option)
       }
     }
   }
@@ -162,9 +163,7 @@ export function fuzzy_match_indices(
 // e.g., "tageoo" matches "tasks/geo-opt" because t-a-g-e-o-o appears in order
 export function fuzzy_match(search_text: string, target_text: string): boolean {
   // guard null/undefined inputs (fuzzy_match_indices would throw on .toLowerCase())
-  if ([search_text, target_text].some((val) => val === null || val === undefined)) {
-    return false
-  }
+  if (search_text == null || target_text == null) return false
   // empty search matches everything, empty target matches nothing - both already
   // handled by fuzzy_match_indices (empty search -> [], else vs empty target -> null)
   return fuzzy_match_indices(search_text, target_text) !== null

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -161,15 +161,10 @@ export function fuzzy_match_indices(
 // Returns true if the search string can be found as a subsequence in the target string
 // e.g., "tageoo" matches "tasks/geo-opt" because t-a-g-e-o-o appears in order
 export function fuzzy_match(search_text: string, target_text: string): boolean {
-  // Handle null/undefined inputs first
-  if (
-    search_text === null ||
-    search_text === undefined ||
-    target_text === null ||
-    target_text === undefined
-  )
+  // guard null/undefined inputs (fuzzy_match_indices would throw on .toLowerCase())
+  if ([search_text, target_text].some((val) => val === null || val === undefined)) {
     return false
-
+  }
   // empty search matches everything, empty target matches nothing - both already
   // handled by fuzzy_match_indices (empty search -> [], else vs empty target -> null)
   return fuzzy_match_indices(search_text, target_text) !== null

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -58,9 +58,16 @@ export function get_style(
   }
   if (typeof option === `object` && option.style) {
     if (typeof option.style === `string`) css_str = option.style
-    if (typeof option.style === `object`) {
-      if (key && key in option.style) return option.style[key] ?? ``
-      else if (key) console.error(`MultiSelect: invalid style object for option`, option)
+    if (typeof option.style === `object` && key) {
+      if (key in option.style) css_str = option.style[key] ?? ``
+      else {
+        // partial style objects (e.g. only `selected`) are fine; only error when
+        // the object has keys but none of the known ones
+        const has_known_key = `option` in option.style || `selected` in option.style
+        if (!has_known_key && Object.keys(option.style).length > 0) {
+          console.error(`MultiSelect: invalid style object for option`, option)
+        }
+      }
     }
   }
   // ensure css_str ends with a semicolon

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -53,14 +53,19 @@ test.describe(`input`, () => {
     await page.goto(`/ui`, { waitUntil: `networkidle` })
     const dropdown = page.locator(`#foods div.multiselect > ul.options`)
 
-    await expect(dropdown).toHaveClass(/hidden/u)
+    // generous timeout: on cold CI runs the dev server may still be compiling /ui
+    await expect(dropdown).toHaveClass(/hidden/u, { timeout: 15_000 })
     await expect(dropdown).toBeHidden()
 
-    await page.evaluate(() => {
-      const input = document.querySelector<HTMLInputElement>(`#foods input[autocomplete]`)
-      input?.focus()
-    })
-    await expect(dropdown).not.toHaveClass(/hidden/u)
+    const focus_input = () =>
+      page.evaluate(() => {
+        document.querySelector<HTMLInputElement>(`#foods input[autocomplete]`)?.focus()
+      })
+    // retry focus: it's a no-op if it fires before hydration attached the focus handler
+    await expect(async () => {
+      await focus_input()
+      await expect(dropdown).not.toHaveClass(/hidden/u, { timeout: 1000 })
+    }).toPass()
     await expect(dropdown).toBeVisible()
 
     await page.evaluate(() => {

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -43,7 +43,7 @@ test(`array cloning infinite loop prevention (issue #309)`, async ({ page }) => 
   await expect(status.locator(`text=⚠️ Regression`)).not.toBeVisible()
 
   const count_text = await status.textContent()
-  const count = parseInt(count_text?.match(/\d+/u)?.[0] ?? `0`, 10)
+  const count = Math.trunc(Number(count_text?.match(/\d+/u)?.[0] ?? `0`))
   expect(count).toBeLessThan(10)
 })
 

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -1,6 +1,17 @@
 // deno-lint-ignore-file no-await-in-loop
 import { foods, languages, octicons } from '$site/options'
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
+
+// Open the /portal demo modal and return its content locator
+async function open_portal_modal(page: Page): Promise<Locator> {
+  await page.goto(`/portal`, { waitUntil: `networkidle` })
+  await page.getByRole(`button`, { name: `Open Modal` }).click()
+  return page.locator(`div.modal-content.modal`)
+}
+
+// Locate the visible portalled dropdown containing an option with the given label
+const portalled_options = (page: Page, label: string): Locator =>
+  page.locator(`body > ul.options:not(.hidden):has(li:has-text("${label}"))`)
 
 async function goto_persistent(page: Page): Promise<void> {
   await page.goto(`/persistent`)
@@ -186,19 +197,14 @@ test.describe(`portal feature`, () => {
 
   test(`mobile touch selection works with portal enabled`, async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 })
-    await page.goto(`/portal`, { waitUntil: `networkidle` })
-    await page.getByRole(`button`, { name: `Open Modal` }).click()
-
-    const modal_content = page.locator(`div.modal-content.modal`)
+    const modal_content = await open_portal_modal(page)
     const languages_input = modal_content.locator(
       `div.multiselect input[placeholder='Choose languages...']`,
     )
 
     await languages_input.click()
 
-    const portalled_languages_options = page.locator(
-      `body > ul.options:not(.hidden):has(li:has-text("${languages[0]}"))`,
-    )
+    const portalled_languages_options = portalled_options(page, languages[0])
     await expect(portalled_languages_options).toBeVisible()
 
     const dropdown_stays_open = await page.evaluate(() => {
@@ -228,18 +234,13 @@ test.describe(`portal feature`, () => {
   })
 
   test(`dropdowns in modal render in body when portal is active`, async ({ page }) => {
-    await page.goto(`/portal`, { waitUntil: `networkidle` })
-    await page.getByRole(`button`, { name: `Open Modal` }).click()
-
-    const modal_content = page.locator(`div.modal-content.modal`)
+    const modal_content = await open_portal_modal(page)
     const languages_input = modal_content.locator(
       `div.multiselect input[placeholder='Choose languages...']`,
     )
     await languages_input.click()
 
-    const portalled_languages_options = page.locator(
-      `body > ul.options:not(.hidden):has(li:has-text("${languages[0]}"))`,
-    )
+    const portalled_languages_options = portalled_options(page, languages[0])
     await expect(portalled_languages_options).toBeVisible()
     await expect(
       modal_content
@@ -263,9 +264,7 @@ test.describe(`portal feature`, () => {
     )
     await octicons_input.click()
 
-    const portalled_octicons_options = page.locator(
-      `body > ul.options:not(.hidden):has(li:has-text("${octicons[0]}"))`,
-    )
+    const portalled_octicons_options = portalled_options(page, octicons[0])
     await expect(portalled_octicons_options).toBeVisible()
     await expect(
       modal_content
@@ -290,10 +289,7 @@ test.describe(`portal feature`, () => {
     page,
   }) => {
     await page.setViewportSize({ width: 900, height: 700 })
-    await page.goto(`/portal`, { waitUntil: `networkidle` })
-    await page.getByRole(`button`, { name: `Open Modal` }).click()
-
-    const modal_content = page.locator(`div.modal-content.modal`)
+    const modal_content = await open_portal_modal(page)
     const languages_input_selector = `div.multiselect input[placeholder='Choose languages...']`
     const languages_input = modal_content.locator(languages_input_selector)
 
@@ -311,9 +307,7 @@ test.describe(`portal feature`, () => {
     })
 
     await languages_input.click()
-    const portalled_languages_options = page.locator(
-      `body > ul.options:not(.hidden):has(li:has-text("${languages[0]}"))`,
-    )
+    const portalled_languages_options = portalled_options(page, languages[0])
     await expect(portalled_languages_options).toBeVisible()
 
     const assert_aligned = async () => {
@@ -400,4 +394,68 @@ test(`component buttons are styled correctly with border: none`, async ({ page }
     (element) => getComputedStyle(element).borderStyle,
   )
   expect(border_style).toBe(`none`)
+})
+
+// Runtime regression tests for the schemeless-dark-page readability fix: the component
+// pairs a light-dark() text-color default with its light-dark() backgrounds so text can't
+// inherit a near-white page color on pages that never declare `color-scheme` (there
+// light-dark() resolves to its light branch). happy-dom strips light-dark()/var() from
+// computed styles, so this can only be verified in a real browser.
+// light-dark(#222, #eee) → #222 = rgb(34, 34, 34) under the schemeless (light) scheme.
+test.describe(`schemeless-dark-page text-color readability`, () => {
+  test.use({ colorScheme: `light` }) // schemeless subtree resolves light-dark() to its light branch
+  const readable = `rgb(34, 34, 34)`
+  const computed_color = (page: Page, selector: string) =>
+    page
+      .locator(selector)
+      .first()
+      .evaluate((element) => getComputedStyle(element).color)
+
+  // in-place: the div.multiselect root default cascades to the input the user types in
+  test(`in-place widget text uses the light-dark() default, not the inherited page color`, async ({
+    page,
+  }) => {
+    await page.goto(`/ui`, { waitUntil: `networkidle` })
+
+    // simulate a dark page that never declares color-scheme: force the schemeless (normal)
+    // scheme on the widget's subtree and give its parent a distinctive inherited color.
+    await page.evaluate(() => {
+      const parent =
+        document.querySelector<HTMLElement>(`#foods div.multiselect`)?.parentElement
+      if (!parent) throw new Error(`#foods div.multiselect parent not found`)
+      parent.style.colorScheme = `normal`
+      parent.style.color = `rgb(255, 0, 0)`
+    })
+
+    expect(await computed_color(page, `#foods div.multiselect`), `root`).toBe(readable)
+    expect(await computed_color(page, `#foods input[autocomplete]`), `input`).toBe(
+      readable,
+    )
+  })
+
+  // portalled: ul.options is moved to document.body and no longer inherits div.multiselect's
+  // color, so it needs its own default — this is the surface an in-place test can't verify.
+  test(`portalled dropdown text uses the light-dark() default, not the inherited page color`, async ({
+    page,
+  }) => {
+    const modal_content = await open_portal_modal(page)
+    await modal_content.locator(`input[placeholder='Choose languages...']`).click()
+
+    const dropdown = page.locator(`body > ul.options:not(.hidden)`)
+    await expect(dropdown).toBeVisible()
+
+    // schemeless dark page: the portalled dropdown inherits color-scheme + color from body
+    await page.evaluate(() => {
+      document.body.style.colorScheme = `normal`
+      document.body.style.color = `rgb(255, 0, 0)`
+    })
+
+    expect(await computed_color(page, `body > ul.options:not(.hidden)`), `dropdown`).toBe(
+      readable,
+    )
+    expect(
+      await computed_color(page, `body > ul.options:not(.hidden) > li`),
+      `option`,
+    ).toBe(readable)
+  })
 })

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -2893,11 +2893,11 @@ test(`remove buttons lack default-icon class when removeIcon snippet is provided
 test(`errors to console when option is an object but has no label key`, () => {
   console.error = vi.fn()
 
-  // mount() doesn't enforce generic component prop types, so { foo: 42 }
-  // isn't caught as a type error despite ObjectOption requiring label https://github.com/sveltejs/svelte/issues/17658
+  // mount() doesn't enforce generic component prop types, so { foo: 42 } is accepted
+  // despite ObjectOption requiring label https://github.com/sveltejs/svelte/issues/17658
   mount(MultiSelect, {
     target: document.body,
-    props: { options: [{ foo: 42 } as unknown as Option] }, // eslint-disable-line @typescript-eslint/no-unsafe-type-assertion
+    props: { options: [{ foo: 42 }] },
   })
 
   expect(console.error).toHaveBeenCalledWith(

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -956,12 +956,10 @@ test(`required and non-empty MultiSelect makes form pass validity check`, () => 
 })
 
 test.each([
-  [
-    [1, 2, 3],
-    [`a`, `b`, `c`],
-    [{ label: `a` }, { label: `b` }, { label: `c` }],
-  ],
-])(`passes selected options=%s to form submission handlers`, async (options) => {
+  [[1, 2, 3]],
+  [[`a`, `b`, `c`]],
+  [[{ label: `a` }, { label: `b` }, { label: `c` }]],
+])(`passes selected options=%j to form submission handlers`, async (options) => {
   const form = document.createElement(`form`)
   // actual form submission not supported in nodejs, would throw without preventing default behavior
   form.addEventListener(`submit`, (event) => event.preventDefault())
@@ -2481,16 +2479,12 @@ describe(`arrow key navigation between selected items`, () => {
     expect(highlighted()).toHaveLength(0)
   })
 
-  test(`ArrowLeft is no-op with no selected items`, async () => {
-    const input = setup([])
-    input.dispatchEvent(press(`ArrowLeft`))
-    await tick()
-    expect(highlighted()).toHaveLength(0)
-  })
-
-  test(`ArrowRight is no-op without prior highlight`, async () => {
-    const input = setup()
-    input.dispatchEvent(press(`ArrowRight`))
+  test.each([
+    [`ArrowLeft`, []],
+    [`ArrowRight`, [`Red`, `Green`, `Blue`]],
+  ])(`%s is a no-op when highlight cannot start`, async (key, selected) => {
+    const input = setup(selected)
+    input.dispatchEvent(press(key))
     await tick()
     expect(highlighted()).toHaveLength(0)
   })
@@ -2606,7 +2600,12 @@ describe(`arrow key navigation between selected items`, () => {
     expect(highlighted()).toHaveLength(0)
   })
 
-  test(`external selected shrink clamps highlighted_idx`, async () => {
+  test.each([
+    // externally shrinking past the highlighted idx should clamp to the last valid index;
+    // clearing should drop the highlight entirely (expected_idx null)
+    [`shrink clamps highlighted_idx`, [`Red`, `Green`], 1],
+    [`clear nullifies highlighted_idx`, [], null],
+  ])(`external selected %s`, async (_name, next_selected, expected_idx) => {
     const props = $state<MultiSelectProps>({
       options,
       selected: [`Red`, `Green`, `Blue`],
@@ -2617,27 +2616,11 @@ describe(`arrow key navigation between selected items`, () => {
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
     expect(is_highlighted(2)).toBe(true)
-    // externally shrink to 2 items — idx 2 is out of bounds
-    props.selected = [`Red`, `Green`]
+    props.selected = next_selected
     await tick()
-    expect(selected_items()).toHaveLength(2)
-    // $effect should clamp to last valid index (1)
-    expect(is_highlighted(1)).toBe(true)
-  })
-
-  test(`external selected clear nullifies highlighted_idx`, async () => {
-    const props = $state<MultiSelectProps>({
-      options,
-      selected: [`Red`, `Green`, `Blue`],
-    })
-    mount(MultiSelect, { target: document.body, props })
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(press(`ArrowLeft`))
-    await tick()
-    expect(highlighted()).toHaveLength(1)
-    props.selected = []
-    await tick()
-    expect(highlighted()).toHaveLength(0)
+    expect(selected_items()).toHaveLength(next_selected.length)
+    if (expected_idx === null) expect(highlighted()).toHaveLength(0)
+    else expect(is_highlighted(expected_idx)).toBe(true)
   })
 
   test(`highlighted pill does not set aria-activedescendant`, async () => {
@@ -4514,60 +4497,26 @@ describe(`loadOptions feature`, () => {
     ul.dispatchEvent(new Event(`scroll`))
   }
 
-  test(`loadOptions is called when dropdown opens`, async () => {
-    const load_options = vi.fn(() =>
-      Promise.resolve({ options: mock_data.slice(0, 50), hasMore: true }),
-    )
-    // Use open prop directly for reliable testing
-    mount(MultiSelect, {
-      target: document.body,
-      props: { loadOptions: load_options, open: true },
-    })
-    await tick()
+  // bare-fn and `{ fetch }` object forms both default to batchSize 50 / onOpen true, so
+  // the object form parameterizes all three initial-open cases uniformly
+  test.each([
+    [`default batch on open`, {}, 1, { search: ``, offset: 0, limit: 50 }],
+    [`batchSize config`, { batchSize: 25 }, 1, { search: ``, offset: 0, limit: 25 }],
+    [`onOpen=false skips open load`, { onOpen: false }, 0, null],
+  ])(
+    `loadOptions initial fetch: %s`,
+    async (_label, config_extra, expected_calls, expected_args) => {
+      const load_options = vi.fn(() => Promise.resolve({ options: [], hasMore: false }))
+      mount(MultiSelect, {
+        target: document.body,
+        props: { loadOptions: { fetch: load_options, ...config_extra }, open: true },
+      })
+      await tick()
 
-    expect(load_options).toHaveBeenCalledTimes(1)
-    expect(load_options).toHaveBeenCalledWith({
-      search: ``,
-      offset: 0,
-      limit: 50, // default batch size
-    })
-  })
-
-  test(`loadOptions respects batchSize config`, async () => {
-    const load_options = vi.fn(() =>
-      Promise.resolve({ options: mock_data.slice(0, 25), hasMore: true }),
-    )
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        loadOptions: { fetch: load_options, batchSize: 25 },
-        open: true,
-      },
-    })
-    await tick()
-
-    expect(load_options).toHaveBeenCalledWith({
-      search: ``,
-      offset: 0,
-      limit: 25,
-    })
-  })
-
-  test(`loadOptions onOpen=false prevents loading on dropdown open`, async () => {
-    const load_options = vi.fn(() =>
-      Promise.resolve({ options: [`Test`], hasMore: false }),
-    )
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        loadOptions: { fetch: load_options, onOpen: false },
-        open: true,
-      },
-    })
-    await tick()
-
-    expect(load_options).not.toHaveBeenCalled()
-  })
+      expect(load_options).toHaveBeenCalledTimes(expected_calls)
+      if (expected_args) expect(load_options).toHaveBeenCalledWith(expected_args)
+    },
+  )
 
   test(`loadOptions renders loaded options in dropdown`, async () => {
     const load_options = vi.fn(() =>
@@ -4604,53 +4553,43 @@ describe(`loadOptions feature`, () => {
     expect(document.querySelector(`ul.options > li.loading-more`)).toBeNull()
   })
 
-  test(`scroll triggers pagination when hasMore=true`, async () => {
-    const load_options = vi
-      .fn()
-      .mockResolvedValueOnce({ options: mock_data.slice(0, 50), hasMore: true })
-      .mockResolvedValueOnce({ options: mock_data.slice(50, 100), hasMore: false })
+  test.each([
+    [
+      `triggers another fetch when hasMore=true`,
+      () =>
+        vi
+          .fn()
+          .mockResolvedValueOnce({ options: mock_data.slice(0, 50), hasMore: true })
+          .mockResolvedValueOnce({ options: mock_data.slice(50, 100), hasMore: false }),
+      2,
+      { search: ``, offset: 50, limit: 50 },
+    ],
+    [
+      `does not fetch again when hasMore=false`,
+      () => vi.fn(() => Promise.resolve({ options: [`A`, `B`], hasMore: false })),
+      1,
+      null,
+    ],
+  ])(
+    `scroll pagination: %s`,
+    async (_label, make_load_options, expected_calls, last_args) => {
+      const load_options = make_load_options()
+      mount(MultiSelect, {
+        target: document.body,
+        props: { loadOptions: load_options, open: true },
+      })
+      await tick()
+      await tick()
 
-    mount(MultiSelect, {
-      target: document.body,
-      props: { loadOptions: load_options, open: true },
-    })
-    await tick()
-    await tick()
+      expect(load_options).toHaveBeenCalledTimes(1)
 
-    expect(load_options).toHaveBeenCalledTimes(1)
+      mock_scroll_near_bottom(doc_query(`ul.options`))
+      await tick()
 
-    const ul = doc_query(`ul.options`)
-    mock_scroll_near_bottom(ul)
-    await tick()
-
-    expect(load_options).toHaveBeenCalledTimes(2)
-    expect(load_options).toHaveBeenLastCalledWith({
-      search: ``,
-      offset: 50,
-      limit: 50,
-    })
-  })
-
-  test(`scroll does not trigger when hasMore=false`, async () => {
-    const load_options = vi.fn(() =>
-      Promise.resolve({ options: [`A`, `B`], hasMore: false }),
-    )
-
-    mount(MultiSelect, {
-      target: document.body,
-      props: { loadOptions: load_options, open: true },
-    })
-    await tick()
-    await tick()
-
-    expect(load_options).toHaveBeenCalledTimes(1)
-
-    const ul = doc_query(`ul.options`)
-    mock_scroll_near_bottom(ul)
-    await tick()
-
-    expect(load_options).toHaveBeenCalledTimes(1)
-  })
+      expect(load_options).toHaveBeenCalledTimes(expected_calls)
+      if (last_args) expect(load_options).toHaveBeenLastCalledWith(last_args)
+    },
+  )
 
   // https://github.com/janosh/svelte-multiselect/issues/412
   test(`auto-fills when small batchSize doesn't overflow dropdown`, async () => {
@@ -5475,15 +5414,38 @@ describe(`CSS static analysis`, () => {
     expect(default_icon_block).toMatch(/overflow:\s*hidden/u)
   })
 
-  test(`options dropdown has border with light-dark default`, () => {
+  test(`options dropdown border and bg use light-dark defaults`, () => {
     expect(options_block).toMatch(/--sms-options-border,\s*1px solid light-dark\(/u)
     expect(options_block).toMatch(
       /border-width:\s*var\(--sms-options-border-width,\s*1px\)/u,
     )
+    expect(options_block).toMatch(/--sms-options-bg,\s*light-dark\(#fcfcfc/u)
   })
 
-  test(`options dropdown bg contrasts with typical page bg`, () => {
-    expect(options_block).toMatch(/--sms-options-bg,\s*light-dark\(#fcfcfc/u)
+  // Guards the schemeless-dark-page readability fix: the primary text-bearing surfaces
+  // (root, input, dropdown) must pair their light-dark() background with a light-dark()
+  // text default, so the widget can't render white-on-white when the page never declares
+  // color-scheme (light-dark() → light).
+  test.each([
+    [`div.multiselect root`, /:where\(div\.multiselect\)\s*\{(?<block>[\s\S]*?)\}/u],
+    [
+      `input`,
+      /:where\(div\.multiselect > ul\.selected > input\)\s*\{(?<block>[\s\S]*?)\}/u,
+    ],
+    [`ul.options dropdown`, /:where\(ul\.options\)\s*\{(?<block>[\s\S]*?)\}/u],
+  ])(`%s pairs text color with a light-dark() default`, (_desc, pattern) => {
+    expect(get_css_block(pattern)).toMatch(
+      /color:\s*var\(--sms-text-color,\s*light-dark\(#222,\s*#eee\)\)/u,
+    )
+  })
+
+  test(`selected option text color chain ends in a light-dark() default`, () => {
+    const selected_block = get_css_block(
+      /:where\(div\.multiselect > ul\.selected > li\)\s*\{(?<block>[\s\S]*?)\}/u,
+    )
+    expect(selected_block).toMatch(
+      /color:\s*var\(--sms-selected-text-color,\s*var\(--sms-text-color,\s*light-dark\(#222,\s*#eee\)\)\)/u,
+    )
   })
 
   test(`custom-snippet remove-all overrides circular defaults`, () => {
@@ -6250,14 +6212,19 @@ describe(`option grouping feature`, () => {
     expect(count_span?.textContent?.trim()).toBe(expected_count)
   })
 
-  test(`searchExpandsCollapsedGroups expands matching groups`, async () => {
+  test.each([
+    [`expands the matching group`, `Rock`, { group: `Genre`, collapsed: false }],
+    // "C Major"/"D Minor" contain spaces, so a bare space fuzzy-matches them. The
+    // has_search_text guard must stop the Key group expanding on whitespace-only input.
+    [`ignores whitespace-only input`, ` `, null],
+  ])(`searchExpandsCollapsedGroups %s`, async (_name, search, expected_toggle) => {
     const ongroupToggle_spy = vi.fn()
     mount(MultiSelect, {
       target: document.body,
       props: {
         options: grouped_options,
         collapsibleGroups: true,
-        collapsedGroups: new Set([`Genre`, `Key`]), // Both collapsed initially
+        collapsedGroups: new Set([`Genre`, `Key`]), // both collapsed initially
         searchExpandsCollapsedGroups: true,
         ongroupToggle: ongroupToggle_spy,
         open: true,
@@ -6265,47 +6232,21 @@ describe(`option grouping feature`, () => {
     })
     await tick()
 
-    // Both groups collapsed, so no options visible
-    const visible_options = document.querySelectorAll(
-      `ul.options > li:not(.group-header):not(.select-all):not(.user-msg)`,
-    )
-    // Only ungrouped option visible
-    expect(visible_options).toHaveLength(1)
+    // both groups collapsed → only the ungrouped option is visible initially
+    expect(
+      document.querySelectorAll(
+        `ul.options > li:not(.group-header):not(.select-all):not(.user-msg)`,
+      ),
+    ).toHaveLength(1)
 
-    // Type search that matches Genre option
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.value = `Rock`
+    input.value = search
     input.dispatchEvent(input_event)
     await tick()
 
-    // Genre group should now be expanded because "Rock" matches
-    // ongroupToggle should have been called
-    expect(ongroupToggle_spy).toHaveBeenCalledWith({ group: `Genre`, collapsed: false })
-  })
-
-  test(`searchExpandsCollapsedGroups ignores whitespace-only input`, async () => {
-    // "C Major" and "D Minor" contain spaces, so a single space fuzzy-matches them.
-    // Without the has_search_text guard, the Key group would expand on whitespace input.
-    const ongroupToggle_spy = vi.fn()
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        options: grouped_options,
-        collapsibleGroups: true,
-        collapsedGroups: new Set([`Genre`, `Key`]),
-        searchExpandsCollapsedGroups: true,
-        ongroupToggle: ongroupToggle_spy,
-        open: true,
-      },
-    })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.value = ` `
-    input.dispatchEvent(input_event)
-    await tick()
-
-    expect(ongroupToggle_spy).not.toHaveBeenCalled()
+    if (expected_toggle) {
+      expect(ongroupToggle_spy).toHaveBeenCalledWith(expected_toggle)
+    } else expect(ongroupToggle_spy).not.toHaveBeenCalled()
   })
 
   test.each([

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -1066,11 +1066,14 @@ test(`invalid=true gives top-level div class 'invalid' and input attribute of 'a
 })
 
 describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
-  test(`implements ARIA combobox pattern with proper attributes and listbox association`, async () => {
+  const mount_a11y = (props: Partial<MultiSelectProps> = {}) =>
     mount(MultiSelect, {
       target: document.body,
-      props: { options: [`foo`, `bar`, `baz`] },
+      props: { options: [`foo`, `bar`, `baz`], ...props },
     })
+
+  test(`implements ARIA combobox pattern with proper attributes and listbox association`, async () => {
+    mount_a11y()
 
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
 
@@ -1097,10 +1100,7 @@ describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
   })
 
   test(`aria-activedescendant tracks keyboard navigation with unique option IDs`, async () => {
-    mount(MultiSelect, {
-      target: document.body,
-      props: { options: [`foo`, `bar`, `baz`] },
-    })
+    mount_a11y()
 
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
     input.focus()
@@ -1134,10 +1134,7 @@ describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
     [`foo`, `1 option available`],
     [`xyz`, `0 options available`],
   ])(`aria-live region announces "%s" filter as "%s"`, async (filter, expected) => {
-    mount(MultiSelect, {
-      target: document.body,
-      props: { options: [`foo`, `bar`, `baz`] },
-    })
+    mount_a11y()
 
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
     input.focus()
@@ -1199,10 +1196,7 @@ describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
   })
 
   test(`options have aria-posinset and aria-setsize for position announcements`, async () => {
-    mount(MultiSelect, {
-      target: document.body,
-      props: { options: [`foo`, `bar`, `baz`] },
-    })
+    mount_a11y()
 
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
     input.focus()
@@ -1220,10 +1214,7 @@ describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
   })
 
   test(`aria-live announces selection changes`, async () => {
-    mount(MultiSelect, {
-      target: document.body,
-      props: { options: [`foo`, `bar`, `baz`] },
-    })
+    mount_a11y()
 
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
     input.focus()
@@ -3981,15 +3972,7 @@ test.each([
 )
 
 test(`closeDropdownOnSelect='retain-focus' works correctly with maxSelect`, async () => {
-  mount(MultiSelect, {
-    target: document.body,
-    props: {
-      options: [1, 2, 3],
-      closeDropdownOnSelect: `retain-focus`,
-      maxSelect: 2,
-      open: true,
-    },
-  })
+  mount_retain_focus({ options: [1, 2, 3], maxSelect: 2 })
 
   const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
   input_el.focus()
@@ -4009,14 +3992,7 @@ test(`closeDropdownOnSelect='retain-focus' works correctly with maxSelect`, asyn
 })
 
 test(`Escape and Tab still blur input even with closeDropdownOnSelect='retain-focus'`, async () => {
-  mount(MultiSelect, {
-    target: document.body,
-    props: {
-      options: [1, 2, 3],
-      closeDropdownOnSelect: `retain-focus`,
-      open: true,
-    },
-  })
+  mount_retain_focus({ options: [1, 2, 3] })
 
   const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
   input_el.focus()
@@ -5136,6 +5112,33 @@ describe(`load_options_pending`, () => {
   }
 
   beforeEach(() => vi.useFakeTimers())
+
+  test(`typing during the first in-flight load debounces instead of firing immediate fetches`, async () => {
+    const { fetch_fn } = create_deferred_fetch()
+
+    mount(MultiSelect, {
+      target: document.body,
+      // onOpen defaults to true, so the first load fires immediately on open
+      props: { loadOptions: { fetch: fetch_fn, debounceMs: 200 }, open: true },
+    })
+    await tick()
+    expect(fetch_fn).toHaveBeenCalledTimes(1) // immediate open load, still in-flight
+
+    // type two chars while the first fetch is still awaiting (load_options_last_search
+    // is null until it resolves). Pre-fix, each keystroke re-entered the first-load branch
+    // and fired another immediate load_dynamic_options(true); the fix routes them to debounce.
+    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    for (const value of [`a`, `ab`]) {
+      input.value = value
+      input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
+      await tick()
+    }
+    expect(fetch_fn).toHaveBeenCalledTimes(1) // no extra immediate fetches while debouncing
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(fetch_fn).toHaveBeenCalledTimes(2) // exactly one debounced fetch for the latest search
+    expect(fetch_fn).toHaveBeenLastCalledWith(expect.objectContaining({ search: `ab` }))
+  })
 
   test(`Enter during debounce does not create unwanted option`, async () => {
     const { fetch_fn, fetch_resolvers } = create_deferred_fetch()
@@ -6502,32 +6505,48 @@ describe(`option grouping feature`, () => {
 })
 
 describe(`keyboard shortcuts`, () => {
-  test(`ctrl+a selects all when shortcut is explicitly set`, async () => {
+  // Mount with shortcut props, focus the input, dispatch one keydown, and return the
+  // bound props plus the (cancelable) event so callers can assert selection + defaultPrevented.
+  async function test_shortcut(
+    shortcut_props: Partial<MultiSelectProps>,
+    key_event: {
+      key: string
+      ctrlKey?: boolean
+      shiftKey?: boolean
+      altKey?: boolean
+      metaKey?: boolean
+    },
+  ): Promise<{ props: MultiSelectProps; input: HTMLInputElement; event: KeyboardEvent }> {
     const props = $state<MultiSelectProps>({
       options: [`a`, `b`, `c`],
-      selectAllOption: true,
       selected: [],
-      shortcuts: { select_all: `ctrl+a` },
       open: true,
+      ...shortcut_props,
     })
 
     mount(MultiSelect, { target: document.body, props })
     await tick()
 
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    input.focus()
     const event = new KeyboardEvent(`keydown`, {
-      key: `a`,
-      ctrlKey: true,
+      ...key_event,
       bubbles: true,
       cancelable: true,
     })
-    const prevent_default_spy = vi.spyOn(event, `preventDefault`)
-
     input.dispatchEvent(event)
     await tick()
 
+    return { props, input, event }
+  }
+
+  test(`ctrl+a selects all when shortcut is explicitly set`, async () => {
+    const { props, event } = await test_shortcut(
+      { selectAllOption: true, shortcuts: { select_all: `ctrl+a` } },
+      { key: `a`, ctrlKey: true },
+    )
     expect(props.selected).toEqual([`a`, `b`, `c`])
-    expect(prevent_default_spy).toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
   })
 
   test.each([
@@ -6536,54 +6555,26 @@ describe(`keyboard shortcuts`, () => {
   ])(
     `%s clears all selected options and prevents default`,
     async (_label, shortcut_override, modifiers) => {
-      const props = $state<MultiSelectProps>({
-        options: [`a`, `b`, `c`],
-        selected: [`a`, `b`],
-        open: true,
-        ...(Object.keys(shortcut_override).length > 0
-          ? { shortcuts: shortcut_override }
-          : {}),
-      })
-
-      mount(MultiSelect, { target: document.body, props })
-      await tick()
-
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-      input.focus()
-      const event = new KeyboardEvent(`keydown`, {
-        key: `Backspace`,
-        ...modifiers,
-        bubbles: true,
-        cancelable: true,
-      })
-      input.dispatchEvent(event)
-      await tick()
-
+      const { props, event } = await test_shortcut(
+        {
+          selected: [`a`, `b`],
+          ...(Object.keys(shortcut_override).length > 0
+            ? { shortcuts: shortcut_override }
+            : {}),
+        },
+        { key: `Backspace`, ...modifiers },
+      )
       expect(props.selected).toEqual([])
       expect(event.defaultPrevented).toBe(true)
     },
   )
 
   test(`custom shortcuts override defaults`, async () => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selectAllOption: true,
-      selected: [],
-      shortcuts: { select_all: `ctrl+e` },
-      open: true,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-
-    // Default ctrl+a should NOT work anymore
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, { key: `a`, ctrlKey: true, bubbles: true }),
+    // Default ctrl+a should NOT work with a custom select_all binding
+    const { props, input } = await test_shortcut(
+      { selectAllOption: true, shortcuts: { select_all: `ctrl+e` } },
+      { key: `a`, ctrlKey: true },
     )
-    await tick()
     expect(props.selected).toEqual([])
 
     // Custom ctrl+e SHOULD work
@@ -6598,27 +6589,10 @@ describe(`keyboard shortcuts`, () => {
     [`default (null)`, {}],
     [`explicitly null`, { shortcuts: { select_all: null } }],
   ])(`select_all %s: ctrl+a not swallowed`, async (_label, extra_props) => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selectAllOption: true,
-      selected: [],
-      open: true,
-      ...extra_props,
-    })
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    const event = new KeyboardEvent(`keydown`, {
-      key: `a`,
-      ctrlKey: true,
-      bubbles: true,
-      cancelable: true,
-    })
-    input.dispatchEvent(event)
-    await tick()
-
+    const { props, event } = await test_shortcut(
+      { selectAllOption: true, ...extra_props },
+      { key: `a`, ctrlKey: true },
+    )
     expect(props.selected).toEqual([])
     expect(event.defaultPrevented).toBe(false)
   })
@@ -6642,88 +6616,32 @@ describe(`keyboard shortcuts`, () => {
       1,
     ],
   ])(`%s`, async (_label, extra_props, key_event, expected_length) => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      open: true,
-      ...extra_props,
-    })
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { ...key_event, bubbles: true }))
-    await tick()
-
+    const { props } = await test_shortcut(extra_props, key_event)
     expect(props.selected).toHaveLength(expected_length)
   })
 
   test(`clear_all skipped when searchText is non-empty`, async () => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selected: [`a`, `b`],
-      searchText: `xyz`,
-      open: true,
-    })
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    const event = new KeyboardEvent(`keydown`, {
-      key: `Backspace`,
-      ctrlKey: true,
-      bubbles: true,
-      cancelable: true,
-    })
-    input.dispatchEvent(event)
-    await tick()
-
+    const { props, event } = await test_shortcut(
+      { selected: [`a`, `b`], searchText: `xyz` },
+      { key: `Backspace`, ctrlKey: true },
+    )
     expect(props.selected).toEqual([`a`, `b`])
     expect(event.defaultPrevented).toBe(false)
   })
 
   test.each([`meta+a`, `cmd+a`])(`%s shortcut works for Mac users`, async (shortcut) => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selectAllOption: true,
-      selected: [],
-      shortcuts: { select_all: shortcut },
-      open: true,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, { key: `a`, metaKey: true, bubbles: true }),
+    const { props } = await test_shortcut(
+      { selectAllOption: true, shortcuts: { select_all: shortcut } },
+      { key: `a`, metaKey: true },
     )
-    await tick()
-
     expect(props.selected).toEqual([`a`, `b`, `c`])
   })
 
   test(`select_all does nothing when selectAllOption is false`, async () => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selectAllOption: false,
-      selected: [],
-      shortcuts: { select_all: `ctrl+a` },
-      open: true,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, { key: `a`, ctrlKey: true, bubbles: true }),
+    const { props } = await test_shortcut(
+      { selectAllOption: false, shortcuts: { select_all: `ctrl+a` } },
+      { key: `a`, ctrlKey: true },
     )
-    await tick()
-
     // Should NOT select all since selectAllOption is false
     expect(props.selected).toEqual([])
   })
@@ -6757,22 +6675,10 @@ describe(`keyboard shortcuts`, () => {
   })
 
   test(`custom close shortcut closes the dropdown`, async () => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      shortcuts: { close: `ctrl+w` },
-      open: true,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, { key: `w`, ctrlKey: true, bubbles: true }),
+    const { props } = await test_shortcut(
+      { shortcuts: { close: `ctrl+w` } },
+      { key: `w`, ctrlKey: true },
     )
-    await tick()
-
     expect(props.open).toBe(false)
   })
 
@@ -6780,46 +6686,18 @@ describe(`keyboard shortcuts`, () => {
     [`alt+a`, `a`, { altKey: true }],
     [`ctrl+shift+alt+s`, `s`, { ctrlKey: true, shiftKey: true, altKey: true }],
   ] as const)(`modifier combo %s works`, async (shortcut, key, modifiers) => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selectAllOption: true,
-      selected: [],
-      shortcuts: { select_all: shortcut },
-      open: true,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, { key, ...modifiers, bubbles: true }),
+    const { props } = await test_shortcut(
+      { selectAllOption: true, shortcuts: { select_all: shortcut } },
+      { key, ...modifiers },
     )
-    await tick()
-
     expect(props.selected).toEqual([`a`, `b`, `c`])
   })
 
   test(`shortcuts are blocked when disabled=true`, async () => {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selectAllOption: true,
-      selected: [],
-      shortcuts: { select_all: `ctrl+a` },
-      disabled: true,
-      open: true,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(
-      new KeyboardEvent(`keydown`, { key: `a`, ctrlKey: true, bubbles: true }),
+    const { props } = await test_shortcut(
+      { selectAllOption: true, shortcuts: { select_all: `ctrl+a` }, disabled: true },
+      { key: `a`, ctrlKey: true },
     )
-    await tick()
-
     // Shortcuts should not work when component is disabled
     expect(props.selected).toEqual([])
   })
@@ -6830,37 +6708,18 @@ describe(`keyboard shortcuts`, () => {
   ])(
     `invalid shortcut format "%s" does not trigger action`,
     async (shortcut, modifiers) => {
-      const props = $state<MultiSelectProps>({
-        options: [`a`, `b`, `c`],
-        selectAllOption: true,
-        selected: [],
-        shortcuts: { select_all: shortcut },
-        open: true,
-      })
-
-      mount(MultiSelect, { target: document.body, props })
-      await tick()
-
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-      input.focus()
-      input.dispatchEvent(
-        new KeyboardEvent(`keydown`, { key: `a`, ...modifiers, bubbles: true }),
+      const { props } = await test_shortcut(
+        { selectAllOption: true, shortcuts: { select_all: shortcut } },
+        { key: `a`, ...modifiers },
       )
-      await tick()
-
       expect(props.selected).toEqual([])
     },
   )
 
   test.each([
-    // deno-fmt-ignore
     [
       `select_all`,
-      {
-        selectAllOption: true,
-        selected: [],
-        shortcuts: { select_all: `ctrl+a` },
-      },
+      { selectAllOption: true, selected: [], shortcuts: { select_all: `ctrl+a` } },
       `a`,
       { ctrlKey: true },
       [`a`, `b`, `c`],
@@ -6869,54 +6728,13 @@ describe(`keyboard shortcuts`, () => {
   ])(
     `%s shortcut works when dropdown is closed`,
     async (_name, extra_props, key, modifiers, expected) => {
-      const props = $state<MultiSelectProps>({
-        options: [`a`, `b`, `c`],
-        open: false,
-        ...extra_props,
-      })
-
-      mount(MultiSelect, { target: document.body, props })
-      await tick()
-
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-      input.focus()
-      input.dispatchEvent(
-        new KeyboardEvent(`keydown`, { key, ...modifiers, bubbles: true }),
+      const { props } = await test_shortcut(
+        { open: false, ...extra_props },
+        { key, ...modifiers },
       )
-      await tick()
-
       expect(props.selected).toEqual(expected)
     },
   )
-
-  // Helper to reduce boilerplate in shortcut tests
-  async function test_shortcut(
-    shortcut_props: Partial<MultiSelectProps>,
-    key_event: {
-      key: string
-      ctrlKey?: boolean
-      shiftKey?: boolean
-      altKey?: boolean
-      metaKey?: boolean
-    },
-  ): Promise<{ props: MultiSelectProps; input: HTMLInputElement }> {
-    const props = $state<MultiSelectProps>({
-      options: [`a`, `b`, `c`],
-      selected: [],
-      open: true,
-      ...shortcut_props,
-    })
-
-    mount(MultiSelect, { target: document.body, props })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { ...key_event, bubbles: true }))
-    await tick()
-
-    return { props, input }
-  }
 
   test.each([
     [`open`, true, { open: `ctrl+o` }, `o`],
@@ -7123,35 +6941,69 @@ describe(`onsearch event`, () => {
 })
 
 describe(`onmaxreached event`, () => {
-  test(`fires when trying to add beyond maxSelect`, async () => {
-    const onmaxreached_spy = vi.fn()
-
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        options: [1, 2, 3, 4],
-        maxSelect: 2,
-        selected: [1, 2],
-        onmaxreached: onmaxreached_spy,
-      },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    await tick()
-
-    // Try to add a 3rd option when maxSelect is 2
-    const option3 = doc_query(`ul.options li:nth-child(1)`) // first available option
-    option3.click()
-    await tick()
-
-    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
-    expect(onmaxreached_spy).toHaveBeenCalledWith({
+  const object_opts = [
+    { label: `Apple`, value: 1 },
+    { label: `Banana`, value: 2 },
+    { label: `Cherry`, value: 3 },
+  ]
+  test.each<{
+    desc: string
+    options: Option[]
+    selected: Option[]
+    trigger: `click` | `keyboard`
+    attempted: Option
+  }>([
+    {
+      desc: `click, primitives`,
+      options: [1, 2, 3, 4],
       selected: [1, 2],
-      maxSelect: 2,
-      attemptedOption: 3,
-    })
-  })
+      trigger: `click`,
+      attempted: 3,
+    },
+    {
+      desc: `keyboard Enter, primitives`,
+      options: [1, 2, 3, 4],
+      selected: [1, 2],
+      trigger: `keyboard`,
+      attempted: 3,
+    },
+    {
+      desc: `click, object options`,
+      options: object_opts,
+      selected: [object_opts[0], object_opts[1]],
+      trigger: `click`,
+      attempted: object_opts[2],
+    },
+  ])(
+    `fires when adding beyond maxSelect ($desc)`,
+    async ({ options, selected, trigger, attempted }) => {
+      const onmaxreached_spy = vi.fn()
+      mount(MultiSelect, {
+        target: document.body,
+        props: { options, maxSelect: 2, selected, onmaxreached: onmaxreached_spy },
+      })
+      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      input.focus()
+      await tick()
+
+      // try to add a 3rd option when maxSelect is 2, via click or keyboard
+      // (fresh events, not the shared arrow_down/enter constants, to avoid cross-test pollution)
+      if (trigger === `keyboard`) {
+        input.dispatchEvent(
+          new KeyboardEvent(`keydown`, { key: `ArrowDown`, bubbles: true }),
+        )
+        input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
+      } else doc_query(`ul.options li:nth-child(1)`).click()
+      await tick()
+
+      expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
+      expect(onmaxreached_spy).toHaveBeenCalledWith({
+        selected,
+        maxSelect: 2,
+        attemptedOption: attempted,
+      })
+    },
+  )
 
   test.each([
     { maxSelect: 3, selected: [1], desc: `under limit` },
@@ -7179,111 +7031,9 @@ describe(`onmaxreached event`, () => {
 
     expect(onmaxreached_spy).not.toHaveBeenCalled()
   })
-
-  test(`fires via keyboard Enter key`, async () => {
-    const onmaxreached_spy = vi.fn()
-
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        options: [1, 2, 3, 4],
-        maxSelect: 2,
-        selected: [1, 2],
-        onmaxreached: onmaxreached_spy,
-      },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    await tick()
-
-    // Navigate to option and try to add via Enter
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `ArrowDown`, bubbles: true }))
-    await tick()
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
-    await tick()
-
-    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
-    expect(onmaxreached_spy).toHaveBeenCalledWith({
-      selected: [1, 2],
-      maxSelect: 2,
-      attemptedOption: 3,
-    })
-  })
-
-  test(`fires with object options`, async () => {
-    const onmaxreached_spy = vi.fn()
-    const options = [
-      { label: `Apple`, value: 1 },
-      { label: `Banana`, value: 2 },
-      { label: `Cherry`, value: 3 },
-    ]
-
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        options,
-        maxSelect: 2,
-        selected: [options[0], options[1]],
-        onmaxreached: onmaxreached_spy,
-      },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    await tick()
-
-    // Try to add Cherry when already at max
-    const option3 = doc_query(`ul.options li:nth-child(1)`)
-    option3.click()
-    await tick()
-
-    expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
-    expect(onmaxreached_spy).toHaveBeenCalledWith({
-      selected: [options[0], options[1]],
-      maxSelect: 2,
-      attemptedOption: options[2],
-    })
-  })
 })
 
 describe(`onduplicate event`, () => {
-  test(`fires when adding duplicate with duplicates=false`, async () => {
-    const onduplicate_spy = vi.fn()
-
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        options: [1, 2, 3],
-        duplicates: false,
-        selected: [1],
-        onduplicate: onduplicate_spy,
-        allowUserOptions: true, // allows typing custom options
-      },
-    })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.focus()
-    await tick()
-
-    // Type "1" which matches the already-selected option
-    // Since selected option is hidden from dropdown, no options match
-    // But pressing Enter will try to create a user option with value "1"
-    // which gets converted to number 1 and triggers duplicate detection
-    input.value = `1`
-    input.dispatchEvent(input_event)
-    await tick()
-
-    // Press Enter to try adding the user-typed value
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
-    await tick()
-
-    expect(onduplicate_spy).toHaveBeenCalledTimes(1)
-    // Note: user typed "1" which stays as string because get_label converts primitives to strings
-    // so the number conversion condition fails (typeof selected_labels[0] is "string", not "number")
-    expect(onduplicate_spy).toHaveBeenCalledWith({ option: `1` })
-  })
-
   test.each([
     { duplicates: true, desc: `duplicates=true allows adding same option` },
     { duplicates: false, desc: `adding different option (not a duplicate)` },
@@ -7313,12 +7063,28 @@ describe(`onduplicate event`, () => {
   // Tests duplicate detection via allowUserOptions for both string and object options
   // For object options, label-based detection fires even when keys differ (e.g., typing "Apple"
   // when {label: "Apple", value: 1} is selected) - prevents confusing UX
-  test.each([
+  test.each<{
+    desc: string
+    options: Option[]
+    selected: Option[]
+    typed_value: string
+    expected: { option: unknown }
+  }>([
+    {
+      // user typed "1" stays a string (get_label stringifies primitives), so numeric
+      // coercion doesn't apply and detection is label-based
+      desc: `numeric options coerced to string`,
+      options: [1, 2, 3],
+      selected: [1],
+      typed_value: `1`,
+      expected: { option: `1` },
+    },
     {
       desc: `string options`,
       options: [`apple`, `banana`, `cherry`],
       selected: [`apple`],
       typed_value: `apple`,
+      expected: { option: `apple` },
     },
     {
       desc: `object options (label match)`,
@@ -7328,10 +7094,11 @@ describe(`onduplicate event`, () => {
       ],
       selected: [{ label: `Apple`, value: 1 }],
       typed_value: `Apple`,
+      expected: { option: `Apple` },
     },
   ])(
     `fires with $desc via allowUserOptions`,
-    async ({ options, selected, typed_value }) => {
+    async ({ options, selected, typed_value, expected }) => {
       const onduplicate_spy = vi.fn()
 
       mount(MultiSelect, {
@@ -7353,10 +7120,13 @@ describe(`onduplicate event`, () => {
       input.dispatchEvent(input_event)
       await tick()
 
+      // fresh Enter event per case: the shared `enter` constant's defaultPrevented flag
+      // persists across re-dispatch and would suppress later iterations
       input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
       await tick()
 
       expect(onduplicate_spy).toHaveBeenCalledTimes(1)
+      expect(onduplicate_spy).toHaveBeenCalledWith(expected)
     },
   )
 
@@ -8390,33 +8160,29 @@ describe(`parse_paste`, () => {
     expect(props.selected).toEqual([`valid`, `also_ok`])
   })
 
-  test(`onparsed_paste fires with added/rejected/overflow summary`, async () => {
-    const { onparsed_paste } = await paste_into(
-      { options: [`a`, `b`, `c`, `d`, `e`], selected: [`a`], maxSelect: 3 },
-      `b,c,d,e`,
-    )
-    expect(onparsed_paste).toHaveBeenCalledTimes(1)
-    const payload = onparsed_paste.mock.calls[0][0]
-    expect(payload.added).toEqual([`b`, `c`])
-    expect(payload.overflow).toEqual([`d`, `e`])
-    expect(payload.raw_text).toBe(`b,c,d,e`)
-  })
-
-  test(`onparsed_paste with maxSelect=1 reports replaced option as added`, async () => {
-    const { onparsed_paste, props } = await paste_into(
-      { options: [`a`, `b`, `c`], selected: [`a`], maxSelect: 1 },
-      `b,c`,
-    )
-    expect(onparsed_paste).toHaveBeenCalledTimes(1)
-    const payload = onparsed_paste.mock.calls[0][0]
-    expect(payload.added).toEqual([`b`])
-    expect(payload.overflow).toEqual([`c`])
-    expect(props.selected).toEqual([`b`])
-  })
-
-  test(`onparsed_paste reports rejected options from oncreate`, async () => {
-    const { onparsed_paste } = await paste_into(
-      {
+  test.each<{
+    desc: string
+    props: Partial<MultiSelectProps>
+    paste: string
+    expected: Record<string, unknown>
+    expected_selected?: Option[]
+  }>([
+    {
+      desc: `added/overflow summary beyond maxSelect`,
+      props: { options: [`a`, `b`, `c`, `d`, `e`], selected: [`a`], maxSelect: 3 },
+      paste: `b,c,d,e`,
+      expected: { added: [`b`, `c`], overflow: [`d`, `e`], raw_text: `b,c,d,e` },
+    },
+    {
+      desc: `maxSelect=1 reports replaced option as added`,
+      props: { options: [`a`, `b`, `c`], selected: [`a`], maxSelect: 1 },
+      paste: `b,c`,
+      expected: { added: [`b`], overflow: [`c`] },
+      expected_selected: [`b`],
+    },
+    {
+      desc: `reports rejected options from oncreate`,
+      props: {
         options: [],
         selected: [],
         allowUserOptions: `append`,
@@ -8425,11 +8191,13 @@ describe(`parse_paste`, () => {
             ? undefined
             : false,
       },
-      `ab,valid,x`,
-    )
-    const payload = onparsed_paste.mock.calls[0][0]
-    expect(payload.added).toEqual([`valid`])
-    expect(payload.rejected).toEqual([`ab`, `x`])
-    expect(payload.overflow).toEqual([])
+      paste: `ab,valid,x`,
+      expected: { added: [`valid`], rejected: [`ab`, `x`], overflow: [] },
+    },
+  ])(`onparsed_paste $desc`, async ({ props, paste, expected, expected_selected }) => {
+    const { onparsed_paste, props: bound } = await paste_into(props, paste)
+    expect(onparsed_paste).toHaveBeenCalledTimes(1)
+    expect(onparsed_paste.mock.calls[0][0]).toEqual(expect.objectContaining(expected))
+    if (expected_selected) expect(bound.selected).toEqual(expected_selected)
   })
 })

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -3711,30 +3711,38 @@ test.each([
   [`test-style`, `selected`, `test-style;`],
   [`test-style`, `option`, `test-style;`],
   [`test-style`, null, `test-style;`],
-  // Object style cases
-  [{ selected: `selected-style`, option: `option-style` }, `selected`, `selected-style`],
-  [{ selected: `selected-style`, option: `option-style` }, `option`, `option-style`],
+  // Object style cases (get the same trailing-semicolon normalization as strings)
+  [{ selected: `selected-style`, option: `option-style` }, `selected`, `selected-style;`],
+  [{ selected: `selected-style`, option: `option-style` }, `option`, `option-style;`],
+  [{ selected: `selected-style` }, `selected`, `selected-style;`],
+  [{ selected: `selected-style` }, `option`, ``],
+  [{ option: `option-style` }, `option`, `option-style;`],
+  [{ option: `option-style` }, `selected`, ``],
+  [{}, `selected`, ``],
   // Invalid object style cases
   [
     { invalid: `invalid-style` },
     `selected`,
     ``,
-    `Invalid style object for option=${JSON.stringify({
-      style: { invalid: `invalid-style` },
-    })}`,
+    [
+      `MultiSelect: invalid style object for option`,
+      { style: { invalid: `invalid-style` } },
+    ],
   ],
 ])(
   `get_style returns and console.errors correctly (%s, %s, %s, %s)`,
-  (style, key, expected, err_msg = ``) => {
+  (style, key, expected, err_args: unknown[] | string = ``) => {
     console.error = vi.fn()
 
     // @ts-expect-error test invalid option
     const result = get_style({ style }, key)
 
-    if (expected.startsWith(`Invalid`) || expected.startsWith(`MultiSelect`)) {
+    if (err_args) {
       expect(console.error).toHaveBeenCalledTimes(1)
-      expect(console.error).toHaveBeenCalledWith(err_msg)
-    }
+      expect(console.error).toHaveBeenCalledWith(
+        ...(Array.isArray(err_args) ? err_args : [err_args]),
+      )
+    } else expect(console.error).not.toHaveBeenCalled()
     expect(result).toBe(expected)
   },
 )
@@ -3749,6 +3757,11 @@ test.each<[OptionStyle, string | null, string]>([
   // Object style cases
   [{ selected: `color: red;`, option: `color: blue;` }, `selected`, `color: red;`],
   [{ selected: `color: red;`, option: `color: blue;` }, `option`, `color: blue;`],
+  [{ selected: `color: red;` }, `selected`, `color: red;`],
+  [{ selected: `color: red;` }, `option`, ``],
+  [{ option: `color: blue;` }, `option`, `color: blue;`],
+  [{ option: `color: blue;` }, `selected`, ``],
+  [{}, `selected`, ``],
   // Invalid object style cases
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- intentionally testing invalid style object
   [{ invalid: `color: green;` } as unknown as OptionStyle, `selected`, ``],

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vite-plus/tes
 import type { Option, OptionStyle } from '$lib'
 import MultiSelect from '$lib'
 import type { MultiSelectProps } from '$lib/types'
-import { get_label, get_style } from '$lib/utils'
+import { get_label } from '$lib/utils'
 
 import { doc_query, type Test2WayBindProps } from './index'
 import Test2WayBind from './Test2WayBind.svelte'
@@ -3696,54 +3696,6 @@ test.each([[true], [-1], [3.5], [`foo`], [{}]])(
       // eslint-disable-next-line @typescript-eslint/no-base-to-string -- testing console.error message with invalid maxOptions values
       `MultiSelect: maxOptions must be undefined or a positive integer, got ${String(maxOptions)}`,
     )
-  },
-)
-
-test.each([
-  // Invalid key cases
-  [
-    `test-style`,
-    `invalid`,
-    `test-style;`,
-    `MultiSelect: Invalid key=invalid for get_style`,
-  ],
-  // Valid key cases
-  [`test-style`, `selected`, `test-style;`],
-  [`test-style`, `option`, `test-style;`],
-  [`test-style`, null, `test-style;`],
-  // Object style cases (get the same trailing-semicolon normalization as strings)
-  [{ selected: `selected-style`, option: `option-style` }, `selected`, `selected-style;`],
-  [{ selected: `selected-style`, option: `option-style` }, `option`, `option-style;`],
-  [{ selected: `selected-style` }, `selected`, `selected-style;`],
-  [{ selected: `selected-style` }, `option`, ``],
-  [{ option: `option-style` }, `option`, `option-style;`],
-  [{ option: `option-style` }, `selected`, ``],
-  [{}, `selected`, ``],
-  // Invalid object style cases
-  [
-    { invalid: `invalid-style` },
-    `selected`,
-    ``,
-    [
-      `MultiSelect: invalid style object for option`,
-      { style: { invalid: `invalid-style` } },
-    ],
-  ],
-])(
-  `get_style returns and console.errors correctly (%s, %s, %s, %s)`,
-  (style, key, expected, err_args: unknown[] | string = ``) => {
-    console.error = vi.fn()
-
-    // @ts-expect-error test invalid option
-    const result = get_style({ style }, key)
-
-    if (err_args) {
-      expect(console.error).toHaveBeenCalledTimes(1)
-      expect(console.error).toHaveBeenCalledWith(
-        ...(Array.isArray(err_args) ? err_args : [err_args]),
-      )
-    } else expect(console.error).not.toHaveBeenCalled()
-    expect(result).toBe(expected)
   },
 )
 

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -737,9 +737,9 @@ describe(`tooltip`, () => {
     })
 
     it(`tooltip uses theme-aware light-dark() defaults`, () => {
-      // Regression test for commit 9bfac33: tooltip must not set color-scheme (would
-      // override page theme). Asserts via raw cssText/setProperty spies because
-      // happy-dom strips var()/light-dark() from parsed style values.
+      // Base styles must not carry a color-scheme (page-declared schemes stay in
+      // control, see #405); the schemeless-page fallback is covered below. Asserts
+      // via raw cssText/setProperty spies because happy-dom strips var()/light-dark().
       const { css_texts, set_prop_values, restore } = capture_style_writes()
       try {
         const element = create_element()
@@ -790,6 +790,76 @@ describe(`tooltip`, () => {
       )
       const tooltip_css = find_tooltip_css(css_texts)
       expect(tooltip_css).toContain(`var(--tooltip-bg,`)
+    })
+
+    // Dark-styled pages that never declare `color-scheme` resolve the default
+    // light-dark() background to LIGHT while their inherited --text-color may be
+    // near-white → unreadable tooltip. The fallback pairs scheme + text color.
+    it(`pairs color-scheme and text color when page declares no scheme`, () => {
+      const { set_prop_values, restore } = capture_style_writes()
+      try {
+        const element = create_element()
+        element.title = `scheme fallback`
+        mock_bounds(element)
+        setup_tooltip(element, { delay: 0 })
+        trigger_tooltip(element)
+      } finally {
+        restore()
+      }
+
+      expect(set_prop_values).toContain(`color-scheme: light dark`)
+      expect(set_prop_values).toContain(`--text-color: light-dark(#222, #eee)`)
+    })
+
+    it.each([
+      [
+        `page declares a color-scheme`,
+        (_element: HTMLElement) => (document.body.style.colorScheme = `dark`),
+      ],
+      [
+        `trigger customizes --tooltip-bg`,
+        (element: HTMLElement) => element.style.setProperty(`--tooltip-bg`, `red`),
+      ],
+      [
+        `trigger carries its own --text-color`,
+        (element: HTMLElement) => element.style.setProperty(`--text-color`, `#0ff`),
+      ],
+    ])(`scheme fallback is skipped when %s`, (_desc, customize) => {
+      const { set_prop_values, restore } = capture_style_writes()
+      try {
+        const element = create_element()
+        element.title = `no fallback`
+        customize(element)
+        mock_bounds(element)
+        setup_tooltip(element, { delay: 0 })
+        trigger_tooltip(element)
+      } finally {
+        restore()
+        document.body.style.colorScheme = ``
+      }
+
+      expect(set_prop_values).not.toContain(`color-scheme: light dark`)
+      expect(set_prop_values).not.toContain(`--text-color: light-dark(#222, #eee)`)
+    })
+
+    it(`scheme fallback still applies when only the trigger has a color-scheme`, () => {
+      // A scheme on the trigger (or some container around it) never reaches the
+      // tooltip since it's appended to document.body, so it must not suppress the
+      // fallback — only a page-level (body-inherited) scheme should.
+      const { set_prop_values, restore } = capture_style_writes()
+      try {
+        const element = create_element()
+        element.title = `trigger scheme`
+        element.style.colorScheme = `dark`
+        mock_bounds(element)
+        setup_tooltip(element, { delay: 0 })
+        trigger_tooltip(element)
+      } finally {
+        restore()
+      }
+
+      expect(set_prop_values).toContain(`color-scheme: light dark`)
+      expect(set_prop_values).toContain(`--text-color: light-dark(#222, #eee)`)
     })
 
     it(`custom --tooltip-border overrides default border`, () => {

--- a/tests/vitest/heading-anchors.test.ts
+++ b/tests/vitest/heading-anchors.test.ts
@@ -2,11 +2,11 @@ import { heading_anchors, heading_ids } from '$lib/heading-anchors'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { doc_query } from './index'
 
+const preprocess = (content: string) => heading_ids().markup({ content })
+
 // SSR/client consistency: both should handle the same heading levels (h1-h6)
 // This test catches drift if someone changes one without the other
 describe(`SSR and client-side heading level consistency`, () => {
-  const preprocess = (content: string) => heading_ids().markup({ content })
-
   it.each([`h1`, `h6`])(
     `%s is processed by both SSR preprocessor and client-side attachment`,
     (tag) => {
@@ -26,8 +26,6 @@ describe(`SSR and client-side heading level consistency`, () => {
 })
 
 describe(`heading_ids preprocessor`, () => {
-  const preprocess = (content: string) => heading_ids().markup({ content })
-
   describe(`basic ID generation`, () => {
     it.each([
       [`<h2>Hello World</h2>`, `<h2 id="hello-world">Hello World</h2>`],
@@ -226,6 +224,15 @@ describe(`heading_anchors attachment`, () => {
       const anchor = document.querySelector(`${id_sel} ${anchor_selector}`)
       if (should_match) expect(anchor).toBeInstanceOf(HTMLAnchorElement)
       else expect(anchor).toBeNull()
+    })
+
+    it(`processes direct child before a later sibling's grandchild (duplicate-id order)`, () => {
+      // guards get_default_headings ordering: a direct-child heading must be processed
+      // before a grandchild in a later sibling, so the duplicate suffix lands on the grandchild
+      const container = create_container(`<h2>Dup</h2><div><h3>Dup</h3></div>`)
+      heading_anchors()(container)
+      const ids = Array.from(container.querySelectorAll(`h2, h3`)).map((el) => el.id)
+      expect(ids).toEqual([`dup`, `dup-1`])
     })
   })
 

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -192,11 +192,15 @@ describe(`fuzzy_match`, () => {
     expect(fuzzy_match(search, target)).toBe(expected)
   })
 
-  test(`handles null/undefined inputs`, () => {
-    // @ts-expect-error testing runtime behavior
-    expect(fuzzy_match(null, `test`)).toBe(false)
-    // @ts-expect-error testing runtime behavior
-    expect(fuzzy_match(undefined, `test`)).toBe(false)
+  test.each([
+    [null, `test`],
+    [undefined, `test`],
+    [`test`, null],
+    [`test`, undefined],
+    [null, null],
+  ])(`handles null/undefined inputs fuzzy_match(%s, %s)`, (search, target) => {
+    // @ts-expect-error testing runtime behavior with null/undefined
+    expect(fuzzy_match(search, target)).toBe(false)
   })
 })
 

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -89,18 +89,28 @@ describe(`get_style`, () => {
     option: `color: green`,
   }
   test.each([
-    [{ style: option_style }, `selected`, `color: blue`],
-    [{ style: option_style }, `option`, `color: green`],
-    [{ style: { selected: `color: blue` } }, `option`, ``],
+    // object styles get the same trailing-semicolon normalization as string styles
+    [{ label: `test`, style: option_style }, `selected`, `color: blue;`],
+    [{ label: `test`, style: option_style }, `option`, `color: green;`],
+    [{ label: `test`, style: { selected: `color: blue` } }, `option`, ``],
+    [{ label: `test`, style: { option: `color: green` } }, `selected`, ``],
+    [{ label: `test`, style: {} }, `option`, ``],
   ] as const)(
     `handles object styles correctly for %j with key %s`,
     (option, key, expected) => {
-      // @ts-expect-error missing key option in last test case
       expect(get_style(option, key)).toBe(expected)
     },
   )
 
-  test(`logs error for invalid style object without requested key`, () => {
+  test(`does not log for partial style objects`, () => {
+    console.error = vi.fn<typeof console.error>()
+    get_style({ label: `test`, style: { selected: `color: blue` } }, `option`)
+    get_style({ label: `test`, style: { option: `color: green` } }, `selected`)
+    get_style({ label: `test`, style: {} }, `option`)
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  test(`logs error for style object with no known style keys`, () => {
     const option_obj = { style: { invalid_key: `some-style` } }
     console.error = vi.fn<typeof console.error>()
     // @ts-expect-error invalid key

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -88,38 +88,34 @@ describe(`get_style`, () => {
     selected: `color: blue`,
     option: `color: green`,
   }
+  // object styles get the same trailing-semicolon normalization as string styles;
+  // partial style objects (e.g. only `selected`) are fine, but any key other than
+  // `option`/`selected` logs an error, even when a valid key is also present
   test.each([
-    // object styles get the same trailing-semicolon normalization as string styles
-    [{ label: `test`, style: option_style }, `selected`, `color: blue;`],
-    [{ label: `test`, style: option_style }, `option`, `color: green;`],
-    [{ label: `test`, style: { selected: `color: blue` } }, `option`, ``],
-    [{ label: `test`, style: { option: `color: green` } }, `selected`, ``],
-    [{ label: `test`, style: {} }, `option`, ``],
+    [option_style, `selected`, `color: blue;`, false],
+    [option_style, `option`, `color: green;`, false],
+    [{ selected: `color: blue` }, `option`, ``, false],
+    [{ option: `color: green` }, `selected`, ``, false],
+    [{}, `option`, ``, false],
+    [{ selected: `color: blue`, custom: `color: red` }, `selected`, `color: blue;`, true],
+    [{ option: `color: green`, custom: `color: red` }, `option`, `color: green;`, true],
+    [{ selected: `color: blue`, custom: `color: red` }, `option`, ``, true],
+    [{ invalid_key: `some-style` }, `selected`, ``, true],
   ] as const)(
-    `handles object styles correctly for %j with key %s`,
-    (option, key, expected) => {
+    `object style %j with key %s returns %j (logs error: %s)`,
+    (style, key, expected, should_log_error) => {
+      console.error = vi.fn<typeof console.error>()
+      const option = { label: `test`, style }
+      // @ts-expect-error style objects with unknown keys test runtime validation
       expect(get_style(option, key)).toBe(expected)
+      if (should_log_error) {
+        expect(console.error).toHaveBeenCalledWith(
+          `MultiSelect: invalid style object for option`,
+          option,
+        )
+      } else expect(console.error).not.toHaveBeenCalled()
     },
   )
-
-  test(`does not log for partial style objects`, () => {
-    console.error = vi.fn<typeof console.error>()
-    get_style({ label: `test`, style: { selected: `color: blue` } }, `option`)
-    get_style({ label: `test`, style: { option: `color: green` } }, `selected`)
-    get_style({ label: `test`, style: {} }, `option`)
-    expect(console.error).not.toHaveBeenCalled()
-  })
-
-  test(`logs error for style object with no known style keys`, () => {
-    const option_obj = { style: { invalid_key: `some-style` } }
-    console.error = vi.fn<typeof console.error>()
-    // @ts-expect-error invalid key
-    get_style(option_obj, `selected`)
-    expect(console.error).toHaveBeenCalledWith(
-      `MultiSelect: invalid style object for option`,
-      option_obj,
-    )
-  })
 
   test.each([undefined, null])(`no error for style object when key is %s`, (key) => {
     console.error = vi.fn<typeof console.error>()
@@ -127,10 +123,13 @@ describe(`get_style`, () => {
     expect(console.error).not.toHaveBeenCalled()
   })
 
-  test(`logs error for invalid key parameter`, () => {
+  test.each([
+    [{ style: `color: red;` }], // string style must not leak through for unknown keys
+    [{ style: option_style }],
+  ])(`logs error and returns empty string for invalid key with style %j`, (option) => {
     console.error = vi.fn<typeof console.error>()
     // @ts-expect-error invalid key
-    get_style({ style: `color: red;` }, `invalid_key`)
+    expect(get_style(option, `invalid_key`)).toBe(``)
     expect(console.error).toHaveBeenCalledWith(
       `MultiSelect: Invalid key=invalid_key for get_style`,
     )


### PR DESCRIPTION
- **Tooltip readability fallback**: pages that style themselves dark via CSS vars but never declare `color-scheme` resolve the tooltip's default `light-dark()` background to light while the mirrored page-wide `--text-color` may be near-white, producing white-on-white tooltips. When the page declares no scheme (read from `document.body`, since the tooltip is body-mounted and a scheme on a container around the trigger never reaches it) and the trigger has no custom `--tooltip-bg` or trigger-specific `--text-color`, the tooltip now opts into `color-scheme: light dark` and pairs its text color with it. Pages that declare a `color-scheme` keep full control, preserving #405.
- **Partial `OptionStyle` objects**: the object form of `OptionStyle` now has optional `option`/`selected` keys. `get_style` no longer logs a spurious `console.error` for partial objects like `{ selected: "..." }`; the error is reserved for objects with no known style keys.
- **Object-style semicolon normalization**: object styles now get the same trailing-semicolon normalization as string styles, fixing invalid CSS when an option's object style was concatenated with the `liOptionStyle`/`liSelectedStyle` props.
- **Portalled dropdown text**: MultiSelect text styling stays consistent when the dropdown is portalled.
- **Command palette navigation**: refine modal opening, initial input focus, and submenu keyboard/Escape behavior.

Tests cover the fallback pairing, all three skip conditions (page-declared scheme, custom `--tooltip-bg`, trigger-specific `--text-color`), the trigger-only-scheme case, partial/empty style objects, and semicolon normalization. Also tightened a vacuous error assertion in the `get_style` parametrized test that never actually ran.