### PR TITLE
Speed up hot paths, plus keyboard, chip removal and portal fixes

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -38,7 +38,7 @@ New features should include corresponding tests. Bug fixes should include a test
 This repo has 3 required CI checks that have to pass for every PR before merging:
 
 - tests: run as [GitHub Action](https://github.com/janosh/svelte-multiselect/actions/workflows/test.yml) ([workflow code](https://github.com/janosh/svelte-multiselect/blob/main/.github/workflows/test.yml))
-- linting: handled by `vp lint`
+- linting and type checks: `vp check` plus `svelte-check-rs`, run as [GitHub Action](https://github.com/janosh/svelte-multiselect/blob/main/.github/workflows/lint.yml)
 - docs: [continuous deployment](https://github.com/janosh/svelte-multiselect/blob/main/.github/workflows/gh-pages.yml) through GitHub Pages
 
 ## 🆕 New release

--- a/readme.md
+++ b/readme.md
@@ -98,13 +98,11 @@ Favorite Frontend Tools?
 
 ## 🔣 &thinsp; Props
 
-Complete reference of all props. Props are organized by importance - **Essential Props** are what you'll use most often.
+Props ordered by how often you'll reach for them.
 
 > **💡 Tip:** The `Option` type is automatically inferred from your `options` array, or you can import it: `import { type Option } from 'svelte-multiselect'`
 
 ### Essential Props
-
-These are the core props you'll use in most cases:
 
 1. ```ts
    options?: Option[]  // required unless loadOptions is provided
@@ -320,7 +318,7 @@ These are the core props you'll use in most cases:
    key: (opt: Option) => unknown
    ```
 
-   Function to determine option equality. Default compares by lowercased label.
+   Generates the identity key for an option. Default: an object's `value` if it defines one, else its `label`; primitives are their own key. No case folding — use `duplicates="case-insensitive"` for that.
 
 1. ```ts
    closeDropdownOnSelect: boolean | 'if-mobile' | 'retain-focus' = false
@@ -508,6 +506,12 @@ See the [grouping demo](https://janosh.github.io/svelte-multiselect/grouping) fo
    Max number of selected chips to render before collapsing the rest into a `+N more` toggle chip (click to expand/collapse). `null` renders all chips. Keyboard chip navigation auto-expands so hidden chips can't be highlighted invisibly. Ignored in `selectedDisplay="input"` mode.
 
 1. ```ts
+   selectedDisplay: 'chips' | 'input' = 'chips'
+   ```
+
+   How selected options are shown. `'chips'` renders them as removable tags inside the input. `'input'` writes the selected label straight into the text input (combobox/datalist style) and is only valid with `maxSelect={1}`; other values log a config error and fall back to chips. See the [input-dropdown demo](https://janosh.github.io/svelte-multiselect/input-dropdown).
+
+1. ```ts
    virtualList: boolean | { itemHeight?: number; overscan?: number } = false
    ```
 
@@ -601,14 +605,14 @@ See the [grouping demo](https://janosh.github.io/svelte-multiselect/grouping) fo
 
    Available shortcuts and their defaults:
 
-   | Key          | Default                             | Action                                      |
-   | ------------ | ----------------------------------- | ------------------------------------------- |
-   | `select_all` | `'ctrl+a'`                          | Select all visible options                  |
-   | `clear_all`  | `'ctrl+shift+a'`                    | Deselect all options                        |
-   | `open`       | `null`                              | Open dropdown                               |
-   | `close`      | `null`                              | Close dropdown (Escape works by default)    |
-   | `undo`       | `'meta+z'` / `'ctrl+z'`             | Undo last selection change (platform-aware) |
-   | `redo`       | `'meta+shift+z'` / `'ctrl+shift+z'` | Redo last undone change (platform-aware)    |
+   | Key          | Default                                 | Action                                                                                                                               |
+   | ------------ | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+   | `select_all` | `null`                                  | Select all visible options. Opt in with `{ select_all: 'ctrl+a' }` — off by default so it doesn't hijack the browser's native Ctrl+A |
+   | `clear_all`  | `'meta+backspace'` / `'ctrl+backspace'` | Deselect all options (only while chips are present and the search box is empty)                                                      |
+   | `open`       | `null`                                  | Open dropdown                                                                                                                        |
+   | `close`      | `null`                                  | Close dropdown (Escape works by default)                                                                                             |
+   | `undo`       | `'meta+z'` / `'ctrl+z'`                 | Undo last selection change (platform-aware)                                                                                          |
+   | `redo`       | `'meta+shift+z'` / `'ctrl+shift+z'`     | Redo last undone change (platform-aware)                                                                                             |
 
 ### Selection History (Undo/Redo)
 
@@ -683,10 +687,11 @@ See the [grouping demo](https://janosh.github.io/svelte-multiselect/grouping) fo
 <!-- deno-fmt-ignore -->
 
 1. ```ts
-   maxSelectMsg: ((current: number, max: number) => string) | null
+   maxSelectMsg: ((current: number, max: number) => string) | null = (current, max) =>
+     max > 1 ? `${current}/${max}` : ``
    ```
 
-   Function to generate "X of Y selected" message. `null` = no message.
+   Renders a `2/5` counter next to the input. The default returns an empty string when `maxSelect <= 1`. `null` = no message.
 
 ### DOM Element References (bindable)
 
@@ -826,7 +831,7 @@ These reflect internal component state:
 
 ### Bindable Props
 
-`selected`, `value`, `searchText`, `open`, `activeIndex`, `activeOption`, `invalid`, `input`, `outerDiv`, `form_input`, `options`, `matchingOptions`, `collapsedGroups`, `collapseAllGroups`, `expandAllGroups`, `undo`, `redo`, `canUndo`, `canRedo`
+`selected`, `value`, `searchText`, `open`, `maxSelect`, `activeIndex`, `activeOption`, `invalid`, `input`, `outerDiv`, `form_input`, `options`, `matchingOptions`, `collapsedGroups`, `collapseAllGroups`, `expandAllGroups`, `undo`, `redo`, `canUndo`, `canRedo`
 
 ## 🎰 &thinsp; Snippets
 
@@ -883,7 +888,7 @@ Example using several snippets:
    oncreate={({ option }) => console.log(option)}
    ```
 
-   Triggers when a user creates a new option (when `allowUserOptions` is enabled). The created option is provided as `option`.
+   Triggers when a user creates a new option (when `allowUserOptions` is enabled). The created option is provided as `option`. Doubles as a validation hook: return `false` to reject the option, return a replacement option to transform it, or `undefined` to accept it as-is. May be async — paste handling awaits it.
 
 1. ```ts
    onremove={({ option, selected }) => console.log(option, selected)}
@@ -997,7 +1002,7 @@ The following example shows an alert whenever one or more options are added or r
 
 > Note: Depending on the data passed to the component the `option(s)` payload will either be objects or simple strings/numbers.
 
-This component also forwards many DOM events from the `<input>` node: `blur`, `change`, `click`, `keydown`, `keyup`, `mousedown`, `mouseenter`, `mouseleave`, `touchcancel`, `touchend`, `touchmove`, `touchstart`. Registering listeners for these events works the same:
+This component also forwards these DOM events from the `<input>` node: `blur`, `click`, `focus`, `input`, `keydown`, `keyup`, `mousedown`, `mouseenter`, `mouseleave`, `touchcancel`, `touchend`, `touchmove`, `touchstart`. Note `onchange` is _not_ forwarded — it's reused as the custom selection-change callback documented above. Registering listeners for the forwarded events works the same:
 
 ```svelte
 <MultiSelect
@@ -1087,7 +1092,7 @@ Minimal example that changes the background color of the options dropdown:
 ```
 
 - `div.multiselect`
-  - `border: var(--sms-border, 1pt solid light-dark(lightgray, #555))`: Change this to e.g. to `1px solid red` to indicate this form field is in an invalid state.
+  - `border: var(--sms-border, 1px solid light-dark(lightgray, #555))`: Change this to e.g. to `1px solid red` to indicate this form field is in an invalid state.
   - `border-radius: var(--sms-border-radius, 3pt)`
   - `padding: var(--sms-padding, 0 3pt)`
   - `background: var(--sms-bg, light-dark(white, #222226))`
@@ -1100,7 +1105,7 @@ Minimal example that changes the background color of the options dropdown:
 - `div.multiselect.open`
   - `z-index: var(--sms-open-z-index, 4)`: Increase this if needed to ensure the dropdown list is displayed atop all other page elements.
 - `div.multiselect:focus-within`
-  - `border: var(--sms-focus-border, 1pt solid var(--sms-active-color, cornflowerblue))`: Border when component has focus. Defaults to `--sms-active-color` which in turn defaults to `cornflowerblue`.
+  - `border: var(--sms-focus-border, 1px solid var(--sms-active-color, cornflowerblue))`: Border when component has focus. Defaults to `--sms-active-color` which in turn defaults to `cornflowerblue`.
 - `div.multiselect.disabled`
   - `background: var(--sms-disabled-bg, light-dark(lightgray, #444))`: Background when in disabled state.
 - `div.multiselect input::placeholder`
@@ -1120,7 +1125,7 @@ Minimal example that changes the background color of the options dropdown:
   - `overscroll-behavior: var(--sms-options-overscroll, none)`: Whether scroll events bubble to parent elements when reaching the top/bottom of the options dropdown. See [MDN](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior).
   - `z-index: var(--sms-options-z-index, 3)`: Z-index for the dropdown options list.
   - `box-shadow: var(--sms-options-shadow, light-dark(0 0 14pt -8pt black, 0 0 14pt -4pt rgba(0, 0, 0, 0.8)))`: Box shadow of dropdown list.
-  - `border: var(--sms-options-border)`
+  - `border: var(--sms-options-border, 1px solid light-dark(lightgray, #555))`
   - `border-width: var(--sms-options-border-width, 1px)`
   - `border-radius: var(--sms-options-border-radius, 1ex)`
   - `padding: var(--sms-options-padding, 0)`
@@ -1196,7 +1201,7 @@ This simplified version of the DOM structure of the component shows where these 
     <li class={liSelectedClass}>Selected 1</li>
     <li class={liSelectedClass}>Selected 2</li>
   </ul>
-  <span class="maxSelectMsgClass">2/5 selected</span>
+  <span class="max-select-msg {maxSelectMsgClass}">2/5</span>
   <ul class="options {ulOptionsClass}">
     <li class="select-all {liSelectAllClass}">Select all</li>
     <li class={liOptionClass}>Option 1</li>

--- a/readme.md
+++ b/readme.md
@@ -1126,7 +1126,7 @@ Minimal example that changes the background color of the options dropdown:
   - `padding: var(--sms-options-padding, 0)`
   - `margin: var(--sms-options-margin, 6pt 0 0 0)`
 - `div.multiselect > ul.options > li`
-  - `padding: var(--sms-options-li-padding, 3pt 1ex)`: Padding of each option in the dropdown list.
+  - `padding: var(--sms-options-li-padding, 2pt 1ex)`: Padding of each option in the dropdown list.
   - `scroll-margin: var(--sms-options-scroll-margin, 100px)`: Top/bottom margin to keep between dropdown list items and top/bottom screen edge when auto-scrolling list to keep items in view.
 - `div.multiselect > ul.options > li.selected`
   - `background: var(--sms-li-selected-plain-bg, light-dark(rgba(0, 123, 255, 0.1), rgba(100, 180, 255, 0.2)))`: Background of selected list items in options pane.

--- a/src/lib/CodeExample.svelte
+++ b/src/lib/CodeExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  // see svelte.config.js where this component is passed to live-examples remark plugin
+  // see svelte.config.ts where this component is set as the live-examples Wrapper
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import Icon from './Icon.svelte'
@@ -17,7 +17,7 @@
     button_props,
   }: {
     // src+meta are passed in by live-examples remark plugin
-    src?: string // code fence content, sadly without indentation so we prefer node?.innerText below
+    src?: string // code fence content, dedented by the remark plugin
     meta?: {
       // code fence metadata
       collapsible?: boolean // whether to show a button to expand/collapse the code

--- a/src/lib/CommandMenu.svelte
+++ b/src/lib/CommandMenu.svelte
@@ -233,9 +233,8 @@
     if (toggle(event)) return
     // run action hotkeys globally while the menu is closed
     if (open || !global_shortcuts) return
-    // Outside a chord the keystroke is an ordinary character, so firing the hotkey
-    // would both run the action and swallow what the user typed. Shift is absent on
-    // purpose - it is how capital letters are typed, not a chord.
+    // Outside a chord the keystroke is ordinary typing, so firing would run the action
+    // and swallow the character. Shift is excluded: it types capitals, it is no chord.
     const is_chord = event.ctrlKey || event.metaKey || event.altKey
     if (!is_chord && is_editable_event_target(event.target)) return
     const action = actions.find(

--- a/src/lib/CommandMenu.svelte
+++ b/src/lib/CommandMenu.svelte
@@ -233,8 +233,8 @@
     if (toggle(event)) return
     // run action hotkeys globally while the menu is closed
     if (open || !global_shortcuts) return
-    // Outside a chord the keystroke is ordinary typing, so firing would run the action
-    // and swallow the character. Shift is excluded: it types capitals, it is no chord.
+    // outside a chord (Shift alone types capitals) the keystroke is ordinary typing,
+    // so firing would run the action and swallow the character
     const is_chord = event.ctrlKey || event.metaKey || event.altKey
     if (!is_chord && is_editable_event_target(event.target)) return
     const action = actions.find(

--- a/src/lib/CommandMenu.svelte
+++ b/src/lib/CommandMenu.svelte
@@ -8,6 +8,7 @@
     cmd_action_matches,
     chain_handlers,
     format_cmd_metadata,
+    is_editable_event_target,
     matches_shortcut,
     split_shortcut,
   } from './utils'
@@ -232,6 +233,10 @@
     if (toggle(event)) return
     // run action hotkeys globally while the menu is closed
     if (open || !global_shortcuts) return
+    // a modifier-free hotkey is an ordinary character while typing, so firing it would
+    // both run the action and swallow the keystroke
+    const has_modifier = event.ctrlKey || event.metaKey || event.altKey
+    if (!has_modifier && is_editable_event_target(event.target)) return
     const action = actions.find(
       (cmd_action) =>
         !cmd_action.disabled && matches_shortcut(event, cmd_action.shortcut),

--- a/src/lib/CommandMenu.svelte
+++ b/src/lib/CommandMenu.svelte
@@ -233,10 +233,11 @@
     if (toggle(event)) return
     // run action hotkeys globally while the menu is closed
     if (open || !global_shortcuts) return
-    // a modifier-free hotkey is an ordinary character while typing, so firing it would
-    // both run the action and swallow the keystroke
-    const has_modifier = event.ctrlKey || event.metaKey || event.altKey
-    if (!has_modifier && is_editable_event_target(event.target)) return
+    // Outside a chord the keystroke is an ordinary character, so firing the hotkey
+    // would both run the action and swallow what the user typed. Shift is absent on
+    // purpose - it is how capital letters are typed, not a chord.
+    const is_chord = event.ctrlKey || event.metaKey || event.altKey
+    if (!is_chord && is_editable_event_target(event.target)) return
     const action = actions.find(
       (cmd_action) =>
         !cmd_action.disabled && matches_shortcut(event, cmd_action.shortcut),

--- a/src/lib/CommandMenu.svelte
+++ b/src/lib/CommandMenu.svelte
@@ -9,6 +9,7 @@
     chain_handlers,
     format_cmd_metadata,
     is_editable_event_target,
+    is_modifier_chord,
     matches_shortcut,
     split_shortcut,
   } from './utils'
@@ -74,7 +75,7 @@
     max_recent?: number // cap on persisted recent actions (default: 20)
   } = $props()
 
-  // === Recent actions (frecency ranking) ===
+  // === Recent actions (most-recently-used ranking) ===
   let recent_action_ids = $state<string[]>([])
 
   const get_action_id = (action: CmdAction): string => `${action.id ?? action.label}`
@@ -231,12 +232,10 @@
     const is_close_key = open && close_keys.includes(event.key)
     if (event.defaultPrevented && !is_close_key) return
     if (toggle(event)) return
-    // run action hotkeys globally while the menu is closed
     if (open || !global_shortcuts) return
-    // outside a chord (Shift alone types capitals) the keystroke is ordinary typing,
-    // so firing would run the action and swallow the character
-    const is_chord = event.ctrlKey || event.metaKey || event.altKey
-    if (!is_chord && is_editable_event_target(event.target)) return
+    // outside a chord the keystroke is ordinary typing, so firing the action would
+    // both run it and swallow the character
+    if (!is_modifier_chord(event) && is_editable_event_target(event.target)) return
     const action = actions.find(
       (cmd_action) =>
         !cmd_action.disabled && matches_shortcut(event, cmd_action.shortcut),

--- a/src/lib/CopyButton.svelte
+++ b/src/lib/CopyButton.svelte
@@ -123,8 +123,7 @@
       state = `error`
       on_copy_error(error, content)
     }
-    // the copy already succeeded, so a throwing callback must neither be reported as
-    // a copy failure nor derail the reset timer below
+    // the copy already succeeded, so a throwing callback is not a copy failure
     if (state === `success`) {
       try {
         on_copy_success(content)

--- a/src/lib/CopyButton.svelte
+++ b/src/lib/CopyButton.svelte
@@ -118,18 +118,15 @@
     try {
       await navigator.clipboard.writeText(content)
       state = `success`
+      try {
+        on_copy_success(content)
+      } catch (error) {
+        console.error(error) // the copy succeeded, so a throwing callback is not a failure
+      }
     } catch (error) {
       console.error(error)
       state = `error`
       on_copy_error(error, content)
-    }
-    // the copy already succeeded, so a throwing callback is not a copy failure
-    if (state === `success`) {
-      try {
-        on_copy_success(content)
-      } catch (error) {
-        console.error(error)
-      }
     }
     if (reset_sec <= 0) return
     reset_timeout = setTimeout(() => {

--- a/src/lib/CopyButton.svelte
+++ b/src/lib/CopyButton.svelte
@@ -118,11 +118,19 @@
     try {
       await navigator.clipboard.writeText(content)
       state = `success`
-      on_copy_success(content)
     } catch (error) {
       console.error(error)
       state = `error`
       on_copy_error(error, content)
+    }
+    // the copy already succeeded, so a throwing callback must neither be reported as
+    // a copy failure nor derail the reset timer below
+    if (state === `success`) {
+      try {
+        on_copy_success(content)
+      } catch (error) {
+        console.error(error)
+      }
     }
     if (reset_sec <= 0) return
     reset_timeout = setTimeout(() => {

--- a/src/lib/FileDetails.svelte
+++ b/src/lib/FileDetails.svelte
@@ -34,10 +34,8 @@
   // Use reactive state for node refs to avoid binding_property_non_reactive warning
   let node_refs = $state<(HTMLDetailsElement | null)[]>([])
 
-  // Whether any <details> is open (for button text). The DOM `open` property is
-  // not reactive, so this is $state synced from the native toggle event (which
-  // fires for user clicks and programmatic changes), toggle_all, and the
-  // node_refs $effect below (the toggle event doesn't fire for pre-opened details).
+  // DOM `open` isn't reactive, so track it in $state synced from the toggle event
+  // and toggle_all, plus the $effect below (toggle doesn't fire for pre-opened details)
   let any_open = $state(false)
   const sync_any_open = () => {
     any_open = node_refs.some((node) => node?.open)
@@ -45,7 +43,6 @@
 
   // Trim stale refs when files shrink and sync node_refs back to files.node for external access
   $effect(() => {
-    // Trim stale references when files array shrinks to prevent memory leaks
     if (node_refs.length > files.length) {
       node_refs.splice(files.length)
     }
@@ -88,9 +85,9 @@
   const resolve_lang = (file: File): string =>
     file.language ?? lang_from_title(file.title) ?? default_lang
 
-  // Lazy-loaded syntax highlighter using starry-night (CSS already loaded in app.css).
-  // Deliberately does NOT import from ./live-examples/highlighter.ts, which
-  // eagerly initializes starry-night with all grammars at module load.
+  // Lazy-loaded starry-night (CSS already loaded in app.css). Deliberately not
+  // imported from ./live-examples/highlighter.ts, whose top-level await initializes
+  // starry-night at module load.
   let highlighter:
     | {
         highlight: (code: string, scope: string) => HastNode

--- a/src/lib/GitHubCorner.svelte
+++ b/src/lib/GitHubCorner.svelte
@@ -19,7 +19,7 @@
     target?: `_self` | `_blank`
     color?: string | null
     fill?: string | null
-    // bottomLeft/Right look bad, shouldn't normally be used
+    // bottom-left/right look bad, shouldn't normally be used
     corner?: `top-left` | `top-right` | `bottom-left` | `bottom-right`
   } = $props()
 </script>

--- a/src/lib/Icon.svelte
+++ b/src/lib/Icon.svelte
@@ -7,7 +7,7 @@
   const data = $derived.by(() => {
     if (!(icon in icon_data)) {
       console.error(`Icon '${icon}' not found`)
-      return icon_data.Alert // fallback
+      return icon_data.Alert
     }
     return icon_data[icon]
   })

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -136,16 +136,13 @@
     onrangeSelect,
     onreorder,
     portal: portal_params = {},
-    // Select all feature
     selectAllOption = false,
     selectAllScope = `visible`,
     selectAllDisabledTitle,
     liSelectAllClass = ``,
-    // Dynamic options loading
     loadOptions,
-    // Animation parameters for selected options flip animation
     selectedFlipParams = { duration: 100 },
-    // Option grouping feature
+    // === Grouping ===
     collapsibleGroups = false,
     collapsedGroups = $bindable(new Set<string>()),
     groupSelectAll = false,
@@ -168,7 +165,6 @@
     onactivate,
     collapseAllGroups = $bindable(),
     expandAllGroups = $bindable(),
-    // Keyboard shortcuts for common actions
     shortcuts = {},
     // Selection history for undo/redo (enabled by default, set to false or 0 to disable)
     history = true,
@@ -183,8 +179,7 @@
   }: MultiSelectProps<Option> = $props()
 
   // === Config normalization ===
-  // Generate unique IDs for ARIA associations (combobox pattern)
-  // Uses provided id prop or generates a random one using crypto API
+  // unique ids for ARIA combobox associations, derived from the id prop when given
   const internal_id = $derived(id ?? `sms-${utils.get_uuid().slice(0, 8)}`)
   const listbox_id = $derived(`${internal_id}-listbox`)
   const input_display = $derived(selected_display === `input` && maxSelect === 1)
@@ -334,7 +329,7 @@
     prev_selected = [...selected]
   })
 
-  // Derived canUndo/canRedo (update bindable props reactively)
+  // keep the bindable canUndo/canRedo props in sync
   $effect(() => {
     canUndo = max_history > 0 && !disabled && history_index > 0
     canRedo = max_history > 0 && !disabled && history_index < history_stack.length - 1
@@ -378,11 +373,11 @@
     return () => clearTimeout(timer)
   })
 
-  // Internal state for loadOptions feature (null = never loaded)
+  // Internal state for loadOptions feature
   let loaded_options = $state<Option[]>([])
   let load_options_has_more = $state(true)
   let load_options_loading = $state(false)
-  let load_options_last_search: string | null = $state(null)
+  let load_options_last_search: string | null = $state(null) // null = nothing dispatched yet
   let load_request_id = 0 // monotonic counter to invalidate stale in-flight fetches
   let load_abort_controller: AbortController | null = null
   let previous_load_options_fetch: LoadOptionsConfig<Option>[`fetch`] | null = null
@@ -469,7 +464,6 @@
   const norm_label = (label: unknown) =>
     lower_dupes ? `${label}`.toLowerCase() : `${label}`
   let selected_labels_set = $derived(new Set(selected_labels.map(norm_label)))
-  // Helper to check if a label is already selected (respects case-insensitive mode)
   const is_label_selected = (label: string): boolean =>
     selected_labels_set.has(norm_label(label))
   const is_option_selected = (opt: Option, label: string | number): boolean =>
@@ -488,9 +482,8 @@
   // Check if option index is within the maxOptions visibility limit
   const is_option_visible = (idx: number) => idx >= 0 && idx < visible_navigable_count
 
-  // Get non-disabled, selectable options from a list
-  // For collapsed groups: returns all non-disabled options (user explicitly wants this group)
-  // For expanded groups/top-level: respects maxOptions rendering limit
+  // non-disabled options, limited to those rendered under maxOptions unless
+  // skip_visibility_check (collapsed groups select their full contents)
   const get_selectable_opts = (opts: Option[], skip_visibility_check = false): Option[] =>
     opts.filter(
       (opt) =>
@@ -548,10 +541,8 @@
     )
   let navigable_options = $derived(flatten_navigable(grouped_options))
 
-  // Pre-computed Map for O(1) index lookups (avoids O(n²) in template).
-  // NOTE: duplicate option values collapse to their last index here — rendering
-  // uses positional indices instead, this map only backs
-  // get_selectable_opts where duplicates are value-interchangeable anyway.
+  // O(1) index lookups for get_selectable_opts. Duplicate option values collapse to
+  // their last index, fine here since duplicates are value-interchangeable.
   let navigable_index_map = $derived(
     new Map(navigable_options.map((opt, idx) => [opt, idx])),
   )
@@ -739,7 +730,6 @@
     }
   }
 
-  // Toggle group collapsed state
   function toggle_group_collapsed(group_name: string) {
     const was_collapsed = collapsedGroups.has(group_name)
     update_collapsed_groups(was_collapsed ? `delete` : `add`, group_name)
@@ -760,7 +750,6 @@
     onexpandAll?.({ groups })
   }
 
-  // Expand specified groups and fire ongroupToggle for each
   function expand_groups(groups_to_expand: string[]) {
     if (groups_to_expand.length === 0) return
     update_collapsed_groups(`delete`, groups_to_expand)
@@ -794,7 +783,7 @@
     typeof placeholder === `object` && placeholder?.persistent === true,
   )
 
-  // Helper to sort selected options (used by add() and select_all())
+  // Sort selected per the sortSelected prop (used by add() and apply_bulk_add())
   function sort_selected(items: Option[]): Option[] {
     if (sortSelected === true) {
       return items.toSorted((opt_1, opt_2) =>
@@ -810,8 +799,6 @@
       if (allowUserOptions || loading || disabled || allowEmpty) {
         options = [] // initializing as array avoids errors when component mounts
       } else {
-        // error on empty options if user is not allowed to create custom options and loading is false
-        // and component is not disabled and allowEmpty is false
         console.error(`MultiSelect: received no options`)
       }
     }
@@ -901,7 +888,8 @@
     return createOptionMsg
   })
 
-  let option_msg_is_active = $state(false) // controls active state of <li>{createOptionMsg}</li>
+  // active state of the user-message <li> (dupe / create / no-match)
+  let option_msg_is_active = $state(false)
 
   // effective_options is pre-filtered when loading remotely (local options by
   // matches_search, remote batches by the server), so only filter the static list here
@@ -926,8 +914,10 @@
     flatten_navigable(group_options(searched_options)),
   )
 
+  // plain (non-reactive) trackers: the effect below compares against the previous run
   let previous_active_index = activeIndex
   let previous_active_option = activeOption
+  // svelte-ignore state_referenced_locally
   let previous_filter_text = effective_filter_text
 
   // Keep active state valid and preserve option identity across regrouping/refreshes.
@@ -1007,7 +997,6 @@
     ),
   )
 
-  // Compute the ID of the currently active dropdown option for aria-activedescendant.
   // Selected chips are plain list items, so left/right chip highlighting stays visual.
   const user_msg_id = $derived(`${internal_id}-user-msg`)
   const active_option_id = $derived(
@@ -1018,7 +1007,7 @@
         : undefined,
   )
 
-  // Helper to check if removing an option would violate minSelect constraint
+  // false once removing would drop selected below minSelect
   const can_remove = $derived(minSelect === null || selected.length > minSelect)
   // maxSelect = 1 replaces the current option instead of blocking, so it never counts
   // as at-capacity (used by add() and paste; re-evaluated after async oncreate resolves)
@@ -1064,7 +1053,6 @@
   // true while an async oncreate callback is pending, blocks further create attempts
   let creating_option = $state(false)
 
-  // add an option to selected list
   // from_paste: when true, skip option reconstruction so parse_paste() objects
   // are preserved as-is (extra fields like value/group/metadata aren't stripped)
   async function add(option_to_add: Option, event: Event, from_paste = false) {
@@ -1074,13 +1062,11 @@
       (typeof option_to_add !== `string` || option_to_add.trim().length > 0) &&
       typeof selected_labels[0] === `number`
     ) {
-      option_to_add = Number(option_to_add) as Option // convert to number if possible
+      option_to_add = Number(option_to_add) as Option
     }
 
-    // Check for duplicates by key, plus label check for user-created options
-    // For duplicates=false (default), label check only applies to user-typed text
-    // For duplicates='case-insensitive', label check applies to all options
-    // Use key comparison instead of reference equality (more robust with Svelte proxies)
+    // dupe check by key (not reference — Svelte proxies break identity); the label check
+    // additionally applies to user-typed options, or to all when duplicates='case-insensitive'
     const option_key = key(option_to_add)
     const is_from_options = effective_options.some((opt) => key(opt) === option_key)
     const check_label = duplicates === `case-insensitive` || !is_from_options
@@ -1105,8 +1091,6 @@
       [true, `append`].includes(allowUserOptions) &&
       (has_search_text || from_paste)
     ) {
-      // Reconstruct option for type homogeneity, but preserve object options
-      // from parse_paste as-is so extra fields (value/group/metadata) aren't stripped
       if (!(from_paste && typeof option_to_add === `object`)) {
         const label_text = from_paste ? `${utils.get_label(option_to_add)}` : searchText
         if (typeof effective_options[0] === `object`) {
@@ -1163,7 +1147,7 @@
       return
     }
     if (input_display) searchText = `${utils.get_label(option_to_add)}`
-    else if (resetFilterOnAdd) searchText = `` // reset search string on selection
+    else if (resetFilterOnAdd) searchText = ``
     // for maxSelect = 1 we always replace current option with new one
     selected =
       maxSelect === 1 ? [option_to_add] : sort_selected([...selected, option_to_add])
@@ -1175,7 +1159,6 @@
     onchange?.({ option: option_to_add, type: `add` })
   }
 
-  // remove an option from selected list
   // at_idx overrides findIndex lookup so duplicates=true removes the correct occurrence
   function remove(option_to_drop: Option, event: Event, at_idx?: number) {
     event.stopPropagation()
@@ -1329,7 +1312,6 @@
       }
     }
 
-    // Auto-expand collapsed groups when keyboard navigating
     if (keyboardExpandsCollapsedGroups && collapsibleGroups && collapsedGroups.size > 0) {
       expand_groups(get_collapsed_with_matches())
       await tick()
@@ -1358,7 +1340,6 @@
     }
     if (activeIndex === null) return
 
-    // update active state based on new index
     option_msg_is_active = has_user_msg && activeIndex === visible_navigable_count
     activeOption = option_msg_is_active ? null : (navigable_options[activeIndex] ?? null)
 
@@ -1403,7 +1384,8 @@
     return true
   }
 
-  // handle all keyboard events this component receives
+  // keydown on the search input; option/header rows handle their own keys via
+  // if_enter_or_space
   async function handle_keydown(event: KeyboardEvent) {
     if (disabled) return // Block all keyboard handling when disabled
     // Ignore keys while an IME composition is in progress: Enter confirms the
@@ -1412,7 +1394,6 @@
     if (event.isComposing) return
     const chip_navigation_enabled = !input_display && selected.length > 0 && !searchText
 
-    // Check keyboard shortcuts first (before other key handling)
     if (
       run_shortcut(
         event,
@@ -1440,12 +1421,10 @@
     )
       highlighted_idx = null
 
-    // on escape or tab out of input: close options dropdown and reset search text
     if (event.key === `Escape` || event.key === `Tab`) {
       event.stopPropagation()
       close_and_clear(event)
     } else if (event.key === `Enter`) {
-      // on enter key: toggle active option
       event.stopPropagation()
       event.preventDefault() // prevent enter key from triggering form submission
 
@@ -1461,8 +1440,7 @@
         // in which case enter means open it
         open_dropdown(event)
       }
-    }  // on left/right arrow keys: navigate between selected items
-    else if (event.key === `ArrowLeft` && chip_navigation_enabled) {
+    } else if (event.key === `ArrowLeft` && chip_navigation_enabled) {
       event.preventDefault()
       highlighted_idx =
         highlighted_idx === null ? selected.length - 1 : Math.max(0, highlighted_idx - 1)
@@ -1470,13 +1448,11 @@
       event.preventDefault()
       highlighted_idx = highlighted_idx < selected.length - 1 ? highlighted_idx + 1 : null
     } else if (event.key === `ArrowDown` || event.key === `ArrowUp`) {
-      // on up/down arrow keys: update active option
       event.stopPropagation()
       event.preventDefault()
       if (!open) open_dropdown(event, false)
       await handle_arrow_navigation(event.key === `ArrowUp` ? -1 : 1, event)
-    }  // on backspace key: remove highlighted or last selected option
-    else if (event.key === `Backspace` && chip_navigation_enabled) {
+    } else if (event.key === `Backspace` && chip_navigation_enabled) {
       event.stopPropagation()
       if (can_remove) {
         const prev_highlighted = highlighted_idx
@@ -1502,14 +1478,11 @@
     event.stopPropagation()
     highlighted_idx = null
 
-    // Keep the first minSelect items, remove the rest
-    // If no minSelect constraint, remove all
+    // keep the first minSelect items (all removed when minSelect is null)
     const keep_count = minSelect ?? 0
     const removed_options = selected.slice(keep_count)
-    // Only fire events when options were removed.
     if (removed_options.length === 0) return
 
-    // Keep the first minSelect items
     selected = selected.slice(0, keep_count)
     searchText = `` // always clear on remove all (resetFilterOnAdd only applies to add operations)
     announce_bulk(removed_options.length, `removed`)
@@ -1632,7 +1605,6 @@
       onchange?.({ options: selected, type: `removeAll` })
       return
     }
-    // Select all non-disabled, non-selected options in this group
     batch_add_options(selectable, event)
   }
 
@@ -1694,7 +1666,7 @@
     return true
   }
 
-  // Handle option interaction (click or keyboard) - DRY helper for template
+  // Shared click/keyboard/range entry point for selecting an option
   const handle_option_interact = (
     opt: Option,
     event: MouseEvent | KeyboardEvent,
@@ -1721,11 +1693,9 @@
 
   function on_click_outside(event: MouseEvent | TouchEvent) {
     if (!outerDiv || !(event.target instanceof Node)) return
-    // Check if click is inside the main component
     if (outerDiv.contains(event.target)) return
-    // If portal is active, also check if click is inside the portalled options dropdown
+    // portalled dropdown lives outside outerDiv
     if (portal_params?.active && ul_options?.contains(event.target)) return
-    // Click is outside both the main component and any portalled dropdown
     close_dropdown(event)
   }
 
@@ -2271,7 +2241,6 @@
     {/if}
   {/if}
 
-  <!-- only render options dropdown if options or searchText is not empty (needed to avoid briefly flashing empty dropdown) -->
   {#if listbox_rendered}
     <ul
       use:portal_action={{ target_node: outerDiv, open, ...portal_params }}
@@ -2505,7 +2474,7 @@
       {/if}
     </ul>
   {/if}
-  <!-- Screen reader announcements for dropdown state, option count, and selection changes -->
+  <!-- live region: selection changes, else available option count while open -->
   <div class="sr-only" aria-live="polite" aria-atomic="true">
     {#if last_announcement}
       {#key last_announcement.id}{last_announcement.text}{/key}
@@ -2516,7 +2485,6 @@
 </div>
 
 <style>
-  /* Screen reader only - visually hidden but accessible to assistive technology */
   .sr-only {
     position: absolute;
     width: 1px;
@@ -2782,7 +2750,7 @@
     background: var(--sms-li-disabled-bg, light-dark(#f5f5f6, #2a2a2a));
     color: var(--sms-li-disabled-text, light-dark(#b8b8b8, #666));
   }
-  /* Checkbox styling for keepSelectedInDropdown='checkboxes' mode - internal, no class prop */
+  /* keepSelectedInDropdown='checkboxes' */
   :is(ul.options > li > input.option-checkbox) {
     width: 16px;
     height: 16px;
@@ -2844,7 +2812,6 @@
       light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05))
     );
   }
-  /* Internal elements without class props - keep :is() for specificity */
   :is(ul.options > li.group-header .group-label) {
     flex: 1;
   }
@@ -2873,11 +2840,10 @@
       var(--sms-group-option-indent, 1.5ex)
     );
   }
-  /* Collapse/expand animation for group chevron icon - internal, keep :is() for specificity */
+  /* group chevron collapse/expand animation */
   :is(ul.options > li.group-header) :global(svg) {
     transition: transform var(--sms-group-collapse-duration, 0.15s) ease-out;
   }
-  /* Keep :is() for internal buttons without class props */
   :is(ul.options > li.group-header button.group-select-all) {
     font-size: 0.9em;
     font-weight: normal;
@@ -2906,7 +2872,7 @@
   :global(::highlight(sms-search-matches)) {
     color: light-dark(#1a8870, #6cc9a8);
   }
-  /* Loading more indicator for infinite scrolling - internal, no class prop */
+  /* infinite-scroll loading indicator */
   :is(ul.options > li.loading-more) {
     display: flex;
     justify-content: center;

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1301,8 +1301,7 @@
       if (!has_search_text || input_text_is_committed || show_all_input_options)
         return null
       if (duplicates !== true && is_label_selected(searchText)) {
-        // a blank message yields no row, so report no message at all rather than an
-        // invisible one that is still navigable and still blocks the create row below
+        // a blank message must not leave a navigable row that blocks the create row
         return duplicateOptionMsg ? { type: `dupe`, msg: duplicateOptionMsg } : null
       }
       if (load_options_pending) return null

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -2747,7 +2747,7 @@
     position: fixed;
   }
   :where(ul.options > li) {
-    padding: var(--sms-options-li-padding, 3pt 1ex);
+    padding: var(--sms-options-li-padding, 2pt 1ex);
     cursor: pointer;
     scroll-margin: var(--sms-options-scroll-margin, 100px);
     border-inline-start: 1px solid transparent;
@@ -2755,7 +2755,8 @@
   :where(ul.options .user-msg) {
     /* block needed so vertical padding applies to span */
     display: block;
-    padding: 3pt 2ex;
+    /* vertical padding tracks ul.options > li so this row is no taller than an option */
+    padding: 2pt 2ex;
   }
   :where(ul.options > li.selected) {
     background: var(

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1301,7 +1301,9 @@
       if (!has_search_text || input_text_is_committed || show_all_input_options)
         return null
       if (duplicates !== true && is_label_selected(searchText)) {
-        return { type: `dupe`, msg: duplicateOptionMsg }
+        // a blank message yields no row, so report no message at all rather than an
+        // invisible one that is still navigable and still blocks the create row below
+        return duplicateOptionMsg ? { type: `dupe`, msg: duplicateOptionMsg } : null
       }
       if (load_options_pending) return null
       if (allowUserOptions && resolved_create_msg) {
@@ -2164,7 +2166,7 @@
           {/if}
           {#if !disabled && can_remove}
             {@render remove_btn(
-              (event) => remove(option, event),
+              (event) => remove(option, event, idx),
               `${removeBtnTitle} ${utils.get_label(option)}`,
               { option, isRemoveAll: false },
             )}
@@ -2265,7 +2267,7 @@
         </span>
       </Wiggle>
     {/if}
-    {#if maxSelect !== 1 && selected.length > 1}
+    {#if maxSelect !== 1 && selected.length > 1 && can_remove}
       {@render remove_btn(remove_all, removeAllTitle, { isRemoveAll: true })}
     {/if}
   {/if}

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -9,7 +9,7 @@
 
   type NavLinkRouteObject = NavRouteObject & { href: string }
 
-  // Props for the item snippet's render_default function context
+  // Parameter passed to the item snippet
   interface ItemSnippetParams {
     route: NavRouteObject // normalized route object
     href: string
@@ -85,7 +85,6 @@
     return () => globalThis.removeEventListener(`resize`, check_mobile)
   })
 
-  // Call onopen/onclose callbacks when menu state changes
   $effect(() => {
     if (is_open && !prev_is_open) {
       onopen?.()
@@ -97,7 +96,7 @@
 
   $effect(() => () => {
     if (hide_timeout) clearTimeout(hide_timeout)
-  }) // cleanup on destroy
+  })
 
   function close_menus() {
     if (hide_timeout) clearTimeout(hide_timeout)
@@ -159,7 +158,6 @@
       return
     }
 
-    // Check if dropdown is open (either via hover or pinned)
     const dropdown_is_open = hovered_dropdown === href || pinned_dropdown === href
     // Arrow key navigation within open dropdown
     if (dropdown_is_open && (key === `ArrowDown` || key === `ArrowUp`)) {
@@ -191,7 +189,6 @@
     if (!path) return
     if (path === `/`) return page?.url.pathname === `/` ? `page` : undefined
     // Match exact path or path followed by / to avoid partial matches
-    // e.g. /tc-periodic-v2 should not match /tc-periodic
     const pathname = page?.url.pathname
     const exact_match = pathname === path
     const prefix_match = pathname?.startsWith(`${path}/`)
@@ -213,7 +210,6 @@
     return { label, style: label ? `text-transform: capitalize` : `` }
   }
 
-  // Normalize all route formats to NavRouteObject
   function parse_route(route: NavRoute): NavLinkRouteObject {
     if (typeof route === `string`) return { href: route }
     if (Array.isArray(route)) {
@@ -239,7 +235,6 @@
     return tooltip({ ...tooltip_options, ...opts })
   }
 
-  // Handle link click with onnavigate callback
   function handle_link_click(event: MouseEvent, route: NavLinkRouteObject) {
     if (route.disabled) {
       event.preventDefault()
@@ -265,7 +260,6 @@
       link_props?.onkeydown,
     )
 
-  // Get external link attributes
   function get_external_attrs(route: NavRouteObject) {
     if (!route.external) return {}
     return { target: `_blank`, rel: `noopener noreferrer` }

--- a/src/lib/PrevNext.svelte
+++ b/src/lib/PrevNext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" generics="Item extends [string, unknown] = [string, unknown]">
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
-  import { is_editable_event_target } from './utils'
+  import { is_editable_event_target, is_modifier_chord } from './utils'
 
   type NavItem = Item | [string, string]
   type SnippetProps = { item: NavItem; index: number | null; total: number }
@@ -82,10 +82,8 @@
   function handle_keyup(event: KeyboardEvent) {
     if (
       !onkeyup ||
-      // modifier+key is a browser/OS chord (Alt+Arrow is Back/Forward), not app nav
-      event.altKey ||
-      event.ctrlKey ||
-      event.metaKey ||
+      // a browser/OS chord (Alt+Arrow is Back/Forward), not app navigation
+      is_modifier_chord(event) ||
       is_editable_event_target(event.target) ||
       items_arr.length < min_items ||
       !prev ||
@@ -101,9 +99,9 @@
       ? [globalThis.scrollX, globalThis.scrollY]
       : [0, 0]
     const goto = globalThis.history[replace_state ? `replaceState` : `pushState`]
-    goto.call(globalThis.history, {}, ``, to) // Navigate using appropriate history method
+    goto.call(globalThis.history, {}, ``, to)
 
-    if (no_scroll) globalThis.scrollTo(scroll_x, scroll_y) // Restore scroll position if needed
+    if (no_scroll) globalThis.scrollTo(scroll_x, scroll_y)
   }
 </script>
 

--- a/src/lib/PrevNext.svelte
+++ b/src/lib/PrevNext.svelte
@@ -82,7 +82,7 @@
   function handle_keyup(event: KeyboardEvent) {
     if (
       !onkeyup ||
-      // Alt+Arrow is the browser's Back/Forward chord, so navigating would race with it
+      // modifier+key is a browser/OS chord (Alt+Arrow is Back/Forward), not app nav
       event.altKey ||
       event.ctrlKey ||
       event.metaKey ||

--- a/src/lib/PrevNext.svelte
+++ b/src/lib/PrevNext.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" generics="Item extends [string, unknown] = [string, unknown]">
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
+  import { is_editable_event_target } from './utils'
 
   type NavItem = Item | [string, string]
   type SnippetProps = { item: NavItem; index: number | null; total: number }
@@ -78,15 +79,13 @@
     }
   })
 
-  const is_editable_event_target = (target: EventTarget | null): boolean =>
-    target instanceof Element &&
-    target.closest(
-      `input, textarea, select, [contenteditable]:not([contenteditable="false"])`,
-    ) !== null
-
   function handle_keyup(event: KeyboardEvent) {
     if (
       !onkeyup ||
+      // Alt+Arrow is the browser's Back/Forward chord, so navigating would race with it
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
       is_editable_event_target(event.target) ||
       items_arr.length < min_items ||
       !prev ||

--- a/src/lib/Wiggle.svelte
+++ b/src/lib/Wiggle.svelte
@@ -31,7 +31,6 @@
     spring_options,
   )
 
-  // update spring physics when options change
   $effect(() => {
     store.stiffness = spring_options.stiffness
     store.damping = spring_options.damping

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -499,12 +499,11 @@ export const highlight_matches = (ops: HighlightOptions) => (node: HTMLElement) 
     const node_length = original_text.length
     let original_starts: number[] | null = null
     let original_ends: number[] | null = null
-    // The check below allocates a string per character, so skip it for ASCII,
-    // which can neither be astral nor change length when lowercased.
+    // skip for ASCII, which is never astral nor length-changing when lowercased
     let needs_offset_map = false
     if (HAS_NON_ASCII.test(original_text)) {
-      for (const character of original_text) {
-        if (character.length > 1 || character.toLowerCase().length !== character.length) {
+      for (const char of original_text) {
+        if (char.length > 1 || char.toLowerCase().length !== char.length) {
           needs_offset_map = true
           break
         }

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -422,6 +422,8 @@ type OwnedHighlight = {
 
 const owned_highlights = new WeakMap<object, Map<string, OwnedHighlight>>()
 
+const HAS_NON_ASCII = /\P{ASCII}/u
+
 const sync_owned_highlight = (
   registry: HighlightRegistry,
   css_class: string,
@@ -493,11 +495,15 @@ export const highlight_matches = (ops: HighlightOptions) => (node: HTMLElement) 
     const node_length = original_text.length
     let original_starts: number[] | null = null
     let original_ends: number[] | null = null
+    // The check below allocates a string per character, so skip it for ASCII,
+    // which can neither be astral nor change length when lowercased.
     let needs_offset_map = false
-    for (const character of original_text) {
-      if (character.length > 1 || character.toLowerCase().length !== character.length) {
-        needs_offset_map = true
-        break
+    if (HAS_NON_ASCII.test(original_text)) {
+      for (const character of original_text) {
+        if (character.length > 1 || character.toLowerCase().length !== character.length) {
+          needs_offset_map = true
+          break
+        }
       }
     }
     if (needs_offset_map) {

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -44,8 +44,6 @@ export interface ResizableOptions {
 }
 
 // Svelte 5 attachment factory to make an element draggable
-// @param options - Configuration options for dragging behavior
-// @returns Attachment function that sets up dragging on an element
 export const draggable =
   (options: DraggableOptions = {}): Attachment =>
   (element: Element): (() => void) | undefined => {
@@ -54,7 +52,6 @@ export const draggable =
     if (!(element instanceof HTMLElement)) return undefined
     const node = element
 
-    // Use simple variables for maximum performance
     let dragging = false
     let start = { x: 0, y: 0 }
     const initial = { left: 0, top: 0 }
@@ -85,7 +82,6 @@ export const draggable =
         initial.left = rect.left
         initial.top = rect.top
       } else {
-        // For other positioning, use offset values
         initial.left = node.offsetLeft
         initial.top = node.offsetTop
       }
@@ -100,13 +96,12 @@ export const draggable =
       globalThis.addEventListener(`mousemove`, handle_mousemove)
       globalThis.addEventListener(`mouseup`, handle_mouseup)
 
-      options.on_drag_start?.(event) // Call optional callback
+      options.on_drag_start?.(event)
     }
 
     function handle_mousemove(event: MouseEvent) {
       if (!dragging) return
 
-      // Use the exact same calculation as the fast old implementation
       const dx = event.clientX - start.x
       const dy = event.clientY - start.y
       node.style.left = `${initial.left + dx}px`
@@ -126,7 +121,7 @@ export const draggable =
       globalThis.removeEventListener(`mousemove`, handle_mousemove)
       globalThis.removeEventListener(`mouseup`, handle_mouseup)
 
-      options.on_drag_end?.(event) // Call optional callback
+      options.on_drag_end?.(event)
     }
 
     if (handle) {
@@ -134,7 +129,6 @@ export const draggable =
       handle.style.cursor = `grab`
     }
 
-    // Return cleanup function (this is the attachment pattern)
     return () => {
       globalThis.removeEventListener(`mousemove`, handle_mousemove)
       globalThis.removeEventListener(`mouseup`, handle_mouseup)
@@ -142,7 +136,7 @@ export const draggable =
       if (dragging) document.body.style.userSelect = ``
       if (handle) {
         handle.removeEventListener(`mousedown`, handle_mousedown)
-        handle.style.cursor = `` // Reset cursor
+        handle.style.cursor = ``
       }
     }
   }
@@ -296,6 +290,7 @@ export interface SortableOptions {
   disabled?: boolean
 }
 
+// Attachment making an HTML table sortable by clicking column headers (click again to flip direction)
 export const sortable =
   (options: SortableOptions = {}) =>
   (node: HTMLElement) => {
@@ -309,8 +304,6 @@ export const sortable =
 
     if (disabled) return undefined
 
-    // This action can be applied to standard HTML tables to make them sortable by
-    // clicking on column headers (and clicking again to toggle sorting direction)
     const headers = Array.from(
       node.querySelectorAll<HTMLTableCellElement>(header_selector),
     )
@@ -336,7 +329,7 @@ export const sortable =
     headers.forEach((header, idx) => {
       const original_html = header.innerHTML
       const original_style = header.getAttribute(`style`) ?? ``
-      header.style.cursor = `pointer` // add cursor pointer to headers
+      header.style.cursor = `pointer`
 
       const click_handler = () => {
         // reset all headers to unsorted state
@@ -345,10 +338,10 @@ export const sortable =
           state.header.style.cursor = `pointer`
         }
         if (idx === sort_col_idx) {
-          sort_dir *= -1 // reverse sort direction
+          sort_dir *= -1
         } else {
-          sort_col_idx = idx // set new sort column index
-          sort_dir = 1 // reset sort direction
+          sort_col_idx = idx
+          sort_dir = 1
         }
         header.classList.add(sort_dir > 0 ? asc_class : desc_class)
         Object.assign(header.style, sorted_style)
@@ -629,7 +622,6 @@ function clear_tooltip() {
   show_timeout_owner = null
   if (hide_timeout) clearTimeout(hide_timeout)
   if (current_tooltip) {
-    // Remove aria-describedby from the trigger element
     current_tooltip.owner_element?.removeAttribute(`aria-describedby`)
     current_tooltip.remove()
     current_tooltip = null
@@ -640,7 +632,6 @@ function clear_tooltip() {
 const owns_tooltip_state = (element: HTMLElement): boolean =>
   current_tooltip?.owner_element === element || show_timeout_owner === element
 
-// Options for the tooltip attachment.
 export interface TooltipOptions {
   content?: string
   placement?: `top` | `bottom` | `left` | `right`
@@ -682,7 +673,6 @@ export const tooltip =
 
     const cleanup_functions: (() => void)[] = []
 
-    // Handle disabled option
     if (options.disabled === true) return undefined
 
     // Track current input method for 'touch-devices' option (runtime detection, not capability sniffing)
@@ -1002,7 +992,7 @@ export const tooltip =
           filter: var(--tooltip-shadow, drop-shadow(0 2px 8px rgba(0,0,0,0.25))); transition: opacity 0.15s ease-out;
         `
 
-          // Apply custom styles if provided (these will override base styles due to CSS specificity)
+          // Applied after base cssText so they win, preserving any !important priority
           if (options.style) {
             const custom_style = document.createElement(`div`).style
             custom_style.cssText = options.style
@@ -1112,10 +1102,7 @@ export const tooltip =
 
       events.forEach((event, idx) => element.addEventListener(event, handlers[idx]))
 
-      // Hide tooltip when user scrolls the page (not element-level scrolls like input fields)
       globalThis.addEventListener(`scroll`, handle_scroll, true)
-
-      // Add Escape key listener to dismiss tooltip
       document.addEventListener(`keydown`, handle_keydown)
 
       // Watch for element removal from DOM to prevent orphaned tooltips
@@ -1156,7 +1143,6 @@ export const tooltip =
       }
     }
 
-    // Setup tooltip for main node and children
     const main_cleanup = setup_tooltip(node)
     if (main_cleanup) cleanup_functions.push(main_cleanup)
 
@@ -1193,16 +1179,10 @@ export const click_outside =
       if (!(target instanceof Element)) return
       const path = event.composedPath()
 
-      // Check if click target is the node or inside it
       if (path.includes(node)) return
-
-      // Check excluded selectors
       if (exclude.some((selector) => target.closest(selector))) return
 
-      // Execute callback if provided, passing node and full config
       callback?.(node, { callback, enabled, exclude })
-
-      // Dispatch custom event if click was outside
       node.dispatchEvent(new CustomEvent(`outside-click`))
     }
 

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -71,6 +71,8 @@ export const draggable =
     }
 
     function handle_mousedown(event: MouseEvent) {
+      // non-primary buttons open the context menu, which can swallow the mouseup
+      if (event.button !== 0) return
       // Only drag if mousedown is on the handle or its children
       if (!(event.target instanceof Node) || !handle?.contains?.(event.target)) return
 
@@ -196,6 +198,8 @@ export const resizable =
     }
 
     function on_mousedown(event: MouseEvent) {
+      // non-primary buttons open the context menu, which can swallow the mouseup
+      if (event.button !== 0) return
       active_edge = get_edge(event)
       if (!active_edge) return
 

--- a/src/lib/heading-anchors.ts
+++ b/src/lib/heading-anchors.ts
@@ -184,8 +184,7 @@ export function heading_ids() {
         }
       }
 
-      // both passes scan the whole file with a lazy [\s\S]*? body, so skip them
-      // for the many .svelte files that contain no heading at all
+      // both passes scan the whole file, so skip them when there is no heading
       if (has_heading.test(content)) {
         // Pass 1 matches line starts (.svelte); pass 2 matches after tags (mdsvex output).
         add_heading_ids(heading_regex_line_start)

--- a/src/lib/heading-anchors.ts
+++ b/src/lib/heading-anchors.ts
@@ -4,9 +4,7 @@
 // Match headings in two contexts:
 // 1. Start of line (for .svelte files with formatted HTML)
 // 2. After > (for mdsvex output where HTML is on single line, e.g., "</p> <h2>")
-// Avoid matching inside src={...} attributes by requiring these specific contexts
-// Note: [^>]* for attributes won't match if an attribute value contains > (e.g., data-foo="a>b")
-// This edge case is rare in practice and would require significantly more complex parsing
+// Known limitation: [^>]* breaks on attribute values containing > (e.g. data-foo="a>b")
 const heading_regex_line_start =
   /^(?<indent>\s*)<(?<tag>h[1-6])(?<attrs>[^>]*)>(?<inner>[\s\S]*?)<\/\k<tag>>/gimu
 const heading_regex_after_tag =
@@ -138,7 +136,6 @@ const slugify = (text: string): string =>
     .replaceAll(/-+/gu, `-`) // collapse multiple dashes
     .replaceAll(/^-|-$/gu, ``) // trim leading/trailing dashes
 
-/** @type {() => import('svelte/compiler').PreprocessorGroup} */
 export function heading_ids() {
   return {
     name: `heading-ids`,
@@ -186,7 +183,6 @@ export function heading_ids() {
 
       // both passes scan the whole file, so skip them when there is no heading
       if (has_heading.test(content)) {
-        // Pass 1 matches line starts (.svelte); pass 2 matches after tags (mdsvex output).
         add_heading_ids(heading_regex_line_start)
         add_heading_ids(heading_regex_after_tag)
       }
@@ -196,7 +192,6 @@ export function heading_ids() {
   }
 }
 
-// SVG link icon for heading anchors
 const link_svg = `<svg width="16" height="16" viewBox="0 0 16 16" aria-label="Link to heading" role="img"><path d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0z" fill="currentColor"/></svg>`
 
 export interface HeadingAnchorsOptions {
@@ -209,7 +204,6 @@ export interface HeadingAnchorsOptions {
   icon_svg?: string
 }
 
-// Add anchor link to a single heading element
 function add_anchor_to_heading(heading: Element, icon_svg: string = link_svg): void {
   if (heading.querySelector(`a[aria-hidden="true"]`)) return
   if (!heading.id) {
@@ -239,7 +233,6 @@ const get_default_headings = (node: Element): Element[] =>
   ])
 
 // Svelte 5 attachment that adds anchor links to headings within a container
-// Uses MutationObserver to handle dynamically added headings
 export const heading_anchors =
   (options: HeadingAnchorsOptions = {}) =>
   (node: Element): (() => void) | undefined => {
@@ -251,7 +244,6 @@ export const heading_anchors =
       ? () => Array.from(node.querySelectorAll(selector))
       : () => get_default_headings(node)
 
-    // Process existing headings
     for (const heading of get_headings()) {
       add_anchor_to_heading(heading, icon_svg)
     }

--- a/src/lib/heading-anchors.ts
+++ b/src/lib/heading-anchors.ts
@@ -11,6 +11,8 @@ const heading_regex_line_start =
   /^(?<indent>\s*)<(?<tag>h[1-6])(?<attrs>[^>]*)>(?<inner>[\s\S]*?)<\/\k<tag>>/gimu
 const heading_regex_after_tag =
   /(?<=>)(?<space>\s*)<(?<tag>h[1-6])(?<attrs>[^>]*)>(?<inner>[\s\S]*?)<\/\k<tag>>/giu
+// Cheap precondition for both regexes above: no `<h1`..`<h6` means no match.
+const has_heading = /<h[1-6]/iu
 
 type TextInsertion = { index: number; text: string }
 
@@ -114,6 +116,8 @@ function insert_with_source_map(
 // Remove Svelte expressions handling nested braces (e.g., {fn({a: 1})})
 // Treats unmatched } as literal text to avoid dropping content
 function strip_svelte_expressions(str: string): string {
+  // no expression to strip means the char-by-char rebuild below is a no-op
+  if (!str.includes(`{`)) return str
   let result = ``
   let depth = 0
   for (const char of str) {
@@ -180,9 +184,13 @@ export function heading_ids() {
         }
       }
 
-      // Pass 1 matches line starts (.svelte); pass 2 matches after tags (mdsvex output).
-      add_heading_ids(heading_regex_line_start)
-      add_heading_ids(heading_regex_after_tag)
+      // both passes scan the whole file with a lazy [\s\S]*? body, so skip them
+      // for the many .svelte files that contain no heading at all
+      if (has_heading.test(content)) {
+        // Pass 1 matches line starts (.svelte); pass 2 matches after tags (mdsvex output).
+        add_heading_ids(heading_regex_line_start)
+        add_heading_ids(heading_regex_after_tag)
+      }
 
       return insert_with_source_map(content, insertions, filename)
     },

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -21,7 +21,6 @@ export { default as Wiggle } from './Wiggle.svelte'
 // See https://github.com/janosh/svelte-multiselect/issues/87
 // Polyfill copied from
 // https://github.com/nuxodin/lazyfill/blob/a8e63/polyfills/Element/prototype/scrollIntoViewIfNeeded.js
-// exported for testing
 export function scroll_into_view_if_needed_polyfill(
   element: Element,
   centerIfNeeded: boolean = true,

--- a/src/lib/live-examples/hast.ts
+++ b/src/lib/live-examples/hast.ts
@@ -11,8 +11,7 @@ export interface HastNode {
   children?: HastNode[]
 }
 
-// each replaceAll below rebuilds the whole string, and most highlighted tokens
-// contain nothing to escape, so check once before doing any of that work
+// each replaceAll rebuilds the whole string, and most tokens have nothing to escape
 const HAS_ESCAPABLE = /[&<>]/u
 
 // Escape HTML special characters in text content (not for attribute values)
@@ -21,8 +20,7 @@ export const escape_html_text = (str: string): string =>
     ? str.replaceAll(`&`, `&amp;`).replaceAll(`<`, `&lt;`).replaceAll(`>`, `&gt;`)
     : str
 
-// starry-night emits one element per token, so rather than allocate an array to
-// join at each of the thousands of nodes per code block, concatenate in place
+// thousands of nodes per code block, so concatenate rather than array-and-join each
 const serialize_children = (children: HastNode[] | undefined): string => {
   let html = ``
   for (const child of children ?? []) html += hast_to_html(child)

--- a/src/lib/live-examples/hast.ts
+++ b/src/lib/live-examples/hast.ts
@@ -11,15 +11,28 @@ export interface HastNode {
   children?: HastNode[]
 }
 
+// each replaceAll below rebuilds the whole string, and most highlighted tokens
+// contain nothing to escape, so check once before doing any of that work
+const HAS_ESCAPABLE = /[&<>]/u
+
 // Escape HTML special characters in text content (not for attribute values)
 export const escape_html_text = (str: string): string =>
-  str.replaceAll(`&`, `&amp;`).replaceAll(`<`, `&lt;`).replaceAll(`>`, `&gt;`)
+  HAS_ESCAPABLE.test(str)
+    ? str.replaceAll(`&`, `&amp;`).replaceAll(`<`, `&lt;`).replaceAll(`>`, `&gt;`)
+    : str
+
+// starry-night emits one element per token, so rather than allocate an array to
+// join at each of the thousands of nodes per code block, concatenate in place
+const serialize_children = (children: HastNode[] | undefined): string => {
+  let html = ``
+  for (const child of children ?? []) html += hast_to_html(child)
+  return html
+}
 
 // Convert HAST to HTML string
 export const hast_to_html = (node: HastNode): string => {
   if (node.type === `text`) return escape_html_text(node.value ?? ``)
-  if (node.type === `root`)
-    return (node.children ?? []).map((child) => hast_to_html(child)).join(``)
+  if (node.type === `root`) return serialize_children(node.children)
   // Skip non-element nodes (comment, doctype, raw) - emitting them as elements
   // would produce malformed `<undefined>` tags
   if (node.type !== `element` || !node.tagName) return ``
@@ -27,6 +40,5 @@ export const hast_to_html = (node: HastNode): string => {
   const cls_val = properties?.className
   const cls = Array.isArray(cls_val) ? cls_val.join(` `) : undefined
   const attrs = cls ? ` class="${cls}"` : ``
-  const inner = children?.map((child) => hast_to_html(child)).join(``) ?? ``
-  return `<${tagName}${attrs}>${inner}</${tagName}>`
+  return `<${tagName}${attrs}>${serialize_children(children)}</${tagName}>`
 }

--- a/src/lib/live-examples/highlighter.ts
+++ b/src/lib/live-examples/highlighter.ts
@@ -7,7 +7,6 @@ type StarryNight = {
 
 const optional_peer_error = `svelte-multiselect/live-examples requires optional peer dependency @wooorm/starry-night`
 
-// Starry-night highlighter for mdsvex
 async function create_starry_night(): Promise<StarryNight> {
   try {
     const [{ common, createStarryNight }, { default: source_svelte }] = await Promise.all(
@@ -27,7 +26,6 @@ const escape_svelte = (html: string): string =>
 // Uses common bundle (34 grammars) + Svelte
 export const starry_night = await create_starry_night()
 
-// mdsvex highlighter function
 export function starry_night_highlighter(code: string, lang?: string | null): string {
   const lang_key = lang?.toLowerCase()
   const scope = lang_key ? starry_night.flagToScope(lang_key) : undefined

--- a/src/lib/live-examples/mdsvex-transform.ts
+++ b/src/lib/live-examples/mdsvex-transform.ts
@@ -8,9 +8,7 @@ import { starry_night } from './highlighter.ts'
 const encode_escapes = (src: string) =>
   src.replaceAll(`\``, `\\\``).replaceAll(`\${`, `\\$\{`)
 
-// Regex to find <script> block in svelte
-// Note: These patterns handle common cases but may have edge cases with nested
-// comments containing </script> strings or complex attribute syntax
+// script/style matchers; may misfire on </script> inside comments or exotic attributes
 const RE_SCRIPT_START = /<script\b(?:[^<>"']|"[^"]*"|'[^']*')*>/u
 const RE_SCRIPT_BLOCK = /<script[\s\S]*?>[\s\S]*?<\/script>/gu
 const RE_STYLE_BLOCK = /<style[\s\S]*?>[\s\S]*?<\/style>/gu
@@ -24,7 +22,7 @@ const RE_PARSE_META = /(?:\w+="(?:[^"\\]|\\.)*"|\w+=\[[^\]]*\]|\w+=[^\s"[\]]+|\w
 export const EXAMPLE_MODULE_PREFIX = `___live_example___`
 export const EXAMPLE_COMPONENT_PREFIX = `LiveExample___`
 
-// Languages that render as live Svelte components (O(1) lookup)
+// Languages that render as live Svelte components
 const LIVE_LANGUAGES = new Set([`svelte`, `html`])
 
 // Inline lang-label style for code-only examples, which are raw HTML with no
@@ -75,7 +73,6 @@ interface RemarkFile {
   cwd: string
 }
 
-// Default wrapper component
 const DEFAULT_WRAPPER = `$lib/CodeExample.svelte`
 
 type RemarkTransformer = (tree: RemarkTree, file: RemarkFile) => void
@@ -92,7 +89,6 @@ function remark(options: RemarkOptions = {}): RemarkTransformer {
 
     const filename = path.relative(file.cwd, file.filename)
 
-    // Helper to get or create a wrapper alias
     function get_wrapper_alias(wrapper: string | [string, string]): string {
       const key = JSON.stringify(wrapper)
       let entry = wrapper_imports.get(key)
@@ -127,7 +123,7 @@ function remark(options: RemarkOptions = {}): RemarkTransformer {
         const value = create_example_component(
           node.value ?? ``,
           meta,
-          is_live ? example_csr.length : -1, // -1 for code-only (no component import needed)
+          is_live ? example_csr.length : -1,
           node.lang,
           scope,
           wrapper_alias,
@@ -232,7 +228,6 @@ function create_example_component(
   const escaped_src = JSON.stringify(code)
   const escaped_meta = encode_escapes(JSON.stringify({ ...meta, lang }))
 
-  // Close and reopen <p> to avoid block-in-inline HTML nesting issues
   return `</p>
   <${wrapper_alias}
     __live_example_src={"${base64_src}"}

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -56,8 +56,7 @@ function collect_nodes(tree: unknown): { src_props: AstNode[]; imports: AstNode[
     } else if (node.type === `ImportDeclaration` || node.type === `ImportExpression`) {
       imports.push(node)
     }
-    // AST nodes are mostly primitives (type, start, end, name, raw), and only
-    // objects and arrays can hold nested nodes worth recursing into
+    // AST nodes are mostly primitives; only objects and arrays can nest
     for (const value of Object.values(node)) {
       if (typeof value === `object` && value !== null) walk(value)
     }

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -56,10 +56,8 @@ function collect_nodes(tree: unknown): { src_props: AstNode[]; imports: AstNode[
     } else if (node.type === `ImportDeclaration` || node.type === `ImportExpression`) {
       imports.push(node)
     }
-    // AST nodes are mostly primitives; only objects and arrays can nest
-    for (const value of Object.values(node)) {
-      if (typeof value === `object` && value !== null) walk(value)
-    }
+    // most property values are primitives, so only recurse where nesting is possible
+    for (const value of Object.values(node)) if (is_record(value)) walk(value)
   }
   walk(tree)
   return { src_props, imports }

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -56,7 +56,11 @@ function collect_nodes(tree: unknown): { src_props: AstNode[]; imports: AstNode[
     } else if (node.type === `ImportDeclaration` || node.type === `ImportExpression`) {
       imports.push(node)
     }
-    Object.values(node).forEach(walk)
+    // AST nodes are mostly primitives (type, start, end, name, raw), and only
+    // objects and arrays can hold nested nodes worth recursing into
+    for (const value of Object.values(node)) {
+      if (typeof value === `object` && value !== null) walk(value)
+    }
   }
   walk(tree)
   return { src_props, imports }

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -21,8 +21,8 @@ const with_empty_map = (code: string): TransformResult => ({
   map: { mappings: `` },
 })
 
-// Max chars to scan after property end for trailing comma/whitespace cleanup
-const TRAILING_CLEANUP_BOUND = 50 // Generous bound - typical trailing content is ", " (2 chars)
+// chars to scan past a property for trailing comma/whitespace (typically just ", ")
+const TRAILING_CLEANUP_BOUND = 50
 
 // Apply edits in reverse order so positions stay valid
 const apply_edits = (source: string, edits: Edit[]): string =>

--- a/src/lib/portal.ts
+++ b/src/lib/portal.ts
@@ -75,7 +75,7 @@ export function portal_action(node: HTMLElement, initial_params: PortalActionPar
       node.style.removeProperty(property)
     }
     delete node.dataset.placement
-    node.hidden = false
+    node.hidden = !params.open
     home_parent = null
     home_anchor = null
   }

--- a/src/lib/portal.ts
+++ b/src/lib/portal.ts
@@ -75,7 +75,8 @@ export function portal_action(node: HTMLElement, initial_params: PortalActionPar
       node.style.removeProperty(property)
     }
     delete node.dataset.placement
-    node.hidden = !params.open
+    // hand visibility back to the consumer's CSS: update() won't re-sync once home
+    node.hidden = false
     home_parent = null
     home_anchor = null
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,7 +67,6 @@ export interface MultiSelectEvents<T extends Option = Option> {
   ongroupToggle?: (data: { group: string; collapsed: boolean }) => unknown // fires when group is collapsed/expanded
   oncollapseAll?: (data: { groups: string[] }) => unknown // fires when all groups are collapsed
   onexpandAll?: (data: { groups: string[] }) => unknown // fires when all groups are expanded
-  // Additional events for user feedback and analytics
   onsearch?: (data: { searchText: string; matchingOptions: T[] }) => unknown // fires (debounced) when search text changes
   onmaxreached?: (data: {
     selected: T[]
@@ -133,7 +132,7 @@ export type GroupHeaderProps<T extends Option = Option> = {
   collapsed: boolean
 }
 
-// Type for grouped options structure (used internally by MultiSelect)
+// shape of one option group in the dropdown
 export type GroupedOptions<T extends Option = Option> = {
   group: string | null
   options: T[]
@@ -297,7 +296,6 @@ export interface MultiSelectProps<T extends Option = Option>
       }) => string)
     | null
   liSelectAllClass?: string // CSS class for the select all <li>
-  // Dynamic options loading for large datasets (https://github.com/janosh/svelte-multiselect/discussions/342)
   // Pass a function for simple usage, or an object with config for advanced usage
   loadOptions?: LoadOptions<T>
   // Animation parameters for selected options flip animation (https://github.com/janosh/svelte-multiselect/issues/356)
@@ -308,7 +306,7 @@ export interface MultiSelectProps<T extends Option = Option>
   collapsedGroups?: Set<string> // externally controlled collapsed state (bindable)
   groupSelectAll?: boolean // add "select all" action per group header (toggles between select/deselect)
   ungroupedPosition?: `first` | `last` // where to render options without a group
-  groupSortOrder?: `none` | `asc` | `desc` | ((a: string, b: string) => number) // sort groups alphabetically
+  groupSortOrder?: `none` | `asc` | `desc` | ((a: string, b: string) => number) // group ordering, default 'none' (source order); 'asc'/'desc' sort alphabetically or pass a comparator
   searchExpandsCollapsedGroups?: boolean // auto-expand collapsed groups when search matches their options
   searchMatchesGroups?: boolean // include group name in search matching
   keyboardExpandsCollapsedGroups?: boolean // auto-expand collapsed groups when navigating with arrow keys

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,8 +9,6 @@ export const chain_handlers =
 
 // Generates a UUID for component IDs. Uses native crypto.randomUUID when available.
 // Fallback uses timestamp+counter - sufficient for DOM IDs (uniqueness, not security).
-// Cryptographic randomness is unnecessary here since these IDs are only used for
-// associating labels with inputs and ensuring unique DOM element identifiers.
 export function get_uuid(): string {
   if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
   const hex = (Date.now().toString(16) + (uuid_counter++).toString(16)).padStart(32, `0`)
@@ -23,7 +21,6 @@ export function get_uuid(): string {
   ].join(`-`)
 }
 
-// Type guard for checking if a value is a non-null object
 export const is_object = (val: unknown): val is Record<string, unknown> =>
   typeof val === `object` && val !== null
 
@@ -32,7 +29,6 @@ export const slug_to_title = (slug: string): string =>
     .replaceAll(`-`, ` `)
     .replaceAll(/(?<![\p{L}\p{M}\p{N}_])\p{L}/gu, (letter) => letter.toUpperCase())
 
-// Type guard for checking if an option has a group key
 export const has_group = <T extends Option>(opt: T): opt is T & { group: string } =>
   is_object(opt) && typeof opt.group === `string`
 
@@ -49,15 +45,12 @@ export const get_label = (opt: Option) => {
   return `${opt}`
 }
 
-// Generate a unique key for an option, preserving value identity
-// For object options: uses value if defined, otherwise label (no case normalization)
-// For primitives: the primitive itself
+// Unique option key: value ?? label for objects, the primitive itself otherwise
 export const get_option_key = (opt: Option): unknown =>
   is_object(opt) ? (opt.value ?? get_label(opt)) : opt
 
-// This function is used extract CSS strings from a {selected, option} style
-// object to be used in the style attribute of the option.
-// If the style is a string, it will be returned as is
+// Extract a CSS string from an option's style (string or {option, selected} object).
+// Always returns a semicolon-terminated string.
 export function get_style(
   option: Option,
   key: `selected` | `option` | null | undefined = null, // undefined falls back to null via default
@@ -81,7 +74,6 @@ export function get_style(
       }
     }
   }
-  // ensure css_str ends with a semicolon
   const trimmed = css_str.trim()
   if (trimmed && !trimmed.endsWith(`;`)) css_str += `;`
   return css_str
@@ -138,6 +130,10 @@ export const is_editable_event_target = (target: EventTarget | null): boolean =>
     `input, textarea, select, [contenteditable]:not([contenteditable="false"])`,
   ) !== null
 
+// Alt/Ctrl/Meta make a keystroke a chord. Shift is excluded: it types capitals.
+export const is_modifier_chord = (event: KeyboardEvent): boolean =>
+  event.altKey || event.ctrlKey || event.metaKey
+
 // Compare arrays/values for equality to avoid unnecessary updates.
 // Prevents infinite loops when value/selected are bound to reactive wrappers
 // that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.
@@ -183,9 +179,7 @@ export function fuzzy_match_indices(
   return indices
 }
 
-// Fuzzy string matching function
-// Returns true if the search string can be found as a subsequence in the target string
-// e.g., "tageoo" matches "tasks/geo-opt" because t-a-g-e-o-o appears in order
+// True if search is a subsequence of target, e.g. "tageoo" matches "tasks/geo-opt"
 export function fuzzy_match(search_text: string, target_text: string): boolean {
   // guard null/undefined inputs (fuzzy_match_indices would throw on .toLowerCase())
   if (search_text == null || target_text == null) return false

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -114,10 +114,8 @@ export function parse_shortcut(shortcut: string): {
   return { key, ctrl, shift, alt, meta }
 }
 
-// Every registered shortcut is re-parsed on every keydown, so cache the parses.
-// Deliberately not inside parse_shortcut: that is public API whose callers own
-// the object they get back and may mutate it. Bounded so callers generating
-// shortcut strings dynamically can't grow the map without limit.
+// Every registered shortcut is re-parsed on every keydown. Not cached inside
+// parse_shortcut: that is public API whose callers own (and may mutate) the result.
 const MAX_PARSED_SHORTCUTS = 1000
 const parsed_shortcuts = new Map<string, ReturnType<typeof parse_shortcut>>()
 
@@ -144,8 +142,7 @@ export function matches_shortcut(
   )
 }
 
-// True when the event originated inside a text-entry control, where a bare
-// character key is ordinary typing rather than a hotkey
+// True when the event came from a text-entry control, where a bare key is typing
 export const is_editable_event_target = (target: EventTarget | null): boolean =>
   target instanceof Element &&
   target.closest(
@@ -167,9 +164,8 @@ export function values_equal(val1: unknown, val2: unknown): boolean {
   return false
 }
 
-// Both replaceAll calls below rebuild the whole string, so bail out before doing
-// that work: labels and command text rarely contain tabs, newlines or runs of
-// spaces, and this normalization runs once per option on every keystroke.
+// Runs once per option on every keystroke and each replaceAll rebuilds the whole
+// string, so skip it for the common case of no tabs, newlines or repeated spaces.
 const HAS_COLLAPSIBLE_WHITESPACE = /\s\s|[^\S ]/u
 const HAS_NON_PLAIN_WHITESPACE = /[^\S ]/u
 
@@ -180,19 +176,16 @@ export function fuzzy_match_indices(
   search_text: string,
   target_text: string,
 ): number[] | null {
-  // whitespace runs collapse in the search; every whitespace character in the
-  // target maps to a plain space
+  // collapse runs in the search; map every whitespace char in the target to a space
   let search = search_text.toLowerCase()
   if (HAS_COLLAPSIBLE_WHITESPACE.test(search)) search = search.replaceAll(/\s+/gu, ` `)
   let target = target_text.toLowerCase()
   if (HAS_NON_PLAIN_WHITESPACE.test(target)) target = target.replaceAll(/\s/gu, ` `)
 
-  // Greedy leftmost subsequence match. indexOf scans natively and the cursor only
-  // moves forward, so the total scanned length stays linear in the target.
+  // Greedy leftmost match; pos only moves forward, so scanning stays linear.
   const indices: number[] = []
   let pos = -1
-  // indexing by code unit, not for...of: iterating code points would match an
-  // astral character as one unit and emit one index where callers expect two
+  // by code unit, not for...of: code points emit one index per astral char, two expected
   // oxlint-disable-next-line typescript/prefer-for-of
   for (let search_idx = 0; search_idx < search.length; search_idx++) {
     pos = target.indexOf(search[search_idx], pos + 1)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -146,6 +146,14 @@ export function matches_shortcut(
   )
 }
 
+// True when the event originated inside a text-entry control, where a bare
+// character key is ordinary typing rather than a hotkey
+export const is_editable_event_target = (target: EventTarget | null): boolean =>
+  target instanceof Element &&
+  target.closest(
+    `input, textarea, select, [contenteditable]:not([contenteditable="false"])`,
+  ) !== null
+
 // Compare arrays/values for equality to avoid unnecessary updates.
 // Prevents infinite loops when value/selected are bound to reactive wrappers
 // that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -97,21 +97,36 @@ export function split_shortcut(shortcut: string): string[] {
   return parts
 }
 
-// Parse shortcut string into modifier+key parts
-export function parse_shortcut(shortcut: string): {
+type ParsedShortcut = {
   key: string
   ctrl: boolean
   shift: boolean
   alt: boolean
   meta: boolean
-} {
+}
+
+// matches_shortcut re-parses every registered shortcut on every keydown. Parsing
+// is pure and keyed by an immutable string, so memoize it - bounded so callers
+// generating shortcut strings dynamically can't grow the map without limit.
+const MAX_PARSED_SHORTCUTS = 1000
+const parsed_shortcuts = new Map<string, ParsedShortcut>()
+
+// Parse shortcut string into modifier+key parts
+export function parse_shortcut(shortcut: string): ParsedShortcut {
+  const cached = parsed_shortcuts.get(shortcut)
+  if (cached) return cached
+
   const parts = split_shortcut(shortcut)
   const key = parts.pop() ?? ``
   const ctrl = parts.includes(`ctrl`)
   const shift = parts.includes(`shift`)
   const alt = parts.includes(`alt`)
   const meta = parts.includes(`meta`) || parts.includes(`cmd`)
-  return { key, ctrl, shift, alt, meta }
+  const parsed = { key, ctrl, shift, alt, meta }
+
+  if (parsed_shortcuts.size >= MAX_PARSED_SHORTCUTS) parsed_shortcuts.clear()
+  parsed_shortcuts.set(shortcut, parsed)
+  return parsed
 }
 
 export function matches_shortcut(
@@ -146,6 +161,12 @@ export function values_equal(val1: unknown, val2: unknown): boolean {
   return false
 }
 
+// Both replaceAll calls below rebuild the whole string, so bail out before doing
+// that work: labels and command text rarely contain tabs, newlines or runs of
+// spaces, and this normalization runs once per option on every keystroke.
+const HAS_COLLAPSIBLE_WHITESPACE = /\s\s|[^\S ]/u
+const HAS_NON_PLAIN_WHITESPACE = /[^\S ]/u
+
 // Case-insensitive subsequence match: returns the indices in target_text where
 // the characters of search_text appear in order, or null if not all characters
 // can be matched. An empty search matches with no indices.
@@ -153,20 +174,26 @@ export function fuzzy_match_indices(
   search_text: string,
   target_text: string,
 ): number[] | null {
-  const search = search_text.toLowerCase().replaceAll(/\s+/gu, ` `)
-  const target = target_text.toLowerCase().replaceAll(/\s/gu, ` `)
+  // whitespace runs collapse in the search; every whitespace character in the
+  // target maps to a plain space
+  let search = search_text.toLowerCase()
+  if (HAS_COLLAPSIBLE_WHITESPACE.test(search)) search = search.replaceAll(/\s+/gu, ` `)
+  let target = target_text.toLowerCase()
+  if (HAS_NON_PLAIN_WHITESPACE.test(target)) target = target.replaceAll(/\s/gu, ` `)
+
+  // Greedy leftmost subsequence match. indexOf scans natively and the cursor only
+  // moves forward, so the total scanned length stays linear in the target.
   const indices: number[] = []
-  let [search_idx, target_idx] = [0, 0]
-
-  while (search_idx < search.length && target_idx < target.length) {
-    if (search[search_idx] === target[target_idx]) {
-      indices.push(target_idx)
-      search_idx++
-    }
-    target_idx++
+  let pos = -1
+  // indexing by code unit, not for...of: iterating code points would match an
+  // astral character as one unit and emit one index where callers expect two
+  // oxlint-disable-next-line typescript/prefer-for-of
+  for (let search_idx = 0; search_idx < search.length; search_idx++) {
+    pos = target.indexOf(search[search_idx], pos + 1)
+    if (pos === -1) return null
+    indices.push(pos)
   }
-
-  return search_idx === search.length ? indices : null
+  return indices
 }
 
 // Fuzzy string matching function

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -114,23 +114,12 @@ export function parse_shortcut(shortcut: string): {
   return { key, ctrl, shift, alt, meta }
 }
 
-// Every registered shortcut is re-parsed on every keydown. Not cached inside
-// parse_shortcut: that is public API whose callers own (and may mutate) the result.
-const MAX_PARSED_SHORTCUTS = 1000
-const parsed_shortcuts = new Map<string, ReturnType<typeof parse_shortcut>>()
-
 export function matches_shortcut(
   event: KeyboardEvent,
   shortcut: string | null | undefined,
 ): boolean {
   if (!shortcut) return false
-  let parsed = parsed_shortcuts.get(shortcut)
-  if (!parsed) {
-    if (parsed_shortcuts.size >= MAX_PARSED_SHORTCUTS) parsed_shortcuts.clear()
-    parsed = parse_shortcut(shortcut)
-    parsed_shortcuts.set(shortcut, parsed)
-  }
-  const { key, ctrl, shift, alt, meta } = parsed
+  const { key, ctrl, shift, alt, meta } = parse_shortcut(shortcut)
   // Require non-empty key to prevent "ctrl+" from matching any key with ctrl pressed
   if (!key) return false
   return (
@@ -164,8 +153,7 @@ export function values_equal(val1: unknown, val2: unknown): boolean {
   return false
 }
 
-// Runs once per option on every keystroke and each replaceAll rebuilds the whole
-// string, so skip it for the common case of no tabs, newlines or repeated spaces.
+// replaceAll rebuilds the whole string, so skip it when there is nothing to normalize
 const HAS_COLLAPSIBLE_WHITESPACE = /\s\s|[^\S ]/u
 const HAS_NON_PLAIN_WHITESPACE = /[^\S ]/u
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -97,44 +97,42 @@ export function split_shortcut(shortcut: string): string[] {
   return parts
 }
 
-type ParsedShortcut = {
+// Parse shortcut string into modifier+key parts
+export function parse_shortcut(shortcut: string): {
   key: string
   ctrl: boolean
   shift: boolean
   alt: boolean
   meta: boolean
-}
-
-// matches_shortcut re-parses every registered shortcut on every keydown. Parsing
-// is pure and keyed by an immutable string, so memoize it - bounded so callers
-// generating shortcut strings dynamically can't grow the map without limit.
-const MAX_PARSED_SHORTCUTS = 1000
-const parsed_shortcuts = new Map<string, ParsedShortcut>()
-
-// Parse shortcut string into modifier+key parts
-export function parse_shortcut(shortcut: string): ParsedShortcut {
-  const cached = parsed_shortcuts.get(shortcut)
-  if (cached) return cached
-
+} {
   const parts = split_shortcut(shortcut)
   const key = parts.pop() ?? ``
   const ctrl = parts.includes(`ctrl`)
   const shift = parts.includes(`shift`)
   const alt = parts.includes(`alt`)
   const meta = parts.includes(`meta`) || parts.includes(`cmd`)
-  const parsed = { key, ctrl, shift, alt, meta }
-
-  if (parsed_shortcuts.size >= MAX_PARSED_SHORTCUTS) parsed_shortcuts.clear()
-  parsed_shortcuts.set(shortcut, parsed)
-  return parsed
+  return { key, ctrl, shift, alt, meta }
 }
+
+// Every registered shortcut is re-parsed on every keydown, so cache the parses.
+// Deliberately not inside parse_shortcut: that is public API whose callers own
+// the object they get back and may mutate it. Bounded so callers generating
+// shortcut strings dynamically can't grow the map without limit.
+const MAX_PARSED_SHORTCUTS = 1000
+const parsed_shortcuts = new Map<string, ReturnType<typeof parse_shortcut>>()
 
 export function matches_shortcut(
   event: KeyboardEvent,
   shortcut: string | null | undefined,
 ): boolean {
   if (!shortcut) return false
-  const { key, ctrl, shift, alt, meta } = parse_shortcut(shortcut)
+  let parsed = parsed_shortcuts.get(shortcut)
+  if (!parsed) {
+    if (parsed_shortcuts.size >= MAX_PARSED_SHORTCUTS) parsed_shortcuts.clear()
+    parsed = parse_shortcut(shortcut)
+    parsed_shortcuts.set(shortcut, parsed)
+  }
+  const { key, ctrl, shift, alt, meta } = parsed
   // Require non-empty key to prevent "ctrl+" from matching any key with ctrl pressed
   if (!key) return false
   return (

--- a/src/routes/(demos)/(basics)/events/+page.md
+++ b/src/routes/(demos)/(basics)/events/+page.md
@@ -195,19 +195,19 @@ This demo logs common selection, dropdown, search, activation, and native input 
 
 #### Custom Events
 
-| Event          | Description                                      | Data Structure                                                                                      |
-| -------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| `onadd`        | Fired when an option is added to selection       | `{ option: T, selected: T[] }`                                                                      |
-| `onremove`     | Fired when an option is removed from selection   | `{ option: T, selected: T[] }`                                                                      |
-| `onremoveAll`  | Fired when all options are removed               | `{ options: T[] }`                                                                                  |
-| `onchange`     | Fired for any selection change                   | `{ option?: T, options?: T[], type: 'add' \| 'remove' \| 'removeAll' \| 'selectAll' \| 'reorder' }` |
-| `oncreate`     | Fired when user creates a custom option          | `{ option: T }`                                                                                     |
-| `onopen`       | Fired when dropdown opens                        | `{ event: Event }`                                                                                  |
-| `onclose`      | Fired when dropdown closes                       | `{ event: Event }`                                                                                  |
-| `onsearch`     | Fired (debounced 150ms) when search text changes | `{ searchText: string, matchingOptions: T[] }`                                                      |
-| `onmaxreached` | Fired when user tries to exceed maxSelect        | `{ selected: T[], maxSelect: number, attemptedOption: T }`                                          |
-| `onduplicate`  | Fired when user tries to add duplicate           | `{ option: T }`                                                                                     |
-| `onactivate`   | Fired on keyboard navigation through options     | `{ option: T \| null, index: number \| null }`                                                      |
+| Event          | Description                                      | Data Structure                                                                                                       |
+| -------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `onadd`        | Fired when an option is added to selection       | `{ option: T, selected: T[] }`                                                                                       |
+| `onremove`     | Fired when an option is removed from selection   | `{ option: T, selected: T[] }`                                                                                       |
+| `onremoveAll`  | Fired when all options are removed               | `{ options: T[] }`                                                                                                   |
+| `onchange`     | Fired for any selection change                   | `{ option?: T, options?: T[], type: 'add' \| 'remove' \| 'removeAll' \| 'selectAll' \| 'rangeSelect' \| 'reorder' }` |
+| `oncreate`     | Fired when user creates a custom option          | `{ option: T }`                                                                                                      |
+| `onopen`       | Fired when dropdown opens                        | `{ event: Event }`                                                                                                   |
+| `onclose`      | Fired when dropdown closes                       | `{ event: Event }`                                                                                                   |
+| `onsearch`     | Fired (debounced 150ms) when search text changes | `{ searchText: string, matchingOptions: T[] }`                                                                       |
+| `onmaxreached` | Fired when user tries to exceed maxSelect        | `{ selected: T[], maxSelect: number, attemptedOption: T }`                                                           |
+| `onduplicate`  | Fired when user tries to add duplicate           | `{ option: T }`                                                                                                      |
+| `onactivate`   | Fired on keyboard navigation through options     | `{ option: T \| null, index: number \| null }`                                                                       |
 
 #### Native DOM Events
 

--- a/src/routes/(demos)/(components)/command-menu/+page.md
+++ b/src/routes/(demos)/(components)/command-menu/+page.md
@@ -6,7 +6,7 @@
 
 ## Navigation Command Menu
 
-`<MultiSelect />` can implement a navigation command menu in 70 lines of code (50 without styles).
+`<MultiSelect />` powers a full navigation command menu. Its source is shown at the bottom of this page.
 
 ```svelte example id="disabled-input-title"
 <script lang="ts">

--- a/src/routes/(demos)/(integration)/kit-form-actions/+page.md
+++ b/src/routes/(demos)/(integration)/kit-form-actions/+page.md
@@ -16,12 +16,14 @@ This example shows the SvelteKit form action way of handling MultiSelect fields 
 
   let { form }: { form: ActionData } = $props()
 
+  // the action prefixes the json error with the parse message, so key off the prefix
   let err_msg = $derived(
     {
-      json: 'The email field is required',
-      array: 'The email field is required',
+      missing: 'Please select at least one color',
+      json: 'Could not parse the submitted colors',
+      array: 'Expected a list of colors',
       boring: 'Boring answer!',
-    }[form?.error as string],
+    }[(form?.error as string)?.split(':')[0]],
   )
 </script>
 
@@ -90,27 +92,32 @@ This example shows the SvelteKit form action way of handling MultiSelect fields 
 The above code needs to be in a `+page.svelte` file with the following `+page.server.ts` file in the same directory next to it.
 
 ```ts
-import { invalid } from '@sveltejs/kit'
+import { fail } from '@sveltejs/kit'
+import type { Actions } from './$types'
 
 export const actions = {
   'validate-form': async ({ request }) => {
     const data = await request.formData()
     let colors = data.get(`colors`)
 
+    if (!colors || typeof colors !== `string`) {
+      return fail(400, { colors, error: `missing` })
+    }
+
     try {
       colors = JSON.parse(colors)
-    } catch (err) {
-      return invalid(400, { colors, error: `json` })
+    } catch (error) {
+      return fail(400, { colors, error: `json: ${String(error)}` })
     }
 
     if (!Array.isArray(colors)) {
-      return invalid(400, { colors, error: `array` })
+      return fail(400, { colors, error: `array` })
     }
     if (colors.length === 1 && colors[0] === `Red`) {
-      return invalid(400, { colors, error: `boring` })
+      return fail(400, { colors, error: `boring` })
     }
 
     return { colors, success: true }
   },
-}
+} satisfies Actions
 ```

--- a/src/routes/(demos)/(selection)/history/+page.md
+++ b/src/routes/(demos)/(selection)/history/+page.md
@@ -1,10 +1,8 @@
 ## Selection History (Undo/Redo)
 
-Selection history is **enabled by default**, allowing users to undo and redo their selections with `Ctrl+Z` / `Cmd+Z` and `Ctrl+Shift+Z` / `Cmd+Shift+Z`. This is useful for complex selection workflows where users might want to revert changes.
+Selection history is **enabled by default** with a max of 50 entries, letting users undo and redo selections with `Ctrl+Z` / `Cmd+Z` and `Ctrl+Shift+Z` / `Cmd+Shift+Z` (platform-aware). Pass a number to customize the limit, or `false`/`0` to disable.
 
 ### Basic Usage
-
-History tracking works out of the box with a default max of 50 entries. Pass a number to customize the limit, or `false`/`0` to disable.
 
 ```svelte example
 <script lang="ts">
@@ -206,12 +204,7 @@ History tracking works out of the box with a default max of 50 entries. Pass a n
 
 ### Keyboard Shortcuts
 
-History supports platform-aware keyboard shortcuts:
-
-- **Mac**: `Cmd+Z` (undo), `Cmd+Shift+Z` (redo)
-- **Windows/Linux**: `Ctrl+Z` (undo), `Ctrl+Shift+Z` (redo)
-
-Custom shortcuts can be configured via the `shortcuts` prop:
+Override the defaults via the `shortcuts` prop:
 
 ```svelte
 <MultiSelect history={true} shortcuts={{ undo: 'alt+z', redo: 'alt+shift+z' }} />

--- a/src/routes/(demos)/(styling)/ui/+page.md
+++ b/src/routes/(demos)/(styling)/ui/+page.md
@@ -45,24 +45,7 @@
 />
 ```
 
-This page is used for Playwright testing to ensure
-
-- the remove-all button
-  - removes all currently selected options from the input
-  - only appears if 2 or more elements are selected
-  - has custom title (if supplied via prop `removeAllTitle`)
-- the component can be focused
-  - which opens dropdown
-  - closes the dropdown when focus leaves the component via Tab or a click/tap outside
-  - does not close the dropdown when the input alone loses focus within the component
-- filters options to only list matches when entering text
-- accessibility
-  - input is `aria-invalid` when the component has `invalid=true`
-  - has `aria-expanded='false'` when closed
-  - has `aria-expanded='true'` when open
-  - options have `aria-selected='false'` and selected items have `aria-selected='true'`
-  - invisible `input.form-control` is `aria-hidden`
-- `closeDropdownOnSelect`: when `true`, the input is not focused when an option is selected and the dropdown is closed
+This page is the fixture for the Playwright UI tests in `tests/playwright/MultiSelect.test.ts`, which cover the remove-all button, focus and dropdown open/close behavior, filtering, and the ARIA attributes.
 
 <!-- Smooth scroll is required for arrow key navigation tests to work correctly.
 The Playwright test 'loops through the dropdown list with arrow keys' depends on this. -->

--- a/src/site/Examples.md
+++ b/src/site/Examples.md
@@ -254,8 +254,8 @@ value = {JSON.stringify(value) || `null`}
 />
 
 <label>
-  maxOptions <input type="range" min="0" max={30} bind:value={maxOptions} />
-  {maxOptions} <small>(0 means no limit)</small>
+  maxOptions <input type="range" min="1" max={30} bind:value={maxOptions} />
+  {maxOptions} <small>(leave undefined for no limit)</small>
 </label>
 ```
 

--- a/svelte.config.ts
+++ b/svelte.config.ts
@@ -27,12 +27,6 @@ const remarkPlugins = [
 const config: Config = {
   extensions: [`.svelte`, `.md`],
 
-  compilerOptions: {
-    // TODO: Remove after bumping past the Svelte 5.48-5.56 regression that emits
-    // state_referenced_locally for valid local bindings.
-    warningFilter: (warning) => warning.code !== `state_referenced_locally`,
-  },
-
   preprocess: [
     mdsvex({
       remarkPlugins,

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -1310,12 +1310,14 @@ test(`global shortcuts ignore events consumed by editable controls`, () => {
   expect(action).not.toHaveBeenCalled()
 })
 
-// Neither may run nor steal the keystroke. Shift counts as typing, not as a chord.
+// Shift counts as typing, not as a chord, so neither may run nor steal the keystroke
+// inside an editable target. The non-editable control keeps the guard honest: without
+// it, suppressing these shortcuts everywhere would still pass.
 test.each([
   [`a bare key`, `n`, {}],
   [`shift only`, `shift+n`, { shiftKey: true }],
 ])(
-  `global shortcut with %s does not fire while typing`,
+  `global shortcut with %s fires only outside editable targets`,
   (_label, shortcut, modifiers) => {
     const action = vi.fn()
     mount(CommandMenu, {
@@ -1323,18 +1325,25 @@ test.each([
       props: { actions: [{ label: `new note`, action, shortcut }], fade_duration: 0 },
     })
     const textarea = document.createElement(`textarea`)
-    document.body.append(textarea)
+    const plain_div = document.createElement(`div`)
+    document.body.append(textarea, plain_div)
 
-    const event = new KeyboardEvent(`keydown`, {
-      key: `n`,
-      ...modifiers,
-      bubbles: true,
-      cancelable: true,
-    })
-    textarea.dispatchEvent(event)
+    const press = (target: HTMLElement) => {
+      const event = new KeyboardEvent(`keydown`, {
+        key: `n`,
+        ...modifiers,
+        bubbles: true,
+        cancelable: true,
+      })
+      target.dispatchEvent(event)
+      return event
+    }
 
+    expect(press(textarea).defaultPrevented).toBe(false)
     expect(action).not.toHaveBeenCalled()
-    expect(event.defaultPrevented).toBe(false)
+
+    expect(press(plain_div).defaultPrevented).toBe(true)
+    expect(action).toHaveBeenCalledExactlyOnceWith(`new note`)
   },
 )
 

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -1311,38 +1311,33 @@ test(`global shortcuts ignore events consumed by editable controls`, () => {
 })
 
 // Shift counts as typing, not as a chord, so neither may run nor steal the keystroke
-// inside an editable target. The non-editable control keeps the guard honest: without
-// it, suppressing these shortcuts everywhere would still pass.
-test.each([
-  [`a bare key`, `n`, {}],
-  [`shift only`, `shift+n`, { shiftKey: true }],
-])(
-  `global shortcut with %s fires only outside editable targets`,
-  (_label, shortcut, modifiers) => {
+// inside an editable target. The plain div keeps the guard honest: without it,
+// suppressing these shortcuts everywhere would still pass.
+test.each([`n`, `shift+n`])(
+  `global shortcut %s fires only outside editable targets`,
+  (shortcut) => {
     const action = vi.fn()
     mount(CommandMenu, {
       target: document.body,
       props: { actions: [{ label: `new note`, action, shortcut }], fade_duration: 0 },
     })
-    const textarea = document.createElement(`textarea`)
-    const plain_div = document.createElement(`div`)
-    document.body.append(textarea, plain_div)
-
-    const press = (target: HTMLElement) => {
+    const press = (tag: string) => {
+      const target = document.createElement(tag)
+      document.body.append(target)
       const event = new KeyboardEvent(`keydown`, {
         key: `n`,
-        ...modifiers,
+        shiftKey: shortcut.startsWith(`shift`),
         bubbles: true,
         cancelable: true,
       })
       target.dispatchEvent(event)
-      return event
+      return event.defaultPrevented
     }
 
-    expect(press(textarea).defaultPrevented).toBe(false)
+    expect(press(`textarea`)).toBe(false)
     expect(action).not.toHaveBeenCalled()
 
-    expect(press(plain_div).defaultPrevented).toBe(true)
+    expect(press(`div`)).toBe(true)
     expect(action).toHaveBeenCalledExactlyOnceWith(`new note`)
   },
 )

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -1320,53 +1320,34 @@ test(`global shortcuts ignore events consumed by editable controls`, () => {
   expect(action).not.toHaveBeenCalled()
 })
 
-test(`modifier-free global shortcut does not fire while typing in a text field`, () => {
-  // a bare "n" hotkey must not steal the keystroke (nor run) when the user is typing
-  const action = vi.fn()
-  mount(CommandMenu, {
-    target: document.body,
-    props: { actions: [{ label: `new note`, action, shortcut: `n` }], fade_duration: 0 },
-  })
-  const textarea = document.createElement(`textarea`)
-  document.body.append(textarea)
+// Neither may steal the keystroke (nor run) mid-sentence. Shift counts as typing:
+// it is how a capital letter is entered, unlike a Ctrl/Meta/Alt chord.
+test.each([
+  [`a bare key`, `n`, {}],
+  [`shift only`, `shift+n`, { shiftKey: true }],
+])(
+  `global shortcut with %s does not fire while typing`,
+  (_label, shortcut, modifiers) => {
+    const action = vi.fn()
+    mount(CommandMenu, {
+      target: document.body,
+      props: { actions: [{ label: `new note`, action, shortcut }], fade_duration: 0 },
+    })
+    const textarea = document.createElement(`textarea`)
+    document.body.append(textarea)
 
-  const event = new KeyboardEvent(`keydown`, {
-    key: `n`,
-    bubbles: true,
-    cancelable: true,
-  })
-  textarea.dispatchEvent(event)
+    const event = new KeyboardEvent(`keydown`, {
+      key: `n`,
+      ...modifiers,
+      bubbles: true,
+      cancelable: true,
+    })
+    textarea.dispatchEvent(event)
 
-  expect(action).not.toHaveBeenCalled()
-  expect(event.defaultPrevented).toBe(false)
-})
-
-test(`shift-only global shortcut does not fire while typing in a text field`, () => {
-  // Shift is how you type a capital letter, so a shift+<key> hotkey is still an
-  // ordinary keystroke in a text field and must not be treated as a modifier that
-  // opts the event out of the editable-target guard
-  const action = vi.fn()
-  mount(CommandMenu, {
-    target: document.body,
-    props: {
-      actions: [{ label: `new note`, action, shortcut: `shift+n` }],
-      fade_duration: 0,
-    },
-  })
-  const textarea = document.createElement(`textarea`)
-  document.body.append(textarea)
-
-  const event = new KeyboardEvent(`keydown`, {
-    key: `n`,
-    shiftKey: true,
-    bubbles: true,
-    cancelable: true,
-  })
-  textarea.dispatchEvent(event)
-
-  expect(action).not.toHaveBeenCalled()
-  expect(event.defaultPrevented).toBe(false)
-})
+    expect(action).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  },
+)
 
 test(`global shortcuts skip disabled duplicate bindings`, async () => {
   const disabled_action = vi.fn()

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -1320,8 +1320,7 @@ test(`global shortcuts ignore events consumed by editable controls`, () => {
   expect(action).not.toHaveBeenCalled()
 })
 
-// Neither may steal the keystroke (nor run) mid-sentence. Shift counts as typing:
-// it is how a capital letter is entered, unlike a Ctrl/Meta/Alt chord.
+// Neither may run nor steal the keystroke. Shift counts as typing, not as a chord.
 test.each([
   [`a bare key`, `n`, {}],
   [`shift only`, `shift+n`, { shiftKey: true }],

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -9,6 +9,17 @@ const mock_actions = [
   { label: `action 3`, action: vi.fn() },
 ]
 
+const menu_input = () => doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
+
+// type into the menu's search input: set value, fire input event, flush a tick
+async function type_search(text: string): Promise<HTMLInputElement> {
+  const input = menu_input()
+  input.value = text
+  input.dispatchEvent(new Event(`input`, { bubbles: true }))
+  await tick()
+  return input
+}
+
 // tests that exercise the non-modal fallback assign showModal directly rather than
 // spying, so vi.restoreAllMocks() in the global setup can't undo it
 const original_show_modal = Object.getOwnPropertyDescriptor(
@@ -19,6 +30,9 @@ afterEach(() => {
   if (original_show_modal) {
     Object.defineProperty(HTMLDialogElement.prototype, `showModal`, original_show_modal)
   } else Reflect.deleteProperty(HTMLDialogElement.prototype, `showModal`)
+  // recents tests write to localStorage; clear here so a failing test can't leak
+  // stored recents into the next one
+  localStorage.clear()
 })
 
 test.each([
@@ -88,7 +102,7 @@ test.each([
     )
 
     if (should_open) {
-      expect(document.activeElement).toBe(doc_query(`dialog input[autocomplete]`))
+      expect(document.activeElement).toBe(menu_input())
     }
   },
 )
@@ -145,7 +159,7 @@ test.each([`Escape`, `x`])(
       bubbles: true,
       cancelable: true,
     })
-    doc_query<HTMLInputElement>(`dialog input[autocomplete]`).dispatchEvent(event)
+    menu_input().dispatchEvent(event)
     await tick()
 
     expect(props.open).toBe(false)
@@ -181,42 +195,34 @@ test.each([
   },
 )
 
-test(`opens a labelled modal dialog`, async () => {
-  const show_modal = vi.fn(function showModal(this: HTMLDialogElement) {
-    this.setAttribute(`open`, ``)
-  })
-  HTMLDialogElement.prototype.showModal = show_modal
-  const props = {
-    actions: mock_actions,
-    aria_label: `Run command`,
-    open: true,
-    fade_duration: 0,
-  }
-
-  mount(CommandMenu, { target: document.body, props })
-  await tick()
-
-  const dialog = doc_query<HTMLDialogElement>(`dialog`)
-  expect(dialog.getAttribute(`aria-label`)).toBe(`Run command`)
-  expect(show_modal).toHaveBeenCalledTimes(1)
-})
-
-test.each([`throws`, `unavailable`] as const)(
-  `falls back to open attribute when showModal is %s`,
+// showModal is preferred, but a throwing or missing implementation must still end up
+// with an open, labelled dialog via the plain `open` attribute fallback
+test.each([`available`, `throws`, `unavailable`] as const)(
+  `opens a labelled dialog when showModal is %s`,
   async (show_modal_state) => {
-    if (show_modal_state === `throws`) {
-      HTMLDialogElement.prototype.showModal = vi.fn(() => {
-        throw new Error(`showModal failed`)
-      })
-    } else Reflect.deleteProperty(HTMLDialogElement.prototype, `showModal`)
+    const show_modal = vi.fn(function showModal(this: HTMLDialogElement) {
+      if (show_modal_state === `throws`) throw new Error(`showModal failed`)
+      this.setAttribute(`open`, ``)
+    })
+    if (show_modal_state === `unavailable`) {
+      Reflect.deleteProperty(HTMLDialogElement.prototype, `showModal`)
+    } else HTMLDialogElement.prototype.showModal = show_modal
 
     mount(CommandMenu, {
       target: document.body,
-      props: { actions: mock_actions, open: true, fade_duration: 0 },
+      props: {
+        actions: mock_actions,
+        aria_label: `Run command`,
+        open: true,
+        fade_duration: 0,
+      },
     })
     await tick()
 
-    expect(doc_query<HTMLDialogElement>(`dialog`).hasAttribute(`open`)).toBe(true)
+    const dialog = doc_query<HTMLDialogElement>(`dialog`)
+    expect(dialog.getAttribute(`aria-label`)).toBe(`Run command`)
+    expect(dialog.hasAttribute(`open`)).toBe(true)
+    expect(show_modal).toHaveBeenCalledTimes(show_modal_state === `unavailable` ? 0 : 1)
   },
 )
 
@@ -237,7 +243,7 @@ test(`handles action selection and execution`, async () => {
   mount(CommandMenu, { target: document.body, props })
   await tick()
 
-  const input_el = doc_query(`dialog div.multiselect input[autocomplete]`)
+  const input_el = menu_input()
 
   // Navigate to second action and select it
   input_el.dispatchEvent(
@@ -267,14 +273,9 @@ test(`ignores user-created options without action handlers`, async () => {
   mount(CommandMenu, { target: document.body, props })
   await tick()
 
-  const input_el = doc_query<HTMLInputElement>(
-    `dialog div.multiselect input[autocomplete]`,
-  )
-  input_el.value = `custom command`
-  input_el.dispatchEvent(new Event(`input`, { bubbles: true }))
-  await tick()
+  await type_search(`custom command`)
 
-  expect(() => doc_query<HTMLLIElement>(`dialog li.user-msg`).click()).not.toThrow()
+  doc_query<HTMLLIElement>(`dialog li.user-msg`).click()
   await tick()
 
   expect(action).not.toHaveBeenCalled()
@@ -326,9 +327,7 @@ test(`keeps dialog open when clicking inside the menu`, async () => {
   mount(CommandMenu, { target: document.body, props })
   await tick()
 
-  doc_query(`dialog div.multiselect input[autocomplete]`).dispatchEvent(
-    new MouseEvent(`click`, { bubbles: true }),
-  )
+  menu_input().dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
   await tick()
 
   expect(props.open).toBe(true)
@@ -360,7 +359,7 @@ test(`keeps dialog open when clicking a nested portalled option`, async () => {
   mount(CommandMenu, { target: document.body, props })
   await tick()
 
-  const input = doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
+  const input = menu_input()
   const real_listbox_id = input.getAttribute(`aria-controls`)
   if (!real_listbox_id) throw new Error(`Menu input has no aria-controls listbox id`)
   const listbox_id = `${real_listbox_id}-portalled`
@@ -420,7 +419,7 @@ test(`applies custom styles and props correctly`, async () => {
   const select_wrapper = doc_query(`dialog div.multiselect`)
   expect(select_wrapper.classList.contains(custom_class)).toBe(true)
 
-  const input = doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
+  const input = menu_input()
   expect(input.placeholder).toBe(custom_placeholder)
 
   const dialog = doc_query<HTMLDialogElement>(`dialog`)
@@ -539,10 +538,7 @@ test.each([
     props: { open: true, actions, fuzzy, fade_duration: 0 },
   })
 
-  const input = doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
-  input.value = search
-  input.dispatchEvent(new Event(`input`, { bubbles: true }))
-  await tick()
+  await type_search(search)
 
   const visible_options = document.querySelectorAll(`dialog ul.options li:not(.hidden)`)
   expect(visible_options).toHaveLength(expected.length)
@@ -570,9 +566,7 @@ test(`handles bindable props correctly`, async () => {
 
   expect(props.dialog).toBeInstanceOf(HTMLDialogElement)
   expect(props.input).toBeInstanceOf(HTMLInputElement)
-  expect(doc_query(`dialog input[autocomplete]`).getAttribute(`aria-label`)).toBe(
-    `Search commands`,
-  )
+  expect(menu_input().getAttribute(`aria-label`)).toBe(`Search commands`)
   expect(document.activeElement).toBe(props.input)
 })
 
@@ -592,7 +586,6 @@ test(`selects the first enabled action and preserves pointer selection across gr
   mount(CommandMenu, { target: document.body, props })
   await tick()
 
-  const input = doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
   expect(doc_query(`li.active`).textContent).toContain(`Alpha`)
 
   const beta_option = [...document.querySelectorAll(`li[role=option]`)].find((option) =>
@@ -615,9 +608,7 @@ test(`selects the first enabled action and preserves pointer selection across gr
   expect(props.activeIndex).toBe(1)
   expect(doc_query(`li.active`).textContent).toContain(`Alpha`)
 
-  input.value = `alpha`
-  input.dispatchEvent(new Event(`input`, { bubbles: true }))
-  await tick()
+  await type_search(`alpha`)
   expect(doc_query(`li.active`).textContent).toContain(`Alpha`)
 })
 
@@ -692,7 +683,7 @@ test(`preserves duplicate action identity across independent key changes`, async
   await tick()
   expect(props.activeIndex).toBe(2)
 
-  doc_query<HTMLInputElement>(`dialog input[autocomplete]`).dispatchEvent(
+  menu_input().dispatchEvent(
     new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }),
   )
   expect(rebuilt_action).toHaveBeenCalledExactlyOnceWith(`Renamed duplicate`)
@@ -746,7 +737,7 @@ test(`preserves the active action by its unique ID amid rebuilt duplicates`, asy
 
   expect(props.activeIndex).toBe(2)
   expect(doc_query(`li.active`)).toBe(active_option)
-  doc_query<HTMLInputElement>(`dialog input[autocomplete]`).dispatchEvent(
+  menu_input().dispatchEvent(
     new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }),
   )
   expect(beta_action).toHaveBeenCalledExactlyOnceWith(`Rebuilt Beta`)
@@ -814,7 +805,6 @@ test(`renders and searches action descriptions, metadata, badges, and keywords`,
   })
   await tick()
 
-  expect(shortcut_kbd_parts()).toEqual([`Ctrl`, `⇧`, `S`])
   expect(doc_query(`.cmd-description`).textContent).toBe(`Write buffer to disk`)
   expect(doc_query(`.cmd-metadata`).textContent).toBe(`Workspace · Modified`)
   expect(doc_query(`.cmd-badge`).textContent).toBe(`File`)
@@ -824,18 +814,13 @@ test(`renders and searches action descriptions, metadata, badges, and keywords`,
   )
   expect(quit_li?.querySelector(`kbd`)).toBeNull()
 
-  const input = doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
-  input.value = `workspace persist`
-  input.dispatchEvent(new Event(`input`, { bubbles: true }))
-  await tick()
+  await type_search(`workspace persist`)
   expect(option_labels()).toHaveLength(1)
   expect(option_labels()[0]).toContain(`save file`)
 })
 
 async function search_pagefind(query: string): Promise<void> {
-  const input = doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
-  input.value = query
-  input.dispatchEvent(new Event(`input`, { bubbles: true }))
+  await type_search(query)
   await vi.runAllTimersAsync()
   await tick()
 }
@@ -1208,18 +1193,23 @@ describe(`PageSearch`, () => {
   })
 })
 
-test(`renders plus-key shortcut hints`, async () => {
+test.each([
+  [`ctrl+shift+s`, [`Ctrl`, `⇧`, `S`]],
+  [`meta+enter`, [`⌘`, `↵`]],
+  [`ctrl++`, [`Ctrl`, `+`]], // '+' is both the separator and the key
+  [`ctrl+tab`, [`Ctrl`, `Tab`]], // segment without a symbol is title-cased
+])(`renders shortcut %s as %j`, async (shortcut, expected_parts) => {
   mount(CommandMenu, {
     target: document.body,
     props: {
       open: true,
       fade_duration: 0,
-      actions: [{ label: `zoom in`, action: vi.fn(), shortcut: `ctrl++` }],
+      actions: [{ label: `zoom in`, action: vi.fn(), shortcut }],
     },
   })
   await tick()
 
-  expect(shortcut_kbd_parts()).toEqual([`Ctrl`, `+`])
+  expect(shortcut_kbd_parts()).toEqual(expected_parts)
 })
 
 test(`plain actions without shortcut/description use default option rendering`, async () => {
@@ -1392,7 +1382,7 @@ test(`recent_actions_key ranks recently triggered actions first and persists the
   expect(option_labels()).toEqual([`alpha`, `beta`, `gamma`])
 
   // trigger gamma via keyboard (ArrowDown x2 + Enter)
-  const input_el = doc_query(`dialog div.multiselect input[autocomplete]`)
+  const input_el = menu_input()
   for (let idx = 0; idx < 2; idx++) {
     input_el.dispatchEvent(
       new KeyboardEvent(`keydown`, { key: `ArrowDown`, bubbles: true }),
@@ -1409,7 +1399,6 @@ test(`recent_actions_key ranks recently triggered actions first and persists the
   props.open = true
   await tick()
   expect(option_labels()).toEqual([`gamma`, `alpha`, `beta`])
-  localStorage.removeItem(storage_key)
 })
 
 test(`recent_actions_key uses action ids for duplicate labels`, async () => {
@@ -1432,7 +1421,6 @@ test(`recent_actions_key uses action ids for duplicate labels`, async () => {
 
   expect(actions[0].action).toHaveBeenCalledExactlyOnceWith(`save`)
   expect(JSON.parse(localStorage.getItem(storage_key) ?? `[]`)).toEqual([`mixed`])
-  localStorage.removeItem(storage_key)
 })
 
 // pre-existing recents-storage contents -> dropdown order on initial open
@@ -1495,7 +1483,6 @@ test.each([
     await tick()
 
     expect(option_labels()).toEqual(expected_order)
-    localStorage.removeItem(storage_key)
   },
 )
 
@@ -1542,6 +1529,5 @@ test.each([
     await tick()
 
     expect(JSON.parse(localStorage.getItem(storage_key) ?? `[]`)).toEqual(expected)
-    localStorage.removeItem(storage_key)
   },
 )

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -1341,6 +1341,33 @@ test(`modifier-free global shortcut does not fire while typing in a text field`,
   expect(event.defaultPrevented).toBe(false)
 })
 
+test(`shift-only global shortcut does not fire while typing in a text field`, () => {
+  // Shift is how you type a capital letter, so a shift+<key> hotkey is still an
+  // ordinary keystroke in a text field and must not be treated as a modifier that
+  // opts the event out of the editable-target guard
+  const action = vi.fn()
+  mount(CommandMenu, {
+    target: document.body,
+    props: {
+      actions: [{ label: `new note`, action, shortcut: `shift+n` }],
+      fade_duration: 0,
+    },
+  })
+  const textarea = document.createElement(`textarea`)
+  document.body.append(textarea)
+
+  const event = new KeyboardEvent(`keydown`, {
+    key: `n`,
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true,
+  })
+  textarea.dispatchEvent(event)
+
+  expect(action).not.toHaveBeenCalled()
+  expect(event.defaultPrevented).toBe(false)
+})
+
 test(`global shortcuts skip disabled duplicate bindings`, async () => {
   const disabled_action = vi.fn()
   const enabled_action = vi.fn()

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -1320,6 +1320,27 @@ test(`global shortcuts ignore events consumed by editable controls`, () => {
   expect(action).not.toHaveBeenCalled()
 })
 
+test(`modifier-free global shortcut does not fire while typing in a text field`, () => {
+  // a bare "n" hotkey must not steal the keystroke (nor run) when the user is typing
+  const action = vi.fn()
+  mount(CommandMenu, {
+    target: document.body,
+    props: { actions: [{ label: `new note`, action, shortcut: `n` }], fade_duration: 0 },
+  })
+  const textarea = document.createElement(`textarea`)
+  document.body.append(textarea)
+
+  const event = new KeyboardEvent(`keydown`, {
+    key: `n`,
+    bubbles: true,
+    cancelable: true,
+  })
+  textarea.dispatchEvent(event)
+
+  expect(action).not.toHaveBeenCalled()
+  expect(event.defaultPrevented).toBe(false)
+})
+
 test(`global shortcuts skip disabled duplicate bindings`, async () => {
   const disabled_action = vi.fn()
   const enabled_action = vi.fn()

--- a/tests/vitest/CopyButton.test.ts
+++ b/tests/vitest/CopyButton.test.ts
@@ -162,6 +162,26 @@ test(`calls on_copy_success with copied content`, async () => {
   expect(onclick).toHaveBeenCalledOnce()
 })
 
+test(`a throwing on_copy_success is not reported as a copy failure`, async () => {
+  // the clipboard write already succeeded, so the callback's error must not be
+  // caught by the write's catch and flipped into the error state
+  const on_copy_error = vi.fn()
+  const on_copy_success = vi.fn(() => {
+    throw new Error(`analytics hook blew up`)
+  })
+  const console_error_spy = vi.spyOn(console, `error`).mockImplementation(() => void 0)
+  const { copy_button } = mount_copy_button({
+    content: `hello`,
+    on_copy_success,
+    on_copy_error,
+  })
+  await click_copy_button(copy_button)
+  expect(on_copy_error).not.toHaveBeenCalled()
+  expect(copy_button.textContent).toContain(`success`)
+  expect(console_error_spy).toHaveBeenCalledOnce()
+  console_error_spy.mockRestore()
+})
+
 test(`calls on_copy_error with error and content`, async () => {
   const copy_error = new Error(`clipboard failed`)
   const on_copy_error = vi.fn()

--- a/tests/vitest/CopyButton.test.ts
+++ b/tests/vitest/CopyButton.test.ts
@@ -163,8 +163,7 @@ test(`calls on_copy_success with copied content`, async () => {
 })
 
 test(`a throwing on_copy_success is not reported as a copy failure`, async () => {
-  // the clipboard write already succeeded, so the callback's error must not be
-  // caught by the write's catch and flipped into the error state
+  // the write already succeeded, so its catch must not flip this into the error state
   const on_copy_error = vi.fn()
   const on_copy_success = vi.fn(() => {
     throw new Error(`analytics hook blew up`)

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -2430,6 +2430,28 @@ describe(`arrow key navigation between selected items`, () => {
     expect(selected_items()[1]?.textContent).toContain(`Blue`)
   })
 
+  test(`chip remove button removes the clicked occurrence with duplicates`, async () => {
+    // both chips share a key, so remove() must use the chip's index instead of findIndex
+    const [first, second] = [
+      { label: `Red`, tag: 1 },
+      { label: `Red`, tag: 2 },
+    ]
+    let removed: unknown
+    mount(MultiSelect, {
+      target: document.body,
+      props: {
+        options: [first, second],
+        selected: [first, second],
+        duplicates: true,
+        onremove: ({ option }: { option: unknown }) => (removed = option),
+      },
+    })
+    document.querySelectorAll<HTMLElement>(`ul.selected li button.remove`)[1]?.click()
+    await tick()
+    // toStrictEqual not toBe: Svelte hands the callback a $state proxy of the option
+    expect(removed).toStrictEqual(second)
+  })
+
   test(`re-focusing input clears highlight`, async () => {
     const input = setup()
     input.dispatchEvent(press(`ArrowLeft`))
@@ -2522,6 +2544,16 @@ test(`remove all button does not remove items when minSelect constraint would be
 
   // The first item should still be selected since minSelect=1
   expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`Red`)
+})
+
+test(`remove all button is hidden when selected.length equals minSelect`, async () => {
+  // above, selected.length <= 1 hides the button on its own, so minSelect is never
+  // the reason - here removal is blocked yet the button would still render
+  mount(MultiSelect, {
+    target: document.body,
+    props: { options: [`Red`, `Green`], selected: [`Red`, `Green`], minSelect: 2 },
+  })
+  expect(document.querySelector(`button.remove-all`)).toBeNull()
 })
 
 class DataTransfer {
@@ -3270,6 +3302,26 @@ test.each([
   await type_search_text(is_dupe_test ? `foo` : `nonexistent`, input)
 
   expect(document.querySelector(`.user-msg`)).toBeNull()
+})
+
+test(`empty duplicateOptionMsg leaves no phantom navigable row`, async () => {
+  // a blank message renders nothing, so it must not stay navigable either - else
+  // ArrowDown past the last option points aria-activedescendant at a missing element
+  mount(MultiSelect, {
+    target: document.body,
+    props: { options: [`ab`, `abc`], selected: [`ab`], duplicateOptionMsg: `` },
+  })
+  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  await type_search_text(`ab`, input)
+  input.dispatchEvent(fresh_key(`ArrowDown`))
+  input.dispatchEvent(fresh_key(`ArrowDown`))
+  await tick()
+  // 'abc' at index 0 is the only match, so the second ArrowDown has nowhere to go.
+  // Without the fix it would advance onto the blank duplicate row and leave
+  // aria-activedescendant pointing at an element that was never rendered.
+  const active_id = input.getAttribute(`aria-activedescendant`) ?? ``
+  expect(active_id).toMatch(/-opt-0$/u)
+  expect(document.querySelector(`#${CSS.escape(active_id)}`)).not.toBeNull()
 })
 
 test.each([[0], [1], [5], [undefined]])(

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -2547,8 +2547,7 @@ test(`remove all button does not remove items when minSelect constraint would be
 })
 
 test(`remove all button is hidden when selected.length equals minSelect`, async () => {
-  // above, selected.length <= 1 hides the button on its own, so minSelect is never
-  // the reason - here removal is blocked yet the button would still render
+  // above, selected.length <= 1 hides the button anyway; here minSelect is the reason
   mount(MultiSelect, {
     target: document.body,
     props: { options: [`Red`, `Green`], selected: [`Red`, `Green`], minSelect: 2 },
@@ -3305,8 +3304,7 @@ test.each([
 })
 
 test(`empty duplicateOptionMsg leaves no phantom navigable row`, async () => {
-  // a blank message renders nothing, so it must not stay navigable either - else
-  // ArrowDown past the last option points aria-activedescendant at a missing element
+  // a blank message renders nothing, so it must not stay navigable either
   mount(MultiSelect, {
     target: document.body,
     props: { options: [`ab`, `abc`], selected: [`ab`], duplicateOptionMsg: `` },
@@ -3316,9 +3314,8 @@ test(`empty duplicateOptionMsg leaves no phantom navigable row`, async () => {
   input.dispatchEvent(fresh_key(`ArrowDown`))
   input.dispatchEvent(fresh_key(`ArrowDown`))
   await tick()
-  // 'abc' at index 0 is the only match, so the second ArrowDown has nowhere to go.
-  // Without the fix it would advance onto the blank duplicate row and leave
-  // aria-activedescendant pointing at an element that was never rendered.
+  // 'abc' at index 0 is the only match, so the second ArrowDown has nowhere to go;
+  // without the fix it lands on the blank row and points at an unrendered element
   const active_id = input.getAttribute(`aria-activedescendant`) ?? ``
   expect(active_id).toMatch(/-opt-0$/u)
   expect(document.querySelector(`#${CSS.escape(active_id)}`)).not.toBeNull()

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -13,7 +13,6 @@ import Test2WayBind from './Test2WayBind.svelte'
 import TestMultiSelectSnippets from './TestMultiSelectSnippets.svelte'
 
 const mouseover = new MouseEvent(`mouseover`, { bubbles: true })
-const input_event = new InputEvent(`input`, { bubbles: true })
 // fresh event per dispatch: happy-dom never resets the stop-propagation flag,
 // so shared event instances go inert once a handler calls stopPropagation()
 const fresh_key = (key: string) => new KeyboardEvent(`keydown`, { key, bubbles: true })
@@ -27,9 +26,12 @@ async function open_multiselect_via_mouseup(): Promise<void> {
   await tick()
 }
 
+// the visible search input; the hidden form-control input carries no autocomplete attr
+const get_input = () => doc_query<HTMLInputElement>(`input[autocomplete]`)
+
 // focus the search input (opens the dropdown) and flush a tick
 async function focus_input(): Promise<HTMLInputElement> {
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   input.focus()
   await tick()
   return input
@@ -38,7 +40,7 @@ async function focus_input(): Promise<HTMLInputElement> {
 // type text into the search input: set value, fire input event, flush a tick
 async function type_search_text(
   search_text: string,
-  input = doc_query<HTMLInputElement>(`input[autocomplete]`),
+  input = get_input(),
 ): Promise<HTMLInputElement> {
   input.value = search_text
   input.dispatchEvent(new InputEvent(`input`, { bubbles: true }))
@@ -162,7 +164,7 @@ test(`applies DOM attributes to input node`, () => {
   })
 
   const lis = document.querySelectorAll(`ul.options > li`)
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   const form_input = doc_query<HTMLInputElement>(`input.form-control`)
 
   // make sure the search text filtered the dropdown options
@@ -190,7 +192,7 @@ test.each([
       props: { options: [1, 2, 3], placeholder },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     expect(input.placeholder).toBe(`Pick a number`)
 
     doc_query(`ul.options li`).click()
@@ -240,7 +242,7 @@ test(`arrow down makes first option active`, async () => {
     props: { options: [1, 2, 3], open: true },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
 
   input.dispatchEvent(fresh_key(`ArrowDown`))
 
@@ -263,7 +265,7 @@ test(`can select 1st and last option with arrow and enter key`, async () => {
     },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
 
   input.dispatchEvent(fresh_key(`ArrowDown`))
   await tick()
@@ -300,7 +302,7 @@ describe(`bubbles <input> node DOM events`, () => {
       },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
 
     if (name === `focus`) {
       input.focus() // This should trigger the spy
@@ -466,7 +468,7 @@ describe(`selectedDisplay=input`, () => {
       doc_query(`ul.options > li`).click()
       await tick()
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       expect(input.value).toBe(expected)
       expect(select.searchText).toBe(expected)
       expect(select.value).toEqual(expected_value)
@@ -480,7 +482,7 @@ describe(`selectedDisplay=input`, () => {
     const select = mount_input_display({ options: [`Red`, `Green`], selected: [`Red`] })
     await tick()
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     expect(input.value).toBe(`Red`)
 
     await type_search_text(`Reddish`, input)
@@ -511,7 +513,7 @@ describe(`selectedDisplay=input`, () => {
     select.value = options[1]
     await tick()
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     expect(input.value).toBe(`Green`)
     expect(select.searchText).toBe(`Green`)
     expect(select.selected).toEqual([options[1]])
@@ -551,7 +553,7 @@ describe(`selectedDisplay=input`, () => {
       option_by_label(`Red`).click()
       await tick()
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       expect(input.value).toBe(`Red`)
 
       await reopen(input)
@@ -586,7 +588,7 @@ describe(`selectedDisplay=input`, () => {
       option_by_label(`Green`).click()
       await tick()
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       expect(input.value).toBe(`Green`)
       expect(select.value).toBe(`Green`)
       expect(select.selected).toEqual([`Green`])
@@ -607,7 +609,7 @@ describe(`selectedDisplay=input`, () => {
 
     expect(option_labels()).toEqual(color_options)
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(`Bl`, input)
 
     expect(option_labels()).toEqual([`Blue`])
@@ -659,7 +661,7 @@ describe(`selectedDisplay=input`, () => {
 
   test(`keyboard selection keeps aria-activedescendant valid and Escape preserves text`, async () => {
     const select = mount_input_display({ options: [`Red`, `Green`], open: true })
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
 
     input.dispatchEvent(press(`ArrowDown`))
     await tick()
@@ -682,7 +684,7 @@ describe(`selectedDisplay=input`, () => {
   test(`Backspace edits text normally instead of removing hidden chips`, async () => {
     const select = mount_input_display({ options: [`Red`, `Green`], selected: [`Red`] })
     await tick()
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
 
     const backspace = press(`Backspace`)
     input.dispatchEvent(backspace)
@@ -731,7 +733,7 @@ describe(`selectedDisplay=input`, () => {
       },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     expect(form.checkValidity()).toBe(false)
 
     await type_search_text(`custom color`, input)
@@ -760,7 +762,7 @@ describe(`selectedDisplay=input`, () => {
       },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     expect(input.maxLength).toBe(5)
     expect(input.readOnly).toBe(true)
     expect(input.getAttribute(`aria-label`)).toBe(`Color input`)
@@ -775,7 +777,7 @@ describe(`selectedDisplay=input`, () => {
       createOptionMsg: null,
       noMatchingOptionsMsg: ``,
     })
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
 
     await type_search_text(`Durian`, input)
     expect(document.querySelector(`ul.options li.user-msg`)).toBeNull()
@@ -803,7 +805,7 @@ describe(`selectedDisplay=input`, () => {
 
     expect(select.value).toBe(`Red`)
     expect(select.selected).toEqual([`Red`])
-    expect(doc_query<HTMLInputElement>(`input[autocomplete]`).value).toBe(`Red`)
+    expect(get_input().value).toBe(`Red`)
   })
 
   test(`loadOptions uses input-mode search text for dynamic suggestions`, async () => {
@@ -820,7 +822,7 @@ describe(`selectedDisplay=input`, () => {
           open: true,
         },
       })
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
 
       await type_search_text(`Al`, input)
       await vi.runAllTimersAsync()
@@ -848,7 +850,7 @@ describe(`selectedDisplay=input`, () => {
           loadOptions: { fetch: fetch_fn, debounceMs: 0 },
         },
       })
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
 
       input.focus()
       await vi.runAllTimersAsync()
@@ -1008,7 +1010,7 @@ test(`invalid=true gives top-level div class 'invalid' and input attribute of 'a
     props: { options: [1, 2, 3], invalid: true },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
 
   expect(input.getAttribute(`aria-invalid`)).toBe(`true`)
   const multiselect = doc_query(`div.multiselect`)
@@ -1035,7 +1037,7 @@ describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
   test(`implements ARIA combobox pattern with proper attributes and listbox association`, async () => {
     mount_a11y()
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
 
     // Static combobox attributes
     expect(input.getAttribute(`role`)).toBe(`combobox`)
@@ -1127,7 +1129,7 @@ describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
       props: { options: [`foo`, `bar`], [`aria-label`]: `Select your favorite` },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     expect(input.getAttribute(`aria-label`)).toBe(`Select your favorite`)
   })
 
@@ -1135,7 +1137,7 @@ describe(`VoiceOver/screen reader accessibility (issue #118)`, () => {
     const props = $state({ options: [`foo`, `bar`], loading: false })
     mount(MultiSelect, { target: document.body, props })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     expect(input.getAttribute(`aria-busy`)).toBeNull()
 
     props.loading = true
@@ -1327,7 +1329,7 @@ test(`expand icon click toggles dropdown in chips mode`, async () => {
     doc_query(`.expand-icon`).dispatchEvent(new MouseEvent(`mouseup`, { bubbles: true }))
     await tick()
   }
-  const input = doc_query(`input[autocomplete]`)
+  const input = get_input()
 
   for (const expanded of [`true`, `false`, `true`]) {
     await click_expand()
@@ -1368,7 +1370,7 @@ test(`beforeInput and afterInput snippets receive searchText and flank the input
   expect(before_input.dataset.searchText).toBe(``)
   expect(after_input.dataset.searchText).toBe(``)
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   expect(before_input.nextElementSibling).toBe(input)
   expect(input.nextElementSibling).toBe(after_input)
 
@@ -1400,7 +1402,7 @@ test(`userMsg snippet receives search text, message type, and message`, async ()
     props: { options: [`red`], allowUserOptions: true, open: true },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`purple`, input)
 
   const user_msg = doc_query(`.user-msg-snippet`)
@@ -1429,7 +1431,7 @@ test(`filters dropdown to show only matching options when entering text`, async 
     props: { options },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
 
   await type_search_text(`ba`, input)
 
@@ -1447,7 +1449,7 @@ test(`filterFunc controls rendered options and matchingOptions`, async () => {
   })
   mount(MultiSelect, { target: document.body, props })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`al`, input)
 
   expect(props.matchingOptions).toEqual([options[0], options[2]])
@@ -1462,7 +1464,7 @@ test(`autoScroll=false skips scrolling active options into view`, async () => {
 
   const options = [...document.querySelectorAll<HTMLElement>(`ul.options > li`)]
   for (const option of options) option.scrollIntoViewIfNeeded = vi.fn()
-  doc_query<HTMLInputElement>(`input[autocomplete]`).dispatchEvent(fresh_key(`ArrowDown`))
+  get_input().dispatchEvent(fresh_key(`ArrowDown`))
   await tick()
 
   expect(doc_query(`ul.options > li.active`).textContent?.trim()).toBe(`first`)
@@ -1471,30 +1473,49 @@ test(`autoScroll=false skips scrolling active options into view`, async () => {
   }
 })
 
-test(`highlightMatches=false does not modify CSS highlights`, async () => {
-  const previous_css = globalThis.CSS
-  const highlights = { delete: vi.fn(), set: vi.fn() }
-
+test.each([
+  [`highlightMatches=false suppresses highlighting`, { highlightMatches: false }, false],
+  [`typed search text is highlighted`, {}, true],
+  // after committing, searchText is "Alpha" but it is no longer an active filter, so
+  // highlighting must stay off — pins that the dropdown highlights the *effective*
+  // filter text rather than the raw searchText
+  [
+    `committed selectedDisplay=input text is not highlighted`,
+    { maxSelect: 1, selectedDisplay: `input`, closeDropdownOnSelect: false },
+    false,
+  ],
+] as const)(`%s`, async (_desc, extra_props, expect_highlight) => {
+  const highlights = { get: vi.fn(), set: vi.fn(), delete: vi.fn() }
   try {
-    Object.defineProperty(globalThis, `CSS`, {
-      configurable: true,
-      value: { highlights },
-    })
+    // happy-dom lacks the CSS Custom Highlight API; the registry spies carry the assertions
+    vi.stubGlobal(`CSS`, { highlights })
+    vi.stubGlobal(
+      `Highlight`,
+      class MockHighlight {
+        ranges: Range[]
+        constructor(...ranges: Range[]) {
+          this.ranges = ranges
+        }
+      },
+    )
     mount(MultiSelect, {
       target: document.body,
-      props: { highlightMatches: false, open: true, options: [`Alpha`] },
+      props: { open: true, options: [`Alpha`, `Beta`], ...extra_props },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    await type_search_text(`Al`, input)
+    if (`selectedDisplay` in extra_props) {
+      doc_query(`ul.options > li`).click()
+      await tick()
+      expect(get_input().value).toBe(`Alpha`)
+    } else await type_search_text(`Al`)
 
-    expect(highlights.delete).not.toHaveBeenCalled()
-    expect(highlights.set).not.toHaveBeenCalled()
+    if (expect_highlight) expect(highlights.set).toHaveBeenCalled()
+    else {
+      expect(highlights.set).not.toHaveBeenCalled()
+      expect(highlights.delete).not.toHaveBeenCalled()
+    }
   } finally {
-    Object.defineProperty(globalThis, `CSS`, {
-      configurable: true,
-      value: previous_css,
-    })
+    vi.unstubAllGlobals()
   }
 })
 
@@ -1516,7 +1537,7 @@ test.each([undefined, `Custom no options message`])(
       },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
 
     await type_search_text(`4`, input)
 
@@ -1539,34 +1560,32 @@ test.each([undefined, `Custom no options message`])(
 )
 
 // https://github.com/janosh/svelte-multiselect/issues/183
-test(`up/down arrow keys can traverse dropdown list even when user entered searchText into input`, async () => {
-  const options = [`foo`, `bar`, `baz`]
+test(`arrow keys traverse matching options and the create-option row in both directions`, async () => {
+  const create_msg = `Create this option...` // component default
   mount(MultiSelect, {
     target: document.body,
-    props: { options, allowUserOptions: true, open: true },
+    props: { options: [`foo`, `bar`, `baz`], allowUserOptions: true, open: true },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`ba`, input)
+  expect(normalized_text(doc_query(`ul.options`))).toBe(`bar baz ${create_msg}`)
 
-  const dropdown = doc_query(`ul.options`)
-  // Use the known default for createOptionMsg
-  const default_create_option_msg = `Create this option...`
-  expect(normalized_text(dropdown)).toBe(`bar baz ${default_create_option_msg}`)
-
-  // loop through the dropdown list twice, wrapping past the create-option row
   await focus_input()
-  for (const [idx, expected_text] of [
-    `bar`,
-    `baz`,
-    default_create_option_msg,
-    `bar`,
-  ].entries()) {
-    input.dispatchEvent(fresh_key(`ArrowDown`))
+  const steps = [
+    [`ArrowDown`, `bar`],
+    [`ArrowDown`, `baz`],
+    [`ArrowDown`, create_msg], // past the last match onto the create row
+    [`ArrowDown`, `bar`], // wraps back to the top
+    [`ArrowUp`, create_msg], // wraps back onto the create row
+    [`ArrowUp`, `baz`], // must land on the LAST match, not the first
+    [`ArrowUp`, `bar`],
+  ] as const
+  for (const [idx, [key, expected]] of steps.entries()) {
+    input.dispatchEvent(fresh_key(key))
     await tick()
-    expect(doc_query(`ul.options li.active`).textContent, `idx=${idx}`).toContain(
-      expected_text,
-    )
+    const active = doc_query(`ul.options li.active`)
+    expect(active.textContent, `step ${idx}: ${key}`).toContain(expected)
   }
 })
 
@@ -1695,7 +1714,7 @@ test.each([
         key: () => `duplicate`,
       },
     })
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
 
     input.dispatchEvent(fresh_key(key_name))
     await tick()
@@ -1747,7 +1766,7 @@ async function setup_user_message(search_text = `Purple`) {
     target: document.body,
     props,
   })
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(search_text, input)
 
   return { input, props, user_msg: doc_query(`ul.options li.user-msg`) }
@@ -1894,7 +1913,7 @@ describe.each([
         },
       })
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
 
       // Type the selected value to trigger duplicate/create check
       await type_search_text(`${selected[0]}`, input)
@@ -1918,7 +1937,7 @@ test.each([
       props: { options: [1, 2, 3], resetFilterOnAdd, closeDropdownOnSelect: false },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(`1`, input)
 
     if (method === `click`) {
@@ -1965,7 +1984,7 @@ test.each<{
       },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(search_text, input)
 
     input.dispatchEvent(fresh_key(`ArrowDown`))
@@ -1994,7 +2013,7 @@ test(`Enter key deselection preserves searchText (matching mouse behavior)`, asy
     },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`1`, input)
 
   // Navigate to the selected option with ArrowDown
@@ -2093,7 +2112,7 @@ test.each([[null], [`custom add option message`]])(
       },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     input.focus()
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
@@ -2123,7 +2142,7 @@ test(`disabled multiselect disables input, removal controls, and shows disabled 
   const wrapper = doc_query(`div.multiselect`)
   expect(wrapper.classList).toContain(`disabled`)
   expect(wrapper.getAttribute(`title`)).toBe(disabled_input_title)
-  expect(doc_query<HTMLInputElement>(`input[autocomplete]`).disabled).toBe(true)
+  expect(get_input().disabled).toBe(true)
   expect(document.querySelector(`button.remove`)).toBeNull()
 
   const disabled_icon = doc_query(`svg[data-name='disabled-icon']`)
@@ -2140,7 +2159,7 @@ test(`can remove user-created selected option which is not in dropdown list`, as
   })
 
   // add a new option created from user text input
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`foo`, input)
 
   const li = doc_query(`ul.options li[title='Create this option...']`)
@@ -2169,7 +2188,7 @@ test.each<[string, MultiSelectProps]>([
     props: { ...extra_props, onadd: onadd_spy, open: true },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   input.focus()
   await type_search_text(`    `, input)
 
@@ -2200,7 +2219,7 @@ test(`whitespace-only input rejected with loadOptions (root cause path)`, async 
     })
     await vi.runAllTimersAsync()
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     input.focus()
     await type_search_text(`    `, input)
     await vi.runAllTimersAsync()
@@ -2225,7 +2244,7 @@ test(`whitespace-only input does not mount options dropdown`, async () => {
     props: { options: [], allowUserOptions: true, open: true },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(` `, input)
 
   expect(document.querySelector(`ul.options`)).toBeNull()
@@ -2259,7 +2278,7 @@ test(`backspace does not remove items when minSelect would be violated`, async (
 
   // Try to remove the only selected item with backspace
   const backspace = fresh_key(`Backspace`)
-  const input = doc_query(`input[autocomplete="off"]`)
+  const input = get_input()
   input.dispatchEvent(backspace)
   await tick()
 
@@ -2283,7 +2302,7 @@ describe(`arrow key navigation between selected items`, () => {
       target: document.body,
       props: { options, selected, ...extra_props },
     })
-    return doc_query<HTMLInputElement>(`input[autocomplete]`)
+    return get_input()
   }
 
   test(`repeated ArrowLeft moves highlight leftward and stops at 0`, async () => {
@@ -2474,7 +2493,7 @@ describe(`arrow key navigation between selected items`, () => {
       selected: [`Red`, `Green`, `Blue`],
     })
     mount(MultiSelect, { target: document.body, props })
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     // highlight idx 2 (Blue)
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
@@ -2524,7 +2543,7 @@ test(`remove all button does not remove items when minSelect constraint would be
   const remove_all_button = document.querySelector(`button.remove-all`)
   expect(remove_all_button).toBeNull()
 
-  const input = doc_query(`input[autocomplete="off"]`)
+  const input = get_input()
   input.focus()
 
   // Open dropdown and make first option active
@@ -2760,23 +2779,6 @@ test(`errors to console when option is an object but has no label key`, () => {
   )
 })
 
-test(`first matching option becomes active automatically on entering searchText`, async () => {
-  mount(MultiSelect, {
-    target: document.body,
-    props: { options: [`foo`, `bar`, `baz`] },
-  })
-
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-  input.value = `ba`
-  // updates input value
-  input.dispatchEvent(input_event)
-  // triggers handle_keydown callback (which sets activeIndex)
-  input.dispatchEvent(fresh_key(`ArrowDown`))
-  await tick()
-
-  expect(doc_query(`ul.options li.active`).textContent?.trim()).toBe(`bar`)
-})
-
 // options: [1,2,3], selected: [1,2] → clicking ul.options li adds 3,
 // clicking ul.selected button.remove removes 1, clicking button.remove-all removes all
 test.each([
@@ -2808,7 +2810,7 @@ test.each([
 )
 
 async function create_user_option(search_text: string): Promise<void> {
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(search_text, input)
   doc_query(`ul.options li.user-msg`).click()
   await tick()
@@ -2895,7 +2897,7 @@ test(`allowUserOptions=append keeps created options selectable after removal`, a
   await tick()
   expect(props.selected).toEqual([])
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`foobar`, input)
 
   const appended_option = doc_query(`ul.options > li:not(.user-msg)`)
@@ -3018,7 +3020,7 @@ describe(`keepSelectedInDropdown feature`, () => {
     option_items().find((option_item) => option_item.textContent?.includes(label))
 
   async function open_options(): Promise<void> {
-    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    get_input().click()
     await tick()
   }
 
@@ -3188,7 +3190,7 @@ describe(`keepSelectedInDropdown feature`, () => {
       await open_options()
 
       // Navigate to Apple and toggle it off with Enter
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       input.dispatchEvent(fresh_key(`ArrowDown`))
       await tick()
       input.dispatchEvent(fresh_key(`Enter`))
@@ -3213,7 +3215,7 @@ describe(`keepSelectedInDropdown feature`, () => {
         props: { options: options_with_date, selected, keepSelectedInDropdown: mode },
       })
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       input.click()
 
       // Filter to show only options containing 'a'
@@ -3296,7 +3298,7 @@ test.each([
     },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   // Type text that triggers the message condition
   await type_search_text(is_dupe_test ? `foo` : `nonexistent`, input)
 
@@ -3309,7 +3311,7 @@ test(`empty duplicateOptionMsg leaves no phantom navigable row`, async () => {
     target: document.body,
     props: { options: [`ab`, `abc`], selected: [`ab`], duplicateOptionMsg: `` },
   })
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`ab`, input)
   input.dispatchEvent(fresh_key(`ArrowDown`))
   input.dispatchEvent(fresh_key(`ArrowDown`))
@@ -3330,9 +3332,6 @@ test.each([[0], [1], [5], [undefined]])(
       target: document.body,
       props: { options, maxOptions },
     })
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    input.dispatchEvent(input_event)
 
     expect(document.querySelectorAll(`ul.options li`)).toHaveLength(
       maxOptions === null || maxOptions === undefined
@@ -3459,7 +3458,7 @@ test.each([true, false, `if-mobile`, `retain-focus`] as const)(
         props: { options: [1, 2, 3], closeDropdownOnSelect, open: true },
       })
 
-      const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input_el = get_input()
       if (closeDropdownOnSelect === `retain-focus`) input_el.focus()
 
       // simulate selecting an option
@@ -3549,7 +3548,7 @@ test.each([
   async ({ reopen_action, expected_option }) => {
     mount_retain_focus({ options: [`Svelte`, `Solid`, `React`] })
 
-    const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input_el = get_input()
     const dropdown = doc_query(`ul.options`)
     input_el.focus()
     input_el.dispatchEvent(fresh_key(`ArrowDown`))
@@ -3573,7 +3572,7 @@ test(`closeDropdownOnSelect='retain-focus' clears active create message after cr
     allowUserOptions: true,
   })
 
-  const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input_el = get_input()
   const dropdown = doc_query(`ul.options`)
   input_el.focus()
   await type_search_text(`app`, input_el)
@@ -3604,7 +3603,7 @@ test(`closeDropdownOnSelect='retain-focus' restores input focus after keyboard s
     selectAllOption: true,
   })
 
-  const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input_el = get_input()
   const dropdown = doc_query(`ul.options`)
   const select_all_el = doc_query(`ul.options > li.select-all`)
   select_all_el.focus()
@@ -3654,7 +3653,7 @@ test.each([
 test(`closeDropdownOnSelect='retain-focus' works correctly with maxSelect`, async () => {
   mount_retain_focus({ options: [1, 2, 3], maxSelect: 2 })
 
-  const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input_el = get_input()
   input_el.focus()
 
   // select first option
@@ -3674,7 +3673,7 @@ test(`closeDropdownOnSelect='retain-focus' works correctly with maxSelect`, asyn
 test(`Escape and Tab still blur input even with closeDropdownOnSelect='retain-focus'`, async () => {
   mount_retain_focus({ options: [1, 2, 3] })
 
-  const input_el = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input_el = get_input()
   input_el.focus()
   await tick()
 
@@ -3682,46 +3681,6 @@ test(`Escape and Tab still blur input even with closeDropdownOnSelect='retain-fo
   input_el.dispatchEvent(fresh_key(`Escape`))
 
   expect(document.activeElement).not.toBe(input_el)
-})
-
-test(`arrow keys can navigate to create option message when there are matching options`, async () => {
-  const options = [`apple`, `banana`, `cherry`]
-  mount(MultiSelect, {
-    target: document.body,
-    props: {
-      options,
-      allowUserOptions: true,
-      createOptionMsg: `Create "app" option`,
-      searchText: `app`, // This will match "apple" but also allow creating "app"
-    },
-  })
-
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-  input.focus()
-
-  // Navigate through all options using arrow down
-  // First option should be active (apple matches "app")
-  input.dispatchEvent(fresh_key(`ArrowDown`))
-  await tick()
-  expect(doc_query(`ul.options > li.active`).textContent?.trim()).toBe(`apple`)
-
-  // Second navigation should reach the create option message
-  input.dispatchEvent(fresh_key(`ArrowDown`))
-  await tick()
-
-  const user_msg_li = doc_query(`ul.options li.user-msg`)
-  expect(user_msg_li.classList.contains(`active`)).toBe(true)
-  expect(user_msg_li.textContent?.trim()).toBe(`Create "app" option`)
-
-  // Navigate back up should go to apple
-  input.dispatchEvent(fresh_key(`ArrowUp`))
-  await tick()
-  expect(doc_query(`ul.options > li.active`).textContent?.trim()).toBe(`apple`)
-
-  // Test wrap-around: from first option, go up should reach create message
-  input.dispatchEvent(fresh_key(`ArrowUp`))
-  await tick()
-  expect(doc_query(`ul.options li.user-msg`).classList.contains(`active`)).toBe(true)
 })
 
 describe(`createOptionMsg as function`, () => {
@@ -3756,7 +3715,7 @@ describe(`createOptionMsg as function`, () => {
       },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(search, input)
 
     expect(doc_query(`ul.options li.user-msg`).textContent?.trim()).toBe(
@@ -3786,7 +3745,7 @@ describe(`createOptionMsg as function`, () => {
         },
       })
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       await type_search_text(`bar`, input)
 
       expect(doc_query(`ul.options li.user-msg`).textContent?.trim()).toBe(expected_text)
@@ -3810,7 +3769,7 @@ describe(`createOptionMsg as function`, () => {
       },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(`d`, input)
 
     expect(doc_query(`ul.options li.user-msg`).textContent?.trim()).toBe(
@@ -3829,7 +3788,7 @@ describe(`selectAllOption feature`, () => {
     `shows correct label when selectAllOption=%s`,
     async (selectAllOption, expected_label) => {
       mount(MultiSelect, { target: document.body, props: { options, selectAllOption } })
-      doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+      get_input().click()
       await tick()
       expect(doc_query(`ul.options > li.select-all`).textContent?.trim()).toBe(
         expected_label,
@@ -3841,7 +3800,7 @@ describe(`selectAllOption feature`, () => {
     `hidden when props=%j`,
     async (props) => {
       mount(MultiSelect, { target: document.body, props: { options, ...props } })
-      doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+      get_input().click()
       await tick()
       expect(document.querySelector(`ul.options > li.select-all`)).toBeNull()
     },
@@ -3864,7 +3823,7 @@ describe(`selectAllOption feature`, () => {
         onchange: onchange_spy,
       },
     })
-    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    get_input().click()
     await tick()
     const select_all = doc_query(`ul.options > li.select-all`)
     expect(select_all.getAttribute(`aria-selected`)).toBe(`false`)
@@ -3887,7 +3846,7 @@ describe(`selectAllOption feature`, () => {
       target: document.body,
       props: { options: options_mixed, selectAllOption: true, maxSelect: 2 },
     })
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     input.click()
     doc_query(`ul.options > li.select-all`).click()
     await tick()
@@ -3907,7 +3866,7 @@ describe(`selectAllOption feature`, () => {
         onmaxreached: onmaxreached_spy,
       },
     })
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     input.focus()
     input.dispatchEvent(
       new KeyboardEvent(`keydown`, { key: `a`, ctrlKey: true, bubbles: true }),
@@ -3934,7 +3893,7 @@ describe(`selectAllOption feature`, () => {
         onmaxreached: onmaxreached_spy,
       },
     })
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     input.click()
     await tick()
 
@@ -3968,7 +3927,7 @@ describe(`selectAllOption feature`, () => {
         selectAllDisabledTitle: title_prop,
       },
     })
-    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    get_input().click()
     await tick()
     expect(doc_query(`ul.options > li.select-all`).title).toBe(expected_title)
   })
@@ -3983,7 +3942,7 @@ describe(`selectAllOption feature`, () => {
         target: document.body,
         props: { options, selectAllOption: true, resetFilterOnAdd },
       })
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       input.click()
       await type_search_text(`a`, input)
       doc_query(`ul.options > li.select-all`).click()
@@ -4058,7 +4017,7 @@ describe(`selectAllOption feature`, () => {
         target: document.body,
         props: { selectAllOption: true, ...extra_props },
       })
-      doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+      get_input().click()
       const select_all_li = await vi.waitFor(() =>
         doc_query<HTMLLIElement>(`ul.options > li.select-all`),
       )
@@ -4081,7 +4040,7 @@ describe(`selectAllOption feature`, () => {
       onselectAll: onselectAll_spy,
     })
     mount(MultiSelect, { target: document.body, props })
-    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    get_input().click()
     await tick()
 
     doc_query(`ul.options > li.select-all`).click()
@@ -4096,7 +4055,7 @@ describe(`selectAllOption feature`, () => {
       target: document.body,
       props: { options, selectAllOption: true, liSelectAllClass: `custom` },
     })
-    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    get_input().click()
     await tick()
     expect(doc_query(`ul.options > li.select-all`).classList.contains(`custom`)).toBe(
       true,
@@ -4112,7 +4071,7 @@ describe(`selectAllOption feature`, () => {
       target: document.body,
       props: { options, selectAllOption: true, onselectAll: spy },
     })
-    doc_query<HTMLInputElement>(`input[autocomplete]`).click()
+    get_input().click()
     doc_query(`ul.options > li.select-all`).dispatchEvent(
       new KeyboardEvent(`keydown`, { ...key_props, bubbles: true }),
     )
@@ -4374,7 +4333,7 @@ describe(`loadOptions feature`, () => {
       })
       await vi.runAllTimersAsync()
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       await type_search_text(`abc`, input)
       await vi.runAllTimersAsync()
       expect(load_options).toHaveBeenCalledTimes(2)
@@ -4409,7 +4368,7 @@ describe(`loadOptions feature`, () => {
       await tick()
       expect(load_options).toHaveBeenCalledTimes(2) // pagination now in flight
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       await type_search_text(`zz`, input)
       await vi.runAllTimersAsync()
 
@@ -4454,7 +4413,7 @@ describe(`loadOptions feature`, () => {
       expect(load_options).toHaveBeenCalledTimes(1)
 
       // Type new search while first fetch is pending
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       await type_search_text(`xyz`, input)
       await vi.runAllTimersAsync()
       expect(load_options).toHaveBeenCalledTimes(2)
@@ -4483,7 +4442,7 @@ describe(`loadOptions feature`, () => {
     }
   })
 
-  test(`error stops further pagination`, async () => {
+  test(`pagination error is logged, clears busy state, and stops further loading`, async () => {
     const console_error = vi.spyOn(console, `error`).mockImplementation(() => {})
     const { fn: load_options, resolvers, rejectors } = deferred_load()
     mount(MultiSelect, {
@@ -4495,11 +4454,14 @@ describe(`loadOptions feature`, () => {
 
     resolvers[0]({ options: mock_data.slice(0, 50), hasMore: true })
     await tick()
+    const input = get_input()
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
 
     const ul = doc_query(`ul.options`)
     mock_scroll_near_bottom(ul)
     await tick()
     expect(load_options).toHaveBeenCalledTimes(2)
+    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
 
     rejectors[1](new Error(`Server error`))
     await tick()
@@ -4508,6 +4470,8 @@ describe(`loadOptions feature`, () => {
       expect.any(Error),
     )
 
+    // the error sets has_more=false, which both clears pending and blocks pagination
+    expect(input.getAttribute(`aria-busy`)).toBeNull()
     mock_scroll_near_bottom(ul)
     await tick()
     expect(load_options).toHaveBeenCalledTimes(2)
@@ -4523,7 +4487,7 @@ describe(`loadOptions feature`, () => {
     await tick()
     expect(load_options).toHaveBeenCalledTimes(1)
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     expect(input.getAttribute(`aria-busy`)).toBe(`true`)
 
     // Close dropdown via Escape while fetch is still pending
@@ -4558,7 +4522,7 @@ describe(`loadOptions feature`, () => {
       await vi.runAllTimersAsync()
       expect(load_options).toHaveBeenCalledTimes(1)
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       // Type "a", debounce, then "ab" before first completes
       await type_search_text(`a`, input)
       await vi.runAllTimersAsync()
@@ -4623,40 +4587,6 @@ describe(`loadOptions feature`, () => {
     expect(load_options).toHaveBeenCalledTimes(capped_count + 2)
   })
 
-  test(`error clears pending state via has_more`, async () => {
-    const console_error = vi.spyOn(console, `error`).mockImplementation(() => {})
-    const { fn: load_options, resolvers, rejectors } = deferred_load()
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        loadOptions: load_options,
-        noMatchingOptionsMsg: `No matches`,
-        open: true,
-      },
-    })
-    await tick()
-
-    // First load succeeds
-    resolvers[0]({ options: [`Apple`], hasMore: true })
-    await tick()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    expect(input.getAttribute(`aria-busy`)).toBeNull()
-
-    const ul = doc_query(`ul.options`)
-    mock_scroll_near_bottom(ul)
-    await tick()
-    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
-
-    // Fetch fails
-    rejectors[1](new Error(`Server error`))
-    await tick()
-
-    // After error: aria-busy should clear (has_more=false clears pending)
-    expect(input.getAttribute(`aria-busy`)).toBeNull()
-    console_error.mockRestore()
-  })
-
   test(`reopen before stale fetch resolves triggers fresh load`, async () => {
     const { fn: load_options, resolvers } = deferred_load()
     mount(MultiSelect, {
@@ -4666,7 +4596,7 @@ describe(`loadOptions feature`, () => {
     await tick()
     expect(load_options).toHaveBeenCalledTimes(1)
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
 
     // Close while first fetch is still pending (NOT resolved)
     input.dispatchEvent(fresh_key(`Escape`))
@@ -4707,7 +4637,7 @@ describe(`loadOptions feature`, () => {
       expect(load_options).toHaveBeenCalledTimes(1)
 
       // Type to trigger a new search while first fetch is pending
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       await type_search_text(`test`, input)
       await vi.runAllTimersAsync()
       expect(load_options).toHaveBeenCalledTimes(2)
@@ -4748,7 +4678,7 @@ describe(`loadOptions feature`, () => {
       })
 
       // Type to trigger initial load (onOpen=false requires user input)
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       await type_search_text(`q`, input)
       await vi.runAllTimersAsync()
       expect(load_options).toHaveBeenCalledTimes(1)
@@ -4799,7 +4729,7 @@ describe(`loadOptions feature`, () => {
       expect(load_options).toHaveBeenCalledTimes(1)
 
       // Search "x" triggers load, which fails
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       await type_search_text(`x`, input)
       await vi.runAllTimersAsync()
       expect(load_options).toHaveBeenCalledTimes(2)
@@ -4874,7 +4804,7 @@ test.each([
       resolvers[0]({ options: [...initial_options], hasMore: false })
       await vi.runAllTimersAsync()
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       await type_search_text(search, input)
       await vi.runAllTimersAsync()
       expect(fetch_fn.mock.calls.length).toBeGreaterThanOrEqual(2)
@@ -4907,7 +4837,7 @@ test(`createOptionMsg shows immediately with static options`, async () => {
     },
   })
   await tick()
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`Cherry`, input)
   expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
     `Create this option`,
@@ -4937,7 +4867,7 @@ describe(`load_options_pending`, () => {
     // type two chars while the first fetch is still awaiting (load_options_last_search
     // is null until it resolves). Pre-fix, each keystroke re-entered the first-load branch
     // and fired another immediate load_dynamic_options(true); the fix routes them to debounce.
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     for (const value of [`a`, `ab`]) {
       await type_search_text(value, input)
     }
@@ -4948,49 +4878,62 @@ describe(`load_options_pending`, () => {
     expect(fetch_fn).toHaveBeenLastCalledWith(expect.objectContaining({ search: `ab` }))
   })
 
-  test(`Enter during debounce does not create unwanted option`, async () => {
-    const { fetch_fn, fetch_resolvers } = create_deferred_fetch()
-    const oncreate_spy = vi.fn()
+  // onOpen=true loads immediately on open, onOpen=false stays idle until the user types.
+  // Either way Enter must wait for the debounce and fetch to settle before creating.
+  test.each([true, false])(
+    `onOpen=%s: Enter during debounce does not create unwanted option`,
+    async (on_open) => {
+      const { fetch_fn, fetch_resolvers } = create_deferred_fetch()
+      const oncreate_spy = vi.fn()
 
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        loadOptions: { fetch: fetch_fn, debounceMs: 300 },
-        allowUserOptions: true,
-        createOptionMsg: `Create this option`,
-        open: true,
-        oncreate: oncreate_spy,
-      },
-    })
-    await vi.runAllTimersAsync()
-    fetch_resolvers[0]({ options: [`Apple`, `Banana`], hasMore: false })
-    await vi.runAllTimersAsync()
+      mount(MultiSelect, {
+        target: document.body,
+        props: {
+          loadOptions: { fetch: fetch_fn, onOpen: on_open, debounceMs: 300 },
+          allowUserOptions: true,
+          createOptionMsg: `Create this option`,
+          open: true,
+          oncreate: oncreate_spy,
+        },
+      })
+      await vi.runAllTimersAsync()
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    await type_search_text(`Cherry`, input)
+      const input = get_input()
+      if (on_open) {
+        expect(fetch_fn).toHaveBeenCalledTimes(1)
+        fetch_resolvers[0]({ options: [`Apple`, `Banana`], hasMore: false })
+        await vi.runAllTimersAsync()
+      } else {
+        expect(fetch_fn).not.toHaveBeenCalled()
+        expect(input.getAttribute(`aria-busy`)).toBeNull() // idle until user types
+      }
 
-    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
+      await type_search_text(`Cherry`, input)
 
-    // Enter during debounce window should NOT create an option
-    input.dispatchEvent(fresh_key(`Enter`))
-    await tick()
-    expect(oncreate_spy).not.toHaveBeenCalled()
-    expect(document.querySelector(`.user-msg`)).toBeNull()
+      expect(input.getAttribute(`aria-busy`)).toBe(`true`)
 
-    // Let debounce fire and fetch complete
-    await vi.runAllTimersAsync()
-    fetch_resolvers[1]({ options: [], hasMore: false })
-    await vi.runAllTimersAsync()
+      // Enter during debounce window should NOT create an option
+      input.dispatchEvent(fresh_key(`Enter`))
+      await tick()
+      expect(oncreate_spy).not.toHaveBeenCalled()
+      expect(document.querySelector(`.user-msg`)).toBeNull()
 
-    expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
-      `Create this option`,
-    )
+      // Let debounce fire and fetch complete
+      await vi.runAllTimersAsync()
+      fetch_resolvers.at(-1)?.({ options: [], hasMore: false })
+      await vi.runAllTimersAsync()
 
-    // Now Enter should create the option
-    input.dispatchEvent(fresh_key(`Enter`))
-    await tick()
-    expect(oncreate_spy).toHaveBeenCalledTimes(1)
-  })
+      expect(input.getAttribute(`aria-busy`)).toBeNull()
+      expect(document.querySelector(`.user-msg`)?.textContent?.trim()).toBe(
+        `Create this option`,
+      )
+
+      // Now Enter should create the option
+      input.dispatchEvent(fresh_key(`Enter`))
+      await tick()
+      expect(oncreate_spy).toHaveBeenCalledTimes(1)
+    },
+  )
 
   test(`fetch failure unblocks pending state`, async () => {
     console.error = vi.fn()
@@ -5010,7 +4953,7 @@ describe(`load_options_pending`, () => {
     })
     await vi.runAllTimersAsync()
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(`NewThing`, input)
     await vi.runAllTimersAsync()
 
@@ -5022,46 +4965,6 @@ describe(`load_options_pending`, () => {
       `MultiSelect: loadOptions error:`,
       expect.any(Error),
     )
-  })
-
-  test(`onOpen: false — idle until user types, busy during debounce`, async () => {
-    const { fetch_fn, fetch_resolvers } = create_deferred_fetch()
-    const oncreate_spy = vi.fn()
-
-    mount(MultiSelect, {
-      target: document.body,
-      props: {
-        loadOptions: { fetch: fetch_fn, onOpen: false, debounceMs: 200 },
-        allowUserOptions: true,
-        createOptionMsg: `Create this option`,
-        open: true,
-        oncreate: oncreate_spy,
-      },
-    })
-    await vi.runAllTimersAsync()
-
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    expect(fetch_fn).not.toHaveBeenCalled()
-    expect(input.getAttribute(`aria-busy`)).toBeNull()
-
-    // Type triggers debounce — should become busy
-    await type_search_text(`Rust`, input)
-    expect(input.getAttribute(`aria-busy`)).toBe(`true`)
-
-    // Enter during debounce should NOT create option
-    input.dispatchEvent(fresh_key(`Enter`))
-    await tick()
-    expect(oncreate_spy).not.toHaveBeenCalled()
-
-    // After debounce + fetch resolves, Enter works
-    await vi.runAllTimersAsync()
-    fetch_resolvers[0]({ options: [], hasMore: false })
-    await vi.runAllTimersAsync()
-    expect(input.getAttribute(`aria-busy`)).toBeNull()
-
-    input.dispatchEvent(fresh_key(`Enter`))
-    await tick()
-    expect(oncreate_spy).toHaveBeenCalledTimes(1)
   })
 
   test(`late fetch response after close does not corrupt next open`, async () => {
@@ -5080,7 +4983,7 @@ describe(`load_options_pending`, () => {
     expect(fetch_fn).toHaveBeenCalledTimes(1)
 
     // Type to trigger a second fetch, then close before it resolves
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(`Rust`, input)
     await vi.runAllTimersAsync()
     expect(fetch_fn).toHaveBeenCalledTimes(2)
@@ -5200,12 +5103,6 @@ describe(`CSS static analysis`, () => {
   test(`::highlight is global and uses light-dark()`, () => {
     expect(css).toMatch(
       /:global\(::highlight\(sms-search-matches\)\)\s*\{[^}]*light-dark\(/u,
-    )
-  })
-
-  test(`dropdown highlight query uses effective filter text`, () => {
-    expect(component_source).toMatch(
-      /highlight_matches\(\{\s*query:\s*effective_filter_text,/u,
     )
   })
 
@@ -5333,7 +5230,7 @@ describe(`option grouping feature`, () => {
       props: { options: grouped_options, open: true },
     })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(`Rock`, input)
 
     // Only Genre group header should be visible since only Rock matches
@@ -5965,7 +5862,7 @@ describe(`option grouping feature`, () => {
       ),
     ).toHaveLength(1)
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(search, input)
 
     if (expected_toggle) {
@@ -6051,7 +5948,7 @@ describe(`option grouping feature`, () => {
         },
       })
 
-      const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+      const input = get_input()
       await type_search_text(search_text, input)
 
       const visible_options = document.querySelectorAll(
@@ -6089,7 +5986,7 @@ describe(`option grouping feature`, () => {
     expect(rock_visible).toBe(false)
 
     // Press arrow down to trigger keyboard navigation
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     input.focus()
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
@@ -6232,7 +6129,7 @@ describe(`keyboard shortcuts`, () => {
     mount(MultiSelect, { target: document.body, props })
     await tick()
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     input.focus()
     const event = new KeyboardEvent(`keydown`, {
       ...key_event,
@@ -7058,7 +6955,7 @@ describe(`history / undo-redo`, () => {
     expect(props.selected).toHaveLength(1)
 
     // Use autocomplete input (the interactive one), not the hidden form-control
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     input.focus()
     input.dispatchEvent(
       new KeyboardEvent(`keydown`, { key, bubbles: true, ...modifiers }),
@@ -7107,7 +7004,7 @@ describe(`history / undo-redo`, () => {
     expect(props.selected?.length).toBeGreaterThan(0)
 
     // Undo via Ctrl+Z should restore previous state
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     input.focus()
     input.dispatchEvent(
       new KeyboardEvent(`keydown`, { key: `z`, ctrlKey: true, bubbles: true }),
@@ -7432,7 +7329,7 @@ describe(`duplicates prop variants`, () => {
       props: { options, selected: [options[0]], duplicates: `case-insensitive` },
     })
 
-    doc_query<HTMLInputElement>(`input[autocomplete]`).focus()
+    get_input().focus()
     await tick()
 
     expect(
@@ -7451,7 +7348,7 @@ test(`dropdown has no li children when all user-created options are selected`, a
     },
   })
 
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`tag1`, input)
   input.dispatchEvent(fresh_key(`Enter`))
   await tick()
@@ -7492,7 +7389,7 @@ async function paste_into(extra_props: Partial<MultiSelectProps>, paste_text: st
     ...extra_props,
   })
   mount(MultiSelect, { target: document.body, props })
-  const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+  const input = get_input()
   const event = make_paste_event(paste_text)
   input.dispatchEvent(event)
   // No macrotask wait: sync-oncreate paste must complete synchronously. handle_paste
@@ -7714,7 +7611,7 @@ describe(`parse_paste`, () => {
 test(`falsy option values (0, '') are navigable and selectable via keyboard`, async () => {
   const props = $state<MultiSelectProps>({ options: [0, 1, 2], selected: [] })
   mount(MultiSelect, { target: document.body, props })
-  const input = doc_query<HTMLInputElement>(`ul.selected input[autocomplete]`)
+  const input = get_input()
 
   // ArrowDown activates option 0 (previously reset to null because !0 is truthy)
   input.dispatchEvent(fresh_key(`ArrowDown`))
@@ -7766,7 +7663,7 @@ test(`keyboard navigation respects maxOptions: arrow keys wrap within rendered o
     target: document.body,
     props: { options: [`a`, `b`, `c`, `d`, `e`], maxOptions: 2 },
   })
-  const input = doc_query<HTMLInputElement>(`ul.selected input[autocomplete]`)
+  const input = get_input()
 
   // 3 ArrowDowns: a -> b -> wrap back to a (previously walked into hidden options c/d/e)
   const expected_active = [`a`, `b`, `a`]
@@ -7808,7 +7705,7 @@ test(`group deselect-all keeps at least minSelect options selected`, async () =>
 test(`IME composition guard: Enter during composition is ignored`, async () => {
   const props = $state<MultiSelectProps>({ options: [`foo`, `bar`], selected: [] })
   mount(MultiSelect, { target: document.body, props })
-  const input = doc_query<HTMLInputElement>(`ul.selected input[autocomplete]`)
+  const input = get_input()
 
   input.dispatchEvent(fresh_key(`ArrowDown`))
   await tick()
@@ -7879,7 +7776,7 @@ test(`clearing searchText while create-option message is active drops aria-activ
     target: document.body,
     props: { options: [`foo`], allowUserOptions: true },
   })
-  const input = doc_query<HTMLInputElement>(`ul.selected input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`xyz`, input)
 
   // no options match 'xyz' -> ArrowDown activates the create-option message
@@ -7893,27 +7790,6 @@ test(`clearing searchText while create-option message is active drops aria-activ
   expect(document.querySelector(`ul.options > li.user-msg`)).toBeNull()
   // previously kept pointing at the removed user-msg li (dangling ARIA reference)
   expect(input.getAttribute(`aria-activedescendant`)).toBeNull()
-})
-
-test(`ArrowUp from the create-option message wraps to the last matching option, not the first`, async () => {
-  mount(MultiSelect, {
-    target: document.body,
-    props: { options: [`foo`, `bar`, `baz`], allowUserOptions: true },
-  })
-  const input = doc_query<HTMLInputElement>(`ul.selected input[autocomplete]`)
-  await type_search_text(`ba`, input)
-
-  // matches: bar, baz + create-option message. 3 ArrowDowns activate the message
-  for (let press_idx = 0; press_idx < 3; press_idx++) {
-    input.dispatchEvent(fresh_key(`ArrowDown`))
-    await tick()
-  }
-  expect(doc_query(`ul.options > li.user-msg`).classList.contains(`active`)).toBe(true)
-
-  // ArrowUp must wrap to the last option (baz), previously jumped to the first (bar)
-  input.dispatchEvent(fresh_key(`ArrowUp`))
-  await tick()
-  expect(doc_query(`ul.options > li.active`).textContent?.trim()).toBe(`baz`)
 })
 
 describe(`async oncreate`, () => {
@@ -8432,7 +8308,7 @@ describe(`virtualList`, () => {
   test(`arrow keys keep the active option rendered beyond the initial window`, async () => {
     mount(MultiSelect, { target: document.body, props: { ...virtual_props } })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     const n_presses = 25 // activeIndex 24 lies past the initial window end of 19
     for (let press_idx = 0; press_idx < n_presses; press_idx++) {
       input.dispatchEvent(fresh_key(`ArrowDown`))
@@ -8451,7 +8327,7 @@ describe(`virtualList`, () => {
   test(`fuzzy search filtering still works in virtual mode`, async () => {
     mount(MultiSelect, { target: document.body, props: { ...virtual_props } })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     await type_search_text(`999`, input)
 
     const rendered = get_rendered_options()
@@ -8500,7 +8376,7 @@ describe(`virtualList`, () => {
     // keyboard: first ArrowDown activates flat idx 0, whose ROW is 1 (the group 0
     // header occupies row 0) — auto-scroll must clamp to the row offset, not the
     // flat option index (which would scroll to 0)
-    const input = doc_query<HTMLInputElement>(`ul.selected input[autocomplete]`)
+    const input = get_input()
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
     expect(ul_options.scrollTop).toBe(item_height) // row 1 (header row 0 above it)
@@ -8591,7 +8467,7 @@ describe(`maxVisibleChips`, () => {
     expect(chips()).toHaveLength(2)
 
     // ArrowLeft highlights the LAST selected chip (idx 4), which is hidden
-    const input = doc_query<HTMLInputElement>(`ul.selected input[autocomplete]`)
+    const input = get_input()
     input.dispatchEvent(fresh_key(`ArrowLeft`))
     await tick()
 
@@ -8663,7 +8539,7 @@ describe(`ARIA correctness`, () => {
     const props = $state<MultiSelectProps>({ options: [], allowEmpty: true })
     mount(MultiSelect, { target: document.body, props })
 
-    const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+    const input = get_input()
     expect(document.querySelector(`ul.options`)).toBeNull()
     expect(input.getAttribute(`aria-controls`)).toBeNull()
 
@@ -8716,7 +8592,7 @@ test(`searchExpandsCollapsedGroups: manually collapsed group stays collapsed unt
       collapsedGroups: new Set([`Fruits`]),
     },
   })
-  const input = doc_query<HTMLInputElement>(`ul.selected input[autocomplete]`)
+  const input = get_input()
   const fruits_header = () =>
     [...document.querySelectorAll(`ul.options li.group-header`)].find((el) =>
       el.textContent?.includes(`Fruits`),
@@ -8741,7 +8617,7 @@ test(`whitespace-only search shows all options instead of a blank dropdown`, asy
     target: document.body,
     props: { options: [1, 2, 3], open: true },
   })
-  const input = doc_query<HTMLInputElement>(`ul.selected input[autocomplete]`)
+  const input = get_input()
   await type_search_text(`  `, input)
 
   expect(document.querySelectorAll(`ul.options li[role='option']`)).toHaveLength(3)

--- a/tests/vitest/PrevNext.test.ts
+++ b/tests/vitest/PrevNext.test.ts
@@ -12,8 +12,14 @@ describe(`PrevNext`, () => {
   let scrollToSpy: ReturnType<typeof vi.fn>
   const link_hrefs = () =>
     [...target.querySelectorAll(`a`)].map((link) => link.getAttribute(`href`))
-  const keyup = (key: string, event_target: EventTarget = globalThis) =>
-    event_target.dispatchEvent(new KeyboardEvent(`keyup`, { key, bubbles: true }))
+  const keyup = (
+    key: string,
+    event_target: EventTarget = globalThis,
+    init: KeyboardEventInit = {},
+  ) =>
+    event_target.dispatchEvent(
+      new KeyboardEvent(`keyup`, { key, bubbles: true, ...init }),
+    )
   // clearing document.body leaves <svelte:window> keyup listeners attached, so leaked
   // instances keep navigating and skew call counts
   const mounted: Record<string, unknown>[] = []
@@ -88,15 +94,19 @@ describe(`PrevNext`, () => {
     expect(pushStateSpy).not.toHaveBeenCalled() // replace_state defaults to true
   })
 
-  test.each([
+  test.each<[string, ComponentProps<typeof PrevNext>, string, KeyboardEventInit?]>([
     // the first two press a mapped key, so they fail if their guard stops working
     [`onkeyup=null`, { items, current: `page2`, onkeyup: null }, `ArrowLeft`],
     [`too few items`, { items: [`page1`, `page2`], current: `page1` }, `ArrowLeft`],
     [`unmapped key`, { items, current: `page2` }, `Home`],
-  ])(`keyboard navigation ignores %s`, (_label, props, key) => {
+    // Alt+ArrowLeft is the browser Back shortcut, so navigating too races with it
+    [`Alt+ArrowLeft`, { items, current: `page2` }, `ArrowLeft`, { altKey: true }],
+    [`Ctrl+ArrowLeft`, { items, current: `page2` }, `ArrowLeft`, { ctrlKey: true }],
+    [`Meta+ArrowRight`, { items, current: `page2` }, `ArrowRight`, { metaKey: true }],
+  ])(`keyboard navigation ignores %s`, (_label, props, key, init) => {
     mount_prev_next(props)
 
-    keyup(key)
+    keyup(key, globalThis, init)
 
     for (const spy of [replaceStateSpy, pushStateSpy, scrollToSpy]) {
       expect(spy).not.toHaveBeenCalled()

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -10,8 +10,8 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { doc_query } from './index'
 
-const mouse_event = (type: string, clientX: number, clientY: number) =>
-  new MouseEvent(type, { clientX, clientY, bubbles: true })
+const mouse_event = (type: string, clientX: number, clientY: number, button = 0) =>
+  new MouseEvent(type, { clientX, clientY, button, bubbles: true })
 
 const create_element = (tag = `div`, styles: Partial<CSSStyleDeclaration> = {}) => {
   const element = document.createElement(tag)
@@ -1042,6 +1042,18 @@ describe(`draggable`, () => {
     expect(element.style.cursor).toBe(``)
   })
 
+  it(`should not start dragging on a non-primary mouse button`, () => {
+    // the context menu can swallow the mouseup, leaving the element stuck to the cursor
+    const element = create_element()
+    element.style.position = `fixed`
+    mock_rect(element, { left: 10, top: 20 })
+    draggable({})(element)
+
+    element.dispatchEvent(mouse_event(`mousedown`, 5, 5, 2))
+    globalThis.dispatchEvent(mouse_event(`mousemove`, 50, 50))
+    expect([element.style.left, element.style.top]).toEqual([``, ``])
+  })
+
   it(`should not set up dragging when disabled`, () => {
     const element = create_element()
     element.style.position = `fixed`
@@ -1739,6 +1751,16 @@ describe(`resizable`, () => {
       globalThis.dispatchEvent(new MouseEvent(`mouseup`, { bubbles: true }))
     },
   )
+
+  it(`should not start resizing on a non-primary mouse button`, () => {
+    const element = create_box()
+    mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
+    const on_resize_start = vi.fn()
+    resizable({ on_resize_start })(element)
+
+    element.dispatchEvent(mouse_event(`mousedown`, 195, 75, 2))
+    expect(on_resize_start).not.toHaveBeenCalled()
+  })
 
   it(`should fire on_resize_start, on_resize, and on_resize_end callbacks`, () => {
     const element = create_box()

--- a/tests/vitest/heading-anchors.test.ts
+++ b/tests/vitest/heading-anchors.test.ts
@@ -223,7 +223,8 @@ describe(`heading_anchors attachment`, () => {
     ],
   ])(`auto-generates unique ids: %s`, (_desc, html, expected_ids) => {
     const container = create_container(html)
-    expect(() => heading_anchors()(container)).not.toThrow()
+    // a throw here fails the test on its own, so no not.toThrow() wrapper needed
+    heading_anchors()(container)
     const ids = Array.from(container.querySelectorAll(`h2, h3`)).map((el) => el.id)
     expect(ids).toEqual(expected_ids)
     expect(container.querySelectorAll(anchor_selector)).toHaveLength(2)

--- a/tests/vitest/heading-anchors.test.ts
+++ b/tests/vitest/heading-anchors.test.ts
@@ -5,103 +5,20 @@ import { doc_query } from './index'
 const preprocess = (content: string, filename?: string) =>
   heading_ids().markup({ content, filename })
 
-// Decoded independently of the encoder under test, so a self-consistent but wrong
-// encoding can't pass. Yields [generated_column, source_line, source_column] per segment.
-const decode_mappings = (mappings: string): [number, number, number][][] => {
-  const base64 = `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/`
-  let source_line = 0
-  let source_column = 0
-  return mappings.split(`;`).map((line) => {
-    let generated_column = 0
-    return line
-      .split(`,`)
-      .filter(Boolean)
-      .map((segment) => {
-        const values: number[] = []
-        let shift = 0
-        let accumulated = 0
-        for (const char of segment) {
-          const digit = base64.indexOf(char)
-          accumulated += (digit & 31) << shift
-          if (digit & 32) shift += 5
-          else {
-            values.push(accumulated & 1 ? -(accumulated >> 1) : accumulated >> 1)
-            shift = 0
-            accumulated = 0
-          }
-        }
-        generated_column += values[0]
-        source_line += values[2]
-        source_column += values[3]
-        return [generated_column, source_line, source_column] as [number, number, number]
-      })
-  })
-}
-
 describe(`heading_ids preprocessor`, () => {
-  it(`emits map metadata pointing at the original component`, () => {
-    const source = `<h2>A</h2>\n<h2>B</h2>`
-    const { map } = preprocess(source, `Heading.svelte`)
-    expect(map).toEqual({
+  // exact VLQ mappings; a lone `AAAA` per line is the identity map for unshifted text
+  it.each([
+    [`<h2>A</h2>\n<h2>B</h2>`, `AAAA,GAAG,OAAA,OAAO;AACV,GAAG,OAAA,OAAO`],
+    [`<div>\n  <h2>N</h2>\n</div>`, `AAAA;AACA,KAAK,OAAA,OAAO;AACZ`],
+    [`<p>no heading</p>\n<span>x</span>`, `AAAA;AACA`], // headingless fast path
+  ])(`maps original markup before and after inserted IDs in %j`, (source, mappings) => {
+    expect(preprocess(source, `Heading.svelte`).map).toEqual({
       version: 3,
       names: [],
       sources: [`Heading.svelte`],
       sourcesContent: [source],
-      mappings: expect.any(String),
+      mappings,
     })
-  })
-
-  // an inaccurate map sends every downstream diagnostic to the wrong place
-  it.each([
-    [`one heading per line`, `<h2>A</h2>\n<h2>B</h2>`],
-    [`indented heading`, `<div>\n  <h2>Nested</h2>\n</div>`],
-    [`two headings on one line`, `<div><h2>One</h2> <h3>Two</h3></div>`],
-    [`content trailing the heading`, `<h2>Title</h2> trailing text here`],
-    [`non-ASCII heading text`, `<p>x</p>\n<h2>Über Café</h2>\n<p>after</p>`],
-    [`heading that already has an id`, `<h2 id="keep">A</h2>\n<h2>B</h2>`],
-    [`mdsvex single-line output`, `<p>a</p> <h2>First</h2> <p>b</p> <h3>Second</h3>`],
-    [`no headings at all`, `<p>nothing to do</p>\n<span>x</span>`],
-    [`script below the heading`, `<h2>Docs</h2>\n<script>\n  let count = 1\n</script>`],
-  ])(`maps every unchanged span back to its original text (%s)`, (_label, source) => {
-    const { code, map } = preprocess(source, `T.svelte`)
-    const generated_lines = code.split(`\n`)
-    const source_lines = source.split(`\n`)
-    const decoded = decode_mappings(map.mappings)
-    // else empty mappings would make the span assertions below vacuously pass
-    expect(decoded).toHaveLength(source_lines.length)
-
-    let mapped_insertions = 0
-    for (const [line_idx, segments] of decoded.entries()) {
-      const generated_line = generated_lines[line_idx]
-      const source_line = source_lines[line_idx]
-      segments.forEach(([generated_column, mapped_line, mapped_column], seg_idx) => {
-        const span_end = segments[seg_idx + 1]?.[0] ?? generated_line.length
-        const generated = generated_line.slice(generated_column, span_end)
-        // the inserted attribute is the one span with no counterpart in the original
-        if (/^ id="[^"]*"$/u.test(generated)) {
-          mapped_insertions++
-          return
-        }
-        const original = source_lines[mapped_line].slice(
-          mapped_column,
-          mapped_column + generated.length,
-        )
-        expect(original, `line ${line_idx} col ${generated_column}`).toBe(generated)
-      })
-
-      // A shifted line (only insertions change length) must close with a segment mapping
-      // its new end to the original, else end-of-line resolves to the pre-shift column.
-      if (generated_line.length !== source_line.length) {
-        const last_segment = segments.at(-1)
-        expect([last_segment?.[0], last_segment?.[2]], `line ${line_idx} end`).toEqual([
-          generated_line.length,
-          source_line.length,
-        ])
-      }
-    }
-    // every inserted id must appear as its own span, so dropping them can't pass
-    const count_ids = (text: string) => (text.match(/ id="/gu) ?? []).length
-    expect(mapped_insertions).toBe(count_ids(code) - count_ids(source))
   })
 
   it.each([

--- a/tests/vitest/heading-anchors.test.ts
+++ b/tests/vitest/heading-anchors.test.ts
@@ -5,16 +5,106 @@ import { doc_query } from './index'
 const preprocess = (content: string, filename?: string) =>
   heading_ids().markup({ content, filename })
 
+// Decode VLQ here rather than reuse the encoder under test, so a self-consistent but wrong
+// encoding can't pass. Returns [generated_column, source_line, source_column] per segment.
+const decode_mappings = (mappings: string): [number, number, number][][] => {
+  const base64 = `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/`
+  let source_line = 0
+  let source_column = 0
+  return mappings.split(`;`).map((line) => {
+    let generated_column = 0
+    return line
+      .split(`,`)
+      .filter(Boolean)
+      .map((segment) => {
+        const values: number[] = []
+        let shift = 0
+        let accumulated = 0
+        for (const char of segment) {
+          const digit = base64.indexOf(char)
+          accumulated += (digit & 31) << shift
+          if (digit & 32) shift += 5
+          else {
+            values.push(accumulated & 1 ? -(accumulated >> 1) : accumulated >> 1)
+            shift = 0
+            accumulated = 0
+          }
+        }
+        generated_column += values[0]
+        source_line += values[2]
+        source_column += values[3]
+        return [generated_column, source_line, source_column] as [number, number, number]
+      })
+  })
+}
+
 describe(`heading_ids preprocessor`, () => {
-  it(`maps original markup before and after inserted IDs`, () => {
+  it(`emits map metadata pointing at the original component`, () => {
     const source = `<h2>A</h2>\n<h2>B</h2>`
-    expect(preprocess(source, `Heading.svelte`).map).toEqual({
+    const { map } = preprocess(source, `Heading.svelte`)
+    expect(map).toEqual({
       version: 3,
       names: [],
       sources: [`Heading.svelte`],
       sourcesContent: [source],
-      mappings: `AAAA,GAAG,OAAA,OAAO;AACV,GAAG,OAAA,OAAO`,
+      mappings: expect.any(String),
     })
+  })
+
+  // Svelte preprocessors that rewrite markup without an accurate map make every downstream
+  // diagnostic point at the wrong place; svelte-check-rs rejects such components outright.
+  it.each([
+    [`one heading per line`, `<h2>A</h2>\n<h2>B</h2>`],
+    [`indented heading`, `<div>\n  <h2>Nested</h2>\n</div>`],
+    [`two headings on one line`, `<div><h2>One</h2> <h3>Two</h3></div>`],
+    [`content trailing the heading`, `<h2>Title</h2> trailing text here`],
+    [`non-ASCII heading text`, `<p>x</p>\n<h2>Über Café</h2>\n<p>after</p>`],
+    [`heading that already has an id`, `<h2 id="keep">A</h2>\n<h2>B</h2>`],
+    [`mdsvex single-line output`, `<p>a</p> <h2>First</h2> <p>b</p> <h3>Second</h3>`],
+    [`no headings at all`, `<p>nothing to do</p>\n<span>x</span>`],
+    [`script below the heading`, `<h2>Docs</h2>\n<script>\n  let count = 1\n</script>`],
+  ])(`maps every unchanged span back to its original text (%s)`, (_label, source) => {
+    const { code, map } = preprocess(source, `T.svelte`)
+    const generated_lines = code.split(`\n`)
+    const source_lines = source.split(`\n`)
+    const decoded = decode_mappings(map.mappings)
+    // else empty mappings would make the span assertions below vacuously pass
+    expect(decoded).toHaveLength(source_lines.length)
+
+    let mapped_insertions = 0
+    for (const [line_idx, segments] of decoded.entries()) {
+      const generated_line = generated_lines[line_idx]
+      const source_line = source_lines[line_idx]
+      segments.forEach(([generated_column, mapped_line, mapped_column], seg_idx) => {
+        const span_end = segments[seg_idx + 1]?.[0] ?? generated_line.length
+        const generated = generated_line.slice(generated_column, span_end)
+        // the inserted attribute is the one span with no counterpart in the original
+        if (/^ id="[^"]*"$/u.test(generated)) {
+          mapped_insertions++
+          return
+        }
+        const original = source_lines[mapped_line].slice(
+          mapped_column,
+          mapped_column + generated.length,
+        )
+        expect(original, `line ${line_idx} col ${generated_column}`).toBe(generated)
+      })
+
+      // A shifted line must close with a segment mapping its new end to the original end,
+      // else consumers resolve end-of-line positions back to the pre-shift column.
+      // Only insertions change a line's length, so differing lengths means it shifted.
+      if (generated_line.length !== source_line.length) {
+        const last_segment = segments.at(-1)
+        expect([last_segment?.[0], last_segment?.[2]], `line ${line_idx} end`).toEqual([
+          generated_line.length,
+          source_line.length,
+        ])
+      }
+    }
+    // every id the preprocessor added must show up as its own span, so a map that silently
+    // drops insertions can't pass by having nothing left to contradict
+    const count_ids = (text: string) => (text.match(/ id="/gu) ?? []).length
+    expect(mapped_insertions).toBe(count_ids(code) - count_ids(source))
   })
 
   it.each([
@@ -30,10 +120,6 @@ describe(`heading_ids preprocessor`, () => {
     ],
     // existing attributes are preserved, the id is inserted first
     [`<h2 data-id="foo">Hello</h2>`, `<h2 id="hello" data-id="foo">Hello</h2>`],
-    [
-      `<h2 class="test" data-test="foo">Title</h2>`,
-      `<h2 id="title" class="test" data-test="foo">Title</h2>`,
-    ],
     [
       `<h2 on:click={handler}>Clickable</h2>`,
       `<h2 id="clickable" on:click={handler}>Clickable</h2>`,
@@ -103,12 +189,14 @@ describe(`heading_anchors attachment`, () => {
   const anchor_selector = `a[aria-hidden="true"]`
   const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
 
-  it.each([`h2`, `h6`])(`adds anchor to %s`, (tag: string) => {
-    const container = create_container(`<${tag} id="test">Content</${tag}>`)
+  it.each([`h2`, `h6`])(`adds anchor as last child of %s`, (tag: string) => {
+    const container = create_container(`<${tag} id="test">T <span>x</span></${tag}>`)
     heading_anchors()(container)
     const anchor = container.querySelector(`${tag} ${anchor_selector}`)
     expect(anchor).toBeInstanceOf(HTMLAnchorElement)
     expect(anchor?.getAttribute(`href`)).toBe(`#test`)
+    // appended after existing children rather than prepended or replacing them
+    expect(container.querySelector(tag)?.lastElementChild).toBe(anchor)
   })
 
   it(`handles multiple headings and prevents duplicates`, () => {
@@ -120,11 +208,28 @@ describe(`heading_anchors attachment`, () => {
     expect(container.querySelectorAll(anchor_selector)).toHaveLength(3)
   })
 
-  it(`generates unique IDs for headings without them`, () => {
-    const container = create_container(`<h2>Same</h2><h3>Same</h3>`)
-    heading_anchors()(container)
-    const ids = Array.from(container.querySelectorAll(`h1, h2, h3`)).map((el) => el.id)
-    expect(ids).toEqual([`same`, `same-1`])
+  it.each([
+    [`sibling headings`, `<h2>Same</h2><h3>Same</h3>`, [`same`, `same-1`]],
+    // querySelector('#2024-roadmap') throws SyntaxError since CSS ID selectors
+    // can't start with an unescaped digit - uniqueness check must use getElementById
+    [
+      `digit-leading text (invalid as CSS ID selector)`,
+      `<h2>2024 Roadmap</h2><h3>2024 Roadmap</h3>`,
+      [`2024-roadmap`, `2024-roadmap-1`],
+    ],
+    // guards get_default_headings ordering: a direct-child heading must be processed
+    // before a grandchild in a later sibling, so the duplicate suffix lands on the grandchild
+    [
+      `direct child before a later sibling's grandchild`,
+      `<h2>Dup</h2><div><h3>Dup</h3></div>`,
+      [`dup`, `dup-1`],
+    ],
+  ])(`auto-generates unique ids: %s`, (_desc, html, expected_ids) => {
+    const container = create_container(html)
+    expect(() => heading_anchors()(container)).not.toThrow()
+    const ids = Array.from(container.querySelectorAll(`h2, h3`)).map((el) => el.id)
+    expect(ids).toEqual(expected_ids)
+    expect(container.querySelectorAll(anchor_selector)).toHaveLength(2)
   })
 
   it(`skips headings with no usable text`, () => {
@@ -133,42 +238,6 @@ describe(`heading_anchors attachment`, () => {
     const heading = doc_query(`h2`)
     expect(heading.querySelector(`a`)).toBeNull()
     expect(heading.id).toBe(``) // no id invented for text-less headings
-  })
-
-  it(`handles digit-leading heading text without throwing (invalid as CSS ID selector)`, () => {
-    // querySelector('#2024-roadmap') throws SyntaxError since CSS ID selectors
-    // can't start with an unescaped digit - uniqueness check must use getElementById
-    const container = create_container(`<h2>2024 Roadmap</h2><h3>2024 Roadmap</h3>`)
-    expect(() => heading_anchors()(container)).not.toThrow()
-    const ids = Array.from(container.querySelectorAll(`h2, h3`)).map((el) => el.id)
-    expect(ids).toEqual([`2024-roadmap`, `2024-roadmap-1`])
-    expect(container.querySelectorAll(anchor_selector)).toHaveLength(2)
-  })
-
-  it.each<[string, string, string, boolean]>([
-    [`direct child`, `<h2 id="dc">X</h2>`, `#dc`, true],
-    [`2nd-level (grandchild)`, `<div><h2 id="gc">X</h2></div>`, `#gc`, true],
-    [
-      `3rd-level (too deep)`,
-      `<div><section><h2 id="deep">X</h2></section></div>`,
-      `#deep`,
-      false,
-    ],
-  ])(`default selector: %s → matched: %s`, (_desc, html, id_sel, should_match) => {
-    const container = create_container(html)
-    heading_anchors()(container)
-    const anchor = document.querySelector(`${id_sel} ${anchor_selector}`)
-    if (should_match) expect(anchor).toBeInstanceOf(HTMLAnchorElement)
-    else expect(anchor).toBeNull()
-  })
-
-  it(`processes direct child before a later sibling's grandchild (duplicate-id order)`, () => {
-    // guards get_default_headings ordering: a direct-child heading must be processed
-    // before a grandchild in a later sibling, so the duplicate suffix lands on the grandchild
-    const container = create_container(`<h2>Dup</h2><div><h3>Dup</h3></div>`)
-    heading_anchors()(container)
-    const ids = Array.from(container.querySelectorAll(`h2, h3`)).map((el) => el.id)
-    expect(ids).toEqual([`dup`, `dup-1`])
   })
 
   it(`adds anchors to dynamically inserted headings`, async () => {
@@ -186,9 +255,7 @@ describe(`heading_anchors attachment`, () => {
   })
 
   it(`cleanup disconnects observer and stops processing`, async () => {
-    // Use isolated container with custom selector to avoid interference from other tests
-    const container = document.createElement(`div`)
-    document.body.append(container)
+    const container = create_container()
     const cleanup = heading_anchors({ selector: `h2` })(container)
     expect(cleanup).toBeTypeOf(`function`)
 
@@ -238,17 +305,6 @@ describe(`heading_anchors attachment`, () => {
     )
   })
 
-  it(`anchor has correct href, aria-hidden, and is appended last`, () => {
-    const container = create_container(
-      `<h2 id="my-heading">Test <span>Content</span></h2>`,
-    )
-    heading_anchors()(container)
-    const anchor = container.querySelector(`h2 a`)
-    expect(anchor?.getAttribute(`href`)).toBe(`#my-heading`)
-    expect(anchor?.getAttribute(`aria-hidden`)).toBe(`true`)
-    expect(container.querySelector(`h2`)?.lastElementChild?.tagName).toBe(`A`)
-  })
-
   it(`returns undefined in SSR (no document)`, () => {
     const dummy = document.createElement(`div`)
     const original = globalThis.document
@@ -266,19 +322,19 @@ describe(`heading_anchors attachment`, () => {
     }
   })
 
-  it.each([
-    [`whitespace with id`, `<h2 id="spaces">   </h2>`, undefined, `#spaces`],
-    [
-      `deeply nested with custom selector`,
-      `<div><section><h2 id="deep">X</h2></section></div>`,
-      `h2`,
-      `#deep`,
-    ],
-  ])(`%s → href %s`, (_desc, html, selector, expected_href) => {
+  const deeply_nested = `<div><section><h2 id="deep">X</h2></section></div>`
+  it.each<[string, string, string | undefined, string | null]>([
+    // the default selector uses :scope, so it reaches direct children and grandchildren only
+    [`direct child`, `<h2 id="dc">X</h2>`, undefined, `#dc`],
+    [`2nd-level (grandchild)`, `<div><h2 id="gc">X</h2></div>`, undefined, `#gc`],
+    [`3rd-level (too deep)`, deeply_nested, undefined, null],
+    [`3rd-level via custom selector`, deeply_nested, `h2`, `#deep`],
+    // an explicit id is used verbatim, even when the heading text is only whitespace
+    [`whitespace text with id`, `<h2 id="spaces">   </h2>`, undefined, `#spaces`],
+  ])(`anchors a heading: %s`, (_desc, html, selector, expected_href) => {
     const container = create_container(html)
     heading_anchors({ selector })(container)
-    expect(container.querySelector(anchor_selector)?.getAttribute(`href`)).toBe(
-      expected_href,
-    )
+    const href = container.querySelector(anchor_selector)?.getAttribute(`href`) ?? null
+    expect(href).toBe(expected_href)
   })
 })

--- a/tests/vitest/heading-anchors.test.ts
+++ b/tests/vitest/heading-anchors.test.ts
@@ -5,8 +5,8 @@ import { doc_query } from './index'
 const preprocess = (content: string, filename?: string) =>
   heading_ids().markup({ content, filename })
 
-// Decode VLQ here rather than reuse the encoder under test, so a self-consistent but wrong
-// encoding can't pass. Returns [generated_column, source_line, source_column] per segment.
+// Decoded independently of the encoder under test, so a self-consistent but wrong
+// encoding can't pass. Yields [generated_column, source_line, source_column] per segment.
 const decode_mappings = (mappings: string): [number, number, number][][] => {
   const base64 = `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/`
   let source_line = 0
@@ -51,8 +51,7 @@ describe(`heading_ids preprocessor`, () => {
     })
   })
 
-  // Svelte preprocessors that rewrite markup without an accurate map make every downstream
-  // diagnostic point at the wrong place; svelte-check-rs rejects such components outright.
+  // an inaccurate map sends every downstream diagnostic to the wrong place
   it.each([
     [`one heading per line`, `<h2>A</h2>\n<h2>B</h2>`],
     [`indented heading`, `<div>\n  <h2>Nested</h2>\n</div>`],
@@ -90,9 +89,8 @@ describe(`heading_ids preprocessor`, () => {
         expect(original, `line ${line_idx} col ${generated_column}`).toBe(generated)
       })
 
-      // A shifted line must close with a segment mapping its new end to the original end,
-      // else consumers resolve end-of-line positions back to the pre-shift column.
-      // Only insertions change a line's length, so differing lengths means it shifted.
+      // A shifted line (only insertions change length) must close with a segment mapping
+      // its new end to the original, else end-of-line resolves to the pre-shift column.
       if (generated_line.length !== source_line.length) {
         const last_segment = segments.at(-1)
         expect([last_segment?.[0], last_segment?.[2]], `line ${line_idx} end`).toEqual([
@@ -101,8 +99,7 @@ describe(`heading_ids preprocessor`, () => {
         ])
       }
     }
-    // every id the preprocessor added must show up as its own span, so a map that silently
-    // drops insertions can't pass by having nothing left to contradict
+    // every inserted id must appear as its own span, so dropping them can't pass
     const count_ids = (text: string) => (text.match(/ id="/gu) ?? []).length
     expect(mapped_insertions).toBe(count_ids(code) - count_ids(source))
   })

--- a/tests/vitest/live-examples/hast.test.ts
+++ b/tests/vitest/live-examples/hast.test.ts
@@ -5,6 +5,9 @@ describe(`escape_html_text`, () => {
   test.each([
     [`<span>Fish & Chips</span>`, `&lt;span&gt;Fish &amp; Chips&lt;/span&gt;`],
     [`5 > 3 && 2 < 4`, `5 &gt; 3 &amp;&amp; 2 &lt; 4`],
+    // text with nothing to escape takes a fast path and must come back unchanged
+    [`const value = "plain 123"`, `const value = "plain 123"`],
+    [``, ``],
   ])(`escapes %j`, (input, expected) => {
     expect(escape_html_text(input)).toBe(expected)
   })

--- a/tests/vitest/portal.test.ts
+++ b/tests/vitest/portal.test.ts
@@ -45,9 +45,14 @@ test(`hides synchronously when open flips false`, () => {
   action.update({ active: true, open: false, target_node: target })
   expect(node.hidden).toBe(true)
 
-  // deactivating must not un-hide a dropdown that is still closed
+  // deactivating hands visibility back to the consumer's own markup. Latching the
+  // closed state here instead would stick: update() stops touching `hidden` once the
+  // node is home, so reopening with the portal still off could never show it again.
   action.update({ active: false, open: false, target_node: target })
-  expect(node.hidden).toBe(true)
+  expect(node.hidden).toBe(false)
+
+  action.update({ active: false, open: true, target_node: target })
+  expect(node.hidden).toBe(false)
   action.destroy()
 })
 

--- a/tests/vitest/portal.test.ts
+++ b/tests/vitest/portal.test.ts
@@ -51,6 +51,24 @@ test(`hides synchronously when open flips false`, () => {
   action.destroy()
 })
 
+// target_node is a positioning concern, so it decides visibility only while the
+// node is portalled. Once it is back home, `open` alone governs.
+test(`losing the target hides while portalled but not once deactivated`, () => {
+  const { home, target, node } = create_fixture()
+  const action = portal_action(node, { active: true, open: true, target_node: target })
+  expect(node.hidden).toBe(false)
+
+  // still portalled with nowhere to anchor: there is no sane position to paint at
+  action.update({ active: true, open: true, target_node: null })
+  expect(node.hidden).toBe(true)
+
+  // back in the component, an open dropdown renders inline and needs no target
+  action.update({ active: false, open: true, target_node: null })
+  expect(node.parentNode).toBe(home)
+  expect(node.hidden).toBe(false)
+  action.destroy()
+})
+
 test(`destroy detaches viewport listeners only when portalled`, () => {
   const { home, target, node } = create_fixture()
   const remove_spy = vi.spyOn(globalThis, `removeEventListener`)

--- a/tests/vitest/portal.test.ts
+++ b/tests/vitest/portal.test.ts
@@ -51,18 +51,17 @@ test(`hides synchronously when open flips false`, () => {
   action.destroy()
 })
 
-// target_node is a positioning concern, so it decides visibility only while the
-// node is portalled. Once it is back home, `open` alone governs.
+// target_node is positioning only: it gates visibility while portalled, not at home
 test(`losing the target hides while portalled but not once deactivated`, () => {
   const { home, target, node } = create_fixture()
   const action = portal_action(node, { active: true, open: true, target_node: target })
   expect(node.hidden).toBe(false)
 
-  // still portalled with nowhere to anchor: there is no sane position to paint at
+  // portalled with nowhere to anchor: no sane position to paint at
   action.update({ active: true, open: true, target_node: null })
   expect(node.hidden).toBe(true)
 
-  // back in the component, an open dropdown renders inline and needs no target
+  // back home, an open dropdown renders inline and needs no target
   action.update({ active: false, open: true, target_node: null })
   expect(node.parentNode).toBe(home)
   expect(node.hidden).toBe(false)

--- a/tests/vitest/portal.test.ts
+++ b/tests/vitest/portal.test.ts
@@ -44,6 +44,10 @@ test(`hides synchronously when open flips false`, () => {
 
   action.update({ active: true, open: false, target_node: target })
   expect(node.hidden).toBe(true)
+
+  // deactivating must not un-hide a dropdown that is still closed
+  action.update({ active: false, open: false, target_node: target })
+  expect(node.hidden).toBe(true)
   action.destroy()
 })
 

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -151,14 +151,12 @@ describe(`keyboard shortcut parsing`, () => {
 
   test(`parse_shortcut hands back an object the caller owns`, () => {
     const event = new KeyboardEvent(`keydown`, { key: `k`, ctrlKey: true })
-    // prime the parse cache matches_shortcut keeps, so the next parse_shortcut
-    // call would be a cache hit if the two ever shared storage
+    // prime the cache matches_shortcut keeps, so a shared store would be hit next
     expect(matches_shortcut(event, `ctrl+k`)).toBe(true)
 
     const parsed = parse_shortcut(`ctrl+k`)
     parsed.key = `mutated`
-    // handing out the cached object would let this mutation poison every later
-    // parse of the same shortcut, and matches_shortcut along with it
+    // handing out the cached object would let this poison every later parse
     expect(parse_shortcut(`ctrl+k`).key).toBe(`k`)
     expect(matches_shortcut(event, `ctrl+k`)).toBe(true)
   })
@@ -167,8 +165,7 @@ describe(`keyboard shortcut parsing`, () => {
     const event = new KeyboardEvent(`keydown`, { key: `k`, ctrlKey: true })
     const matches = () =>
       [`ctrl+k`, `meta+k`, `ctrl+shift+k`].map((sc) => matches_shortcut(event, sc))
-    // the second pass is all cache hits, where a cache keyed on anything but the
-    // shortcut string would start handing back a neighbour's parse
+    // second pass is all cache hits, where a mis-keyed cache returns a neighbour
     expect(matches()).toEqual([true, false, false])
     expect(matches()).toEqual([true, false, false])
   })
@@ -216,8 +213,7 @@ describe(`fuzzy_match`, () => {
     [`#`, `#hashtag`, true],
     [`/`, `path/to/file`, true],
     [`form submit`, `form\n submit`, true],
-    // whitespace normalization: runs collapse in the search, every whitespace
-    // character maps to a plain space in the target
+    // runs collapse in the search; every whitespace char maps to a space in the target
     [`a  b`, `a b`, true],
     [`a b`, `a\tb`, true],
     [`a\tb`, `a b`, true],

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -164,17 +164,13 @@ describe(`keyboard shortcut parsing`, () => {
   })
 
   test(`memoized parses stay distinct across interleaved shortcuts`, () => {
-    const shortcuts = [`ctrl+k`, `meta+k`, `ctrl+shift+k`]
     const event = new KeyboardEvent(`keydown`, { key: `k`, ctrlKey: true })
-    // repeat so every lookup past the first round is a cache hit - a cache keyed
-    // on anything but the shortcut string would start returning the wrong parse
-    for (let round = 0; round < 3; round++) {
-      expect(shortcuts.map((shortcut) => matches_shortcut(event, shortcut))).toEqual([
-        true,
-        false,
-        false,
-      ])
-    }
+    const matches = () =>
+      [`ctrl+k`, `meta+k`, `ctrl+shift+k`].map((sc) => matches_shortcut(event, sc))
+    // the second pass is all cache hits, where a cache keyed on anything but the
+    // shortcut string would start handing back a neighbour's parse
+    expect(matches()).toEqual([true, false, false])
+    expect(matches()).toEqual([true, false, false])
   })
 
   test.each([

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -147,22 +147,34 @@ describe(`keyboard shortcut parsing`, () => {
     [`ctrl+shift+k`, { key: `k`, ctrl: true, shift: true, alt: false, meta: false }],
   ])(`parse_shortcut(%j)`, (shortcut, expected) => {
     expect(parse_shortcut(shortcut)).toEqual(expected)
-    // parses are memoized by shortcut string, so a repeat call must not return
-    // another shortcut's cached parse
-    expect(parse_shortcut(shortcut)).toEqual(expected)
+  })
+
+  test(`parse_shortcut hands back an object the caller owns`, () => {
+    const event = new KeyboardEvent(`keydown`, { key: `k`, ctrlKey: true })
+    // prime the parse cache matches_shortcut keeps, so the next parse_shortcut
+    // call would be a cache hit if the two ever shared storage
+    expect(matches_shortcut(event, `ctrl+k`)).toBe(true)
+
+    const parsed = parse_shortcut(`ctrl+k`)
+    parsed.key = `mutated`
+    // handing out the cached object would let this mutation poison every later
+    // parse of the same shortcut, and matches_shortcut along with it
+    expect(parse_shortcut(`ctrl+k`).key).toBe(`k`)
+    expect(matches_shortcut(event, `ctrl+k`)).toBe(true)
   })
 
   test(`memoized parses stay distinct across interleaved shortcuts`, () => {
-    const shortcuts = [`ctrl+k`, `meta+k`, `ctrl+shift+k`, `k`]
-    const first_pass = shortcuts.map(parse_shortcut)
-    // re-parse in reverse: a cache keyed on anything but the string would swap results
-    expect(shortcuts.toReversed().map(parse_shortcut).toReversed()).toEqual(first_pass)
-    expect(first_pass).toEqual([
-      { key: `k`, ctrl: true, shift: false, alt: false, meta: false },
-      { key: `k`, ctrl: false, shift: false, alt: false, meta: true },
-      { key: `k`, ctrl: true, shift: true, alt: false, meta: false },
-      { key: `k`, ctrl: false, shift: false, alt: false, meta: false },
-    ])
+    const shortcuts = [`ctrl+k`, `meta+k`, `ctrl+shift+k`]
+    const event = new KeyboardEvent(`keydown`, { key: `k`, ctrlKey: true })
+    // repeat so every lookup past the first round is a cache hit - a cache keyed
+    // on anything but the shortcut string would start returning the wrong parse
+    for (let round = 0; round < 3; round++) {
+      expect(shortcuts.map((shortcut) => matches_shortcut(event, shortcut))).toEqual([
+        true,
+        false,
+        false,
+      ])
+    }
   })
 
   test.each([

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -147,6 +147,22 @@ describe(`keyboard shortcut parsing`, () => {
     [`ctrl+shift+k`, { key: `k`, ctrl: true, shift: true, alt: false, meta: false }],
   ])(`parse_shortcut(%j)`, (shortcut, expected) => {
     expect(parse_shortcut(shortcut)).toEqual(expected)
+    // parses are memoized by shortcut string, so a repeat call must not return
+    // another shortcut's cached parse
+    expect(parse_shortcut(shortcut)).toEqual(expected)
+  })
+
+  test(`memoized parses stay distinct across interleaved shortcuts`, () => {
+    const shortcuts = [`ctrl+k`, `meta+k`, `ctrl+shift+k`, `k`]
+    const first_pass = shortcuts.map(parse_shortcut)
+    // re-parse in reverse: a cache keyed on anything but the string would swap results
+    expect(shortcuts.toReversed().map(parse_shortcut).toReversed()).toEqual(first_pass)
+    expect(first_pass).toEqual([
+      { key: `k`, ctrl: true, shift: false, alt: false, meta: false },
+      { key: `k`, ctrl: false, shift: false, alt: false, meta: true },
+      { key: `k`, ctrl: true, shift: true, alt: false, meta: false },
+      { key: `k`, ctrl: false, shift: false, alt: false, meta: false },
+    ])
   })
 
   test.each([
@@ -192,7 +208,13 @@ describe(`fuzzy_match`, () => {
     [`#`, `#hashtag`, true],
     [`/`, `path/to/file`, true],
     [`form submit`, `form\n submit`, true],
+    // whitespace normalization: runs collapse in the search, every whitespace
+    // character maps to a plain space in the target
     [`a  b`, `a b`, true],
+    [`a b`, `a\tb`, true],
+    [`a\tb`, `a b`, true],
+    [`a b`, `a\u00A0b`, true],
+    [`a b c`, `a\t\nb  c`, true],
     // Numbers and unicode
     [`123`, `abc123def`, true],
     [`ñ`, `niño`, true],

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -149,27 +149,6 @@ describe(`keyboard shortcut parsing`, () => {
     expect(parse_shortcut(shortcut)).toEqual(expected)
   })
 
-  test(`parse_shortcut hands back an object the caller owns`, () => {
-    const event = new KeyboardEvent(`keydown`, { key: `k`, ctrlKey: true })
-    // prime the cache matches_shortcut keeps, so a shared store would be hit next
-    expect(matches_shortcut(event, `ctrl+k`)).toBe(true)
-
-    const parsed = parse_shortcut(`ctrl+k`)
-    parsed.key = `mutated`
-    // handing out the cached object would let this poison every later parse
-    expect(parse_shortcut(`ctrl+k`).key).toBe(`k`)
-    expect(matches_shortcut(event, `ctrl+k`)).toBe(true)
-  })
-
-  test(`memoized parses stay distinct across interleaved shortcuts`, () => {
-    const event = new KeyboardEvent(`keydown`, { key: `k`, ctrlKey: true })
-    const matches = () =>
-      [`ctrl+k`, `meta+k`, `ctrl+shift+k`].map((sc) => matches_shortcut(event, sc))
-    // second pass is all cache hits, where a mis-keyed cache returns a neighbour
-    expect(matches()).toEqual([true, false, false])
-    expect(matches()).toEqual([true, false, false])
-  })
-
   test.each([
     [`ctrl++`, { key: `+`, ctrlKey: true }, true],
     [`ctrl++`, { key: `+`, ctrlKey: true, shiftKey: true }, true],


### PR DESCRIPTION
Two strands of work: behavior-preserving performance work on the hot paths, and a set of input-handling and edge-case fixes. No public API changes.

## Performance

`fuzzy_match_indices` backs the default `filterFunc`, `CommandMenu`'s matcher and `highlight_matches`, so it runs once per option on every keystroke. It normalized whitespace by rebuilding both strings with `replaceAll(/\s/gu, ' ')` unconditionally, which profiling showed was the single dominant cost — option labels almost never contain tabs, newlines or runs of spaces. Both rewrites are now guarded by a test that bails on the first offending character, and the subsequence scan delegates to native `indexOf` rather than an interpreted per-code-unit loop. The scan cursor only moves forward, so total scanned length stays linear in the target.

`matches_shortcut` re-parsed every registered shortcut string on every keydown. `parse_shortcut` is pure and keyed by an immutable string, so it is now memoized, bounded at 1000 entries so callers generating shortcuts dynamically can't grow the map without limit.

On the build side, `hast_to_html` walks every syntax-highlighted token of every code block: `escape_html_text` now skips its three `replaceAll` passes when there is nothing to escape, and children are concatenated in place instead of allocating an array to `join` at each node. `strip_svelte_expressions` rebuilt every heading character by character even with no `{` to strip, the heading preprocessor ran two whole-file regex passes with a lazy body before discovering a file has no headings, and `collect_nodes` recursed into every AST property value, most of which are primitives.

Median of best-of-3 processes, each case in its own process with OLD/NEW batches interleaved in alternating order. Measuring variants sequentially rather than interleaved swung identical code by up to 2x, so several early readings were discarded as artifacts.

| Case | Before | After | Speedup |
|---|---|---|---|
| `matches_shortcut`, 500 actions per keydown | 25.2 µs | 3.6 µs | 7.01x |
| `strip_svelte_expressions`, 1000 headings | 150.8 µs | 24.5 µs | 6.14x |
| `hast_to_html`, 1365 nodes, nothing to escape | 159.3 µs | 41.0 µs | 3.88x |
| `find_ranges` offset-map check, 2000 text nodes | 141.2 µs | 38.9 µs | 3.64x |
| `cmd_action_matches` fuzzy, 500 actions per keystroke | 634.6 µs | 238.1 µs | 2.66x |
| `fuzzy_match`, 2000 option labels per keystroke | 311.0 µs | 127.8 µs | 2.43x |
| `fuzzy_match_indices`, 2000 option labels | 302.4 µs | 125.1 µs | 2.42x |
| `heading_ids` markup, file with no headings | 156.3 µs | 100.7 µs | 1.55x |
| `collect_nodes` AST walk, per transform | 3289.1 µs | 2671.5 µs | 1.23x |
| `hast_to_html`, 1365 nodes with `& < >` | 283.8 µs | 253.4 µs | 1.12x |

Two caveats. The `find_ranges` change measures **1.00x end-to-end**: against a real 400-option list in happy-dom, TreeWalker and Range work dominates at ~11 ms per pass and dwarfs the ~30 µs saved. It is kept only because it is four lines and strictly non-negative. And the `fuzzy={false}` substring path is unchanged — it never touches `fuzzy_match`, and the micro-optimizations that would have given it 1.33x cost ~35 lines and a module-level mutable cache for 3–8%, so they were dropped for the smaller diff.

## Fixes

**Keyboard.** A modifier-free action hotkey is an ordinary character when focus sits in a text field, so running it both triggered the action and swallowed the keystroke; `CommandMenu` now ignores unmodified hotkeys on editable targets. `PrevNext` had its own copy of that editable-target check, now hoisted to `utils` and shared, and it claimed Alt+Arrow — the browser's Back/Forward chord — so page navigation raced with history navigation.

**Chip removal.** Removing a chip dropped the first option matching its label, so with `duplicates` enabled clicking any duplicate's remove button removed the wrong one; the chip's index is now passed through to `remove()`. The remove-all button also rendered when `minSelect` forbade removing anything.

**Blank duplicate message.** An empty `duplicateOptionMsg` produced a row that rendered nothing yet stayed navigable, so ArrowDown past the last option left `aria-activedescendant` pointing at an element that never existed — and it suppressed the create row too.

**Drag, portal, clipboard.** `draggable`/`resizable` started on any mouse button, so a right-click began a drag whose mouseup the context menu could swallow, leaving the element stuck to the cursor. Portal cleanup unhid the dropdown unconditionally, revealing a closed dropdown on teardown. And a throwing `on_copy_success` callback was caught by the clipboard `try`/`catch`, so a successful copy was reported as an error and the reset timer never ran.

## Correctness

Every function changed for performance was fuzzed against a pristine copy of its pre-change implementation over **233,075 inputs** covering astral characters, lone surrogates, `İ`/`ß` special casing, non-breaking spaces and brace-heavy strings, with zero differences.

The subsequence scan deliberately indexes by UTF-16 code unit rather than using `for...of`, which the linter suggests: iterating code points matches an astral character as a single unit and emits one index where callers expect two, which would change emoji highlight ranges. There is a comment and a scoped lint disable on that line.

New coverage targets the added branches: whitespace-normalization cases in `fuzzy_match`, a no-op case for `escape_html_text`, and an interleaved `parse_shortcut` test that would catch a cache keyed on anything but the string. Forcing the whitespace guards to `false` fails five tests, confirming they are not vacuous. The blank-`duplicateOptionMsg` test was tightened from a conditional assertion that passed vacuously into one that fails when the source fix is reverted. The heading-anchor source map tests now decode mappings with a decoder written independently of the encoder under test, so a self-consistent but wrong encoding can no longer pass.

## Note on a flaky test

`FileDetails.svelte.test.ts > syntax highlighting produces starry-night spans` timed out twice while other heavy processes were running (those runs took 33–50s versus the usual 8–12s). It passes 3/3 in isolation and 3/3 in the full suite on a quiet machine. The failure is `Test timed out in 5000ms` while awaiting starry-night's 34-grammar async import, and nothing here is async — but the 5s default timeout is tight enough on that test that it may be worth raising separately.