### PR TITLE
Dismiss click_outside on pointerdown, add escape and scope options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1052,14 +1052,38 @@ This package also provides subpath exports for utilities used by the component:
 
 ```ts
 import {
-  click_outside,
+  click_outside, // dismiss a surface when a press lands outside it
   draggable,
+  float, // park an element next to an anchor and keep it there
+  focus_trap, // keep Tab inside a surface, hand focus back when it closes
   highlight_matches,
+  hotkey, // declarative keybindings, `mod` maps to Cmd or Ctrl
   sortable,
   tooltip,
 } from 'svelte-multiselect/attachments'
-import { fuzzy_match, get_label } from 'svelte-multiselect/utils'
+import { compute_position, fuzzy_match, get_label } from 'svelte-multiselect/utils'
 import { heading_anchors } from 'svelte-multiselect/heading-anchors'
+```
+
+`Popover` and `ContextMenu` compose these three: a surface positioned by `float`,
+dismissed by `click_outside` (on the press, so a right-click closes it too) and
+keyboard-scoped by `focus_trap`.
+
+```svelte
+<script lang="ts">
+  import { ContextMenu, Popover } from 'svelte-multiselect'
+</script>
+
+<Popover placement="bottom" align="start">
+  {#snippet trigger(props)}
+    <button {...props}>Options</button>
+  {/snippet}
+  <p>Anything you like in here.</p>
+</Popover>
+
+<ContextMenu actions={[{ label: `Reload`, action: () => location.reload() }]}>
+  <div>Right-click anywhere in this region</div>
+</ContextMenu>
 ```
 
 See [src/lib/live-examples/readme.md](https://github.com/janosh/svelte-multiselect/blob/-/src/lib/live-examples/readme.md) for optional live-example helpers.

--- a/src/lib/CommandMenu.svelte
+++ b/src/lib/CommandMenu.svelte
@@ -4,13 +4,12 @@
   import { fade } from 'svelte/transition'
   import MultiSelect from './MultiSelect.svelte'
   import type { CmdAction, MultiSelectProps } from './types'
+  import type { Hotkey } from './utils'
   import {
     cmd_action_matches,
     chain_handlers,
     format_cmd_metadata,
-    is_editable_event_target,
-    is_modifier_chord,
-    matches_shortcut,
+    run_hotkeys,
     split_shortcut,
   } from './utils'
 
@@ -212,16 +211,28 @@
     search_text = ``
   }
 
-  function toggle(event: KeyboardEvent): boolean {
-    const should_open =
-      !open && triggers.includes(event.key) && (event.metaKey || event.ctrlKey)
-    const should_close = open && close_keys.includes(event.key)
-    if (!should_open && !should_close) return false
-    event.preventDefault()
-    if (should_open) open = true
-    else close_menu()
-    return true
-  }
+  // Cmd and Ctrl both open the menu on every platform, so `mod` is too narrow here
+  const open_shortcuts = $derived(
+    triggers.flatMap((key) => [`meta+${key}`, `ctrl+${key}`]),
+  )
+  const toggle_bindings = $derived<Hotkey[]>([
+    { keys: open_shortcuts, handler: () => (open = true), enabled: !open },
+    // Escape has to work while the search input has focus, hence allow_in_inputs
+    { keys: close_keys, handler: close_menu, enabled: open, allow_in_inputs: true },
+  ])
+  // Bare action shortcuts stay inert while the menu is up: there the keyboard
+  // belongs to the search input. An action without a shortcut has no keys to match.
+  const key_bindings = $derived<Hotkey[]>([
+    ...toggle_bindings,
+    ...actions.map((action) => ({
+      keys: action.shortcut ?? ``,
+      enabled: global_shortcuts && !open && !action.disabled,
+      handler: () => {
+        record_recent(action)
+        action.action(action.label)
+      },
+    })),
+  ])
 
   function handle_dialog_cancel(event: DialogEvent) {
     if (!close_keys.includes(`Escape`)) event.preventDefault()
@@ -229,21 +240,9 @@
   }
 
   function handle_window_keydown(event: KeyboardEvent) {
-    const is_close_key = open && close_keys.includes(event.key)
-    if (event.defaultPrevented && !is_close_key) return
-    if (toggle(event)) return
-    if (open || !global_shortcuts) return
-    // outside a chord the keystroke is ordinary typing, so firing the action would
-    // both run it and swallow the character
-    if (!is_modifier_chord(event) && is_editable_event_target(event.target)) return
-    const action = actions.find(
-      (cmd_action) =>
-        !cmd_action.disabled && matches_shortcut(event, cmd_action.shortcut),
-    )
-    if (!action) return
-    event.preventDefault()
-    record_recent(action)
-    action.action(action.label)
+    // a close key still lands after another handler already called preventDefault
+    if (event.defaultPrevented && !(open && close_keys.includes(event.key))) return
+    run_hotkeys(event, key_bindings)
   }
 
   function close_if_outside(event: MouseEvent) {
@@ -327,7 +326,7 @@
       key={get_action_key}
       onadd={trigger_action_and_close}
       onkeydown={(event) => {
-        toggle(event)
+        run_hotkeys(event, toggle_bindings)
         onkeydown?.(event)
       }}
       option={option_snippet ?? (has_action_meta ? action_item : undefined)}

--- a/src/lib/CommandMenu.svelte
+++ b/src/lib/CommandMenu.svelte
@@ -9,8 +9,8 @@
     cmd_action_matches,
     chain_handlers,
     format_cmd_metadata,
+    format_shortcut,
     run_hotkeys,
-    split_shortcut,
   } from './utils'
 
   // MultiSelect's option snippet param (option + idx/selected/active/disabled)
@@ -154,34 +154,6 @@
         (rank.get(get_action_id(right_action)) ?? actions.length),
     )
   })
-
-  // === Shortcut display ===
-  // Map shortcut segments to display symbols (deterministic across platforms)
-  const key_symbols: Record<string, string> = {
-    meta: `⌘`,
-    cmd: `⌘`,
-    shift: `⇧`,
-    alt: `⌥`,
-    ctrl: `Ctrl`,
-    enter: `↵`,
-    backspace: `⌫`,
-    delete: `⌦`,
-    escape: `Esc`,
-    arrowup: `↑`,
-    arrowdown: `↓`,
-    arrowleft: `←`,
-    arrowright: `→`,
-  }
-  const format_shortcut = (shortcut: string): string[] =>
-    split_shortcut(shortcut).map((part) => {
-      const key_segment = part.trim().toLowerCase()
-      // title-case unknown multi-char segments, upper-case single chars (empty stays empty)
-      const title_case = key_segment.charAt(0).toUpperCase() + key_segment.slice(1)
-      return (
-        key_symbols[key_segment] ??
-        (key_segment.length > 1 ? title_case : key_segment.toUpperCase())
-      )
-    })
 
   // Dynamic actions may contain metadata not present in the static action list.
   const has_action_meta = $derived(

--- a/src/lib/ContextMenu.svelte
+++ b/src/lib/ContextMenu.svelte
@@ -3,7 +3,7 @@
   import type { HTMLAttributes } from 'svelte/elements'
   import { click_outside, float, focus_trap } from './attachments'
   import type { CmdAction } from './types'
-  import { split_shortcut } from './utils'
+  import { format_shortcut } from './utils'
 
   interface Props extends HTMLAttributes<HTMLMenuElement> {
     actions: CmdAction[]
@@ -36,7 +36,6 @@
   }
 
   function run(action: CmdAction) {
-    if (action.disabled) return
     at = null
     action.action(action.label)
     on_select?.(action)
@@ -74,7 +73,7 @@
             <span>{action.label}</span>
             {#if action.shortcut}
               <span aria-hidden="true">
-                {#each split_shortcut(action.shortcut) as part, idx (idx)}
+                {#each format_shortcut(action.shortcut) as part, idx (idx)}
                   <kbd>{part}</kbd>
                 {/each}
               </span>

--- a/src/lib/ContextMenu.svelte
+++ b/src/lib/ContextMenu.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
+  import { click_outside, float, focus_trap } from './attachments'
+  import type { CmdAction } from './types'
+  import { split_shortcut } from './utils'
+
+  interface Props extends HTMLAttributes<HTMLMenuElement> {
+    actions: CmdAction[]
+    // Where the menu is open, as viewport coordinates. null while closed.
+    at?: { x: number; y: number } | null
+    // Region the right-click applies to. Omit and the whole document qualifies.
+    children?: Snippet
+    disabled?: boolean
+    item?: Snippet<[{ action: CmdAction }]>
+    on_select?: (action: CmdAction) => void
+  }
+
+  let {
+    actions,
+    at = $bindable(null),
+    children,
+    disabled = false,
+    item,
+    on_select,
+    ...rest
+  }: Props = $props()
+
+  // A right-click is a zero-size anchor: the menu hangs off the pointer itself
+  const anchor = $derived(at && { top: at.y, bottom: at.y, left: at.x, right: at.x })
+
+  function open_at(event: MouseEvent) {
+    if (disabled || actions.length === 0) return
+    event.preventDefault() // replace the browser's own menu
+    at = { x: event.clientX, y: event.clientY }
+  }
+
+  function run(action: CmdAction) {
+    if (action.disabled) return
+    at = null
+    action.action(action.label)
+    on_select?.(action)
+  }
+</script>
+
+<svelte:body oncontextmenu={children ? undefined : open_at} />
+
+{#if children}
+  <!-- svelte-ignore a11y_no_static_element_interactions -- the menu itself carries the semantics; this is only the region a right-click applies to -->
+  <div oncontextmenu={open_at} style="display: contents">{@render children()}</div>
+{/if}
+
+{#if anchor}
+  <menu
+    role="menu"
+    {...rest}
+    class="context-menu {rest.class ?? ``}"
+    {@attach float({ anchor, placement: `bottom`, align: `start`, padding: 8 })}
+    {@attach click_outside({ escape: true, callback: () => (at = null) })}
+    {@attach focus_trap()}
+  >
+    {#each actions as action (action.id ?? action.label)}
+      <li role="none">
+        <button
+          type="button"
+          role="menuitem"
+          disabled={action.disabled}
+          title={action.description}
+          onclick={() => run(action)}
+        >
+          {#if item}
+            {@render item({ action })}
+          {:else}
+            <span>{action.label}</span>
+            {#if action.shortcut}
+              <span aria-hidden="true">
+                {#each split_shortcut(action.shortcut) as part, idx (idx)}
+                  <kbd>{part}</kbd>
+                {/each}
+              </span>
+            {/if}
+          {/if}
+        </button>
+      </li>
+    {/each}
+  </menu>
+{/if}
+
+<style>
+  .context-menu {
+    z-index: var(--context-menu-z-index, 20);
+    margin: 0;
+    padding: var(--context-menu-padding, 3pt);
+    list-style: none;
+    min-width: var(--context-menu-min-width, 10rem);
+    background: var(--context-menu-bg, var(--sms-options-bg, light-dark(#fff, #2a2a2e)));
+    border: var(--context-menu-border, 1px solid light-dark(lightgray, #555));
+    border-radius: var(--context-menu-radius, 5pt);
+    box-shadow: var(--context-menu-shadow, 0 3px 12px rgba(0, 0, 0, 0.3));
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1em;
+      width: 100%;
+      padding: var(--context-menu-item-padding, 3pt 6pt);
+      background: none;
+      border: none;
+      border-radius: 3pt;
+      color: inherit;
+      font: inherit;
+      text-align: left;
+      cursor: pointer;
+    }
+    button:hover:not(:disabled),
+    button:focus-visible {
+      background: var(--context-menu-item-hover-bg, rgba(255, 255, 255, 0.15));
+    }
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    kbd {
+      font-size: 0.8em;
+      opacity: 0.7;
+    }
+  }
+</style>

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -5,7 +5,7 @@
   import { flip } from 'svelte/animate'
   import type { FocusEventHandler } from 'svelte/elements'
   import { SvelteSet } from 'svelte/reactivity'
-  import { highlight_matches } from './attachments'
+  import { click_outside, highlight_matches } from './attachments'
   import CircleSpinner from './CircleSpinner.svelte'
   import Icon from './Icon.svelte'
   import { portal_action } from './portal'
@@ -1691,14 +1691,6 @@
       selected.length > selected_before ? { option: opt, idx: option_idx ?? null } : null
   }
 
-  function on_click_outside(event: MouseEvent | TouchEvent) {
-    if (!outerDiv || !(event.target instanceof Node)) return
-    if (outerDiv.contains(event.target)) return
-    // portalled dropdown lives outside outerDiv
-    if (portal_params?.active && ul_options?.contains(event.target)) return
-    close_dropdown(event)
-  }
-
   // === Drag, input, and paste handlers ===
   let drag_idx: number | null = $state(null)
   // chip index captured on dragstart: the authoritative drag source. Drops whose
@@ -2065,8 +2057,6 @@
   </button>
 {/snippet}
 
-<svelte:window onclick={on_click_outside} ontouchstart={on_click_outside} />
-
 <!-- svelte-ignore a11y_no_static_element_interactions -- the nested combobox input owns the interactive ARIA semantics -->
 <div
   bind:this={outerDiv}
@@ -2077,6 +2067,12 @@
   class:input-display={input_display}
   class="multiselect {outerDivClass} {rest.class ?? ``}"
   onmouseup={open_dropdown}
+  {@attach click_outside({
+    enabled: open,
+    // a portalled dropdown is no longer a descendant of this div
+    inside: [ul_options],
+    callback: (_node, _config, { event }) => close_dropdown(event),
+  })}
   title={disabled ? disabledInputTitle : null}
   data-id={id}
   tabindex="-1"

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -2,7 +2,7 @@
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import type { TooltipOptions } from './attachments'
-  import { click_outside, tooltip } from './attachments'
+  import { click_outside, focus_trap, tooltip } from './attachments'
   import Icon from './Icon.svelte'
   import type { NavRoute, NavRouteObject } from './types'
   import { chain_handlers, get_uuid } from './utils'
@@ -254,6 +254,14 @@
       (event: MouseEvent) => handle_link_click(event, route),
       link_props?.onclick,
     )
+  // Tabbing onto the toggle must not open the submenu: the toggle is also where focus
+  // lands when a dismissed submenu hands it back, which would reopen what the user
+  // just closed. Enter/Space/ArrowDown open it.
+  const dropdown_focusin_handler = (href: string) => (event: FocusEvent) => {
+    const { target } = event
+    if (target instanceof Element && target.closest(`[data-dropdown-toggle]`)) return
+    open_dropdown(href)
+  }
   const dropdown_item_keydown_handler = (parent_href: string) =>
     chain_handlers(
       (event: KeyboardEvent) => handle_dropdown_item_keydown(event, parent_href),
@@ -360,7 +368,7 @@
           data-href={parsed_route.href}
           onmouseenter={() => open_dropdown(parsed_route.href, true)}
           onmouseleave={() => schedule_hide(parsed_route.href, is_pinned)}
-          onfocusin={() => open_dropdown(parsed_route.href)}
+          onfocusin={dropdown_focusin_handler(parsed_route.href)}
           onfocusout={(event: FocusEvent) => {
             if (
               event.relatedTarget instanceof Node &&
@@ -429,6 +437,11 @@
                 return
               schedule_hide(parsed_route.href, is_pinned)
             }}
+            {@attach focus_trap({
+              enabled: is_pinned, // only a pinned submenu owns the keyboard
+              initial: false, // toggle_dropdown already picks the entry point
+              restore: dropdown_toggle(parsed_route.href) ?? false,
+            })}
           >
             {#each filtered_sub_routes as child_href (child_href)}
               {@const child_formatted = format_label(child_href, true)}

--- a/src/lib/Popover.svelte
+++ b/src/lib/Popover.svelte
@@ -76,7 +76,6 @@
     bind:this={surface}
     id={surface_id}
     role="dialog"
-    aria-modal="false"
     {...rest}
     class="popover {rest.class ?? ``}"
     {@attach float({ anchor, placement, align, offset, padding, match_width, strategy })}

--- a/src/lib/Popover.svelte
+++ b/src/lib/Popover.svelte
@@ -74,9 +74,9 @@
 {#if open}
   <div
     bind:this={surface}
-    id={surface_id}
     role="dialog"
     {...rest}
+    id={surface_id}
     class="popover {rest.class ?? ``}"
     {@attach float({ anchor, placement, align, offset, padding, match_width, strategy })}
     {@attach click_outside({

--- a/src/lib/Popover.svelte
+++ b/src/lib/Popover.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
+  import { click_outside, float, focus_trap, tabbable_selector } from './attachments'
+  import { get_uuid, type Placement } from './utils'
+
+  // Attributes for the trigger to spread, so consumers keep their own markup
+  type TriggerProps = {
+    onclick: (event: MouseEvent) => void
+    'aria-expanded': boolean
+    'aria-haspopup': `dialog`
+    'aria-controls': string
+  }
+
+  interface Props extends HTMLAttributes<HTMLDivElement> {
+    open?: boolean
+    placement?: Placement | `auto`
+    align?: `center` | `start`
+    offset?: number
+    padding?: number // closest the surface may come to a viewport edge
+    match_width?: boolean // size the surface to the trigger, for dropdown-like menus
+    // `fixed` escapes overflow: hidden ancestors but is clipped by a transformed one
+    strategy?: `fixed` | `absolute`
+    escape?: boolean
+    trap_focus?: boolean
+    surface?: HTMLDivElement | null
+    trigger?: Snippet<[TriggerProps]>
+    children: Snippet
+    on_close?: (detail: { via: `pointer` | `escape` | `trigger` }) => void
+  }
+
+  let {
+    open = $bindable(false),
+    placement = `bottom`,
+    align = `center`,
+    offset = 8,
+    padding = 8,
+    match_width = false,
+    strategy = `fixed`,
+    escape = true,
+    trap_focus = true,
+    surface = $bindable(null),
+    trigger,
+    children,
+    on_close,
+    ...rest
+  }: Props = $props()
+
+  const surface_id = `popover-${get_uuid()}`
+  let trigger_wrapper = $state<HTMLSpanElement | null>(null)
+  // The wrapper is `display: contents` and has no box of its own — measuring it would
+  // pin every popover to the viewport corner. Anchor to what the snippet rendered.
+  const anchor = $derived(trigger_wrapper?.firstElementChild ?? trigger_wrapper)
+
+  const close = (via: `pointer` | `escape` | `trigger`) => {
+    open = false
+    on_close?.({ via })
+  }
+
+  const trigger_props: TriggerProps = $derived({
+    // the press already went through click_outside, which counts the trigger as
+    // inside — so this click toggles rather than fighting a dismissal
+    onclick: () => (open ? close(`trigger`) : (open = true)),
+    'aria-expanded': open,
+    'aria-haspopup': `dialog`,
+    'aria-controls': surface_id,
+  })
+</script>
+
+<span bind:this={trigger_wrapper} style="display: contents">
+  {@render trigger?.(trigger_props)}
+</span>
+
+{#if open}
+  <div
+    bind:this={surface}
+    id={surface_id}
+    role="dialog"
+    aria-modal="false"
+    {...rest}
+    class="popover {rest.class ?? ``}"
+    {@attach float({ anchor, placement, align, offset, padding, match_width, strategy })}
+    {@attach click_outside({
+      inside: [trigger_wrapper],
+      escape,
+      callback: (_node, _config, { via }) => close(via),
+    })}
+    {@attach focus_trap({
+      enabled: trap_focus,
+      // hand the keyboard back to the trigger, not to wherever the pointer left it
+      restore: trigger_wrapper?.querySelector(tabbable_selector) ?? false,
+    })}
+  >
+    {@render children()}
+  </div>
+{/if}
+
+<style>
+  .popover {
+    z-index: var(--popover-z-index, 10);
+    background: var(--popover-bg, var(--sms-options-bg, light-dark(#fff, #2a2a2e)));
+    color: var(--popover-color, inherit);
+    border: var(--popover-border, 1px solid light-dark(lightgray, #555));
+    border-radius: var(--popover-radius, 5pt);
+    padding: var(--popover-padding, 6pt 8pt);
+    box-shadow: var(--popover-shadow, 0 3px 12px rgba(0, 0, 0, 0.3));
+    max-width: var(--popover-max-width, min(90vw, 30rem));
+  }
+</style>

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1159,36 +1159,75 @@ export const tooltip =
     return () => cleanup_functions.forEach((cleanup) => cleanup())
   }
 
-export type ClickOutsideConfig<T extends HTMLElement> = {
-  enabled?: boolean
-  exclude?: string[]
-  callback?: (node: T, config: ClickOutsideConfig<T>) => void
+export type ClickOutsideDetail = {
+  // Whether focus sat inside the node, so an Escape dismissal can hand focus back
+  // to the trigger instead of stranding it on a removed element
+  focus_inside: boolean
+  via: `pointer` | `escape`
 }
 
+export type ClickOutsideConfig<T extends HTMLElement> = {
+  enabled?: boolean
+  // Regions that count as inside though they sit outside the node — the trigger
+  // above all, whose own click toggles the surface right after this runs
+  exclude?: string[]
+  // Confines `exclude` matches to one subtree, so a second instance of the same
+  // component cannot shield this one's surface with its own trigger
+  scope?: Element | null
+  escape?: boolean // dismiss on Escape as well, reporting where focus was
+  callback?: (node: T, config: ClickOutsideConfig<T>, detail: ClickOutsideDetail) => void
+}
+
+// Dismiss a surface when a press lands outside it. Listens for `pointerdown`, not
+// `click`: a right-click fires no click at all, a press that hands a drag to the OS
+// (a custom titlebar) never produces one either, and a drag released outside reports
+// its click on the nearest common ancestor, dismissing a surface the user was only
+// resizing. Capture phase so a handler calling stopPropagation cannot suppress
+// dismissal; composedPath survives shadow DOM and targets detached mid-dispatch.
 export const click_outside =
   <T extends HTMLElement>(config: ClickOutsideConfig<T> = {}) =>
   (node: T): (() => void) | undefined => {
-    const { callback, enabled = true, exclude = [] } = config
+    const { callback, enabled = true, exclude = [], scope, escape = false } = config
 
     if (!enabled) return undefined // Early return avoids registering unused listener
 
-    function handle_click(event: MouseEvent) {
-      const { target } = event
+    const exclude_selector = exclude.join(`,`)
+    // `path` is empty for the focus check, which has no event to walk
+    const is_inside = (target: EventTarget | null, path: EventTarget[] = []): boolean => {
+      if (path.includes(node)) return true
       // Element (not HTMLElement) so clicks on SVG elements still count; .closest
       // below exists on all Elements
-      if (!(target instanceof Element)) return
-      const path = event.composedPath()
-
-      if (path.includes(node)) return
-      if (exclude.some((selector) => target.closest(selector))) return
-
-      callback?.(node, { callback, enabled, exclude })
-      node.dispatchEvent(new CustomEvent(`outside-click`))
+      if (!(target instanceof Element)) return false
+      if (node.contains(target)) return true
+      if (!exclude_selector) return false
+      const match = target.closest(exclude_selector)
+      return Boolean(match) && (!scope || scope.contains(match))
     }
 
-    document.addEventListener(`click`, handle_click, true)
+    const dismiss = (detail: ClickOutsideDetail) => {
+      callback?.(node, config, detail)
+      node.dispatchEvent(new CustomEvent(`outside-click`, { detail }))
+    }
+
+    function handle_press(event: PointerEvent) {
+      // A press never restores focus — the user already picked where it lands
+      if (!is_inside(event.target, event.composedPath())) {
+        dismiss({ focus_inside: false, via: `pointer` })
+      }
+    }
+
+    function handle_keydown(event: KeyboardEvent) {
+      if (event.key !== `Escape` || event.defaultPrevented) return
+      event.preventDefault()
+      event.stopPropagation()
+      dismiss({ focus_inside: is_inside(document.activeElement), via: `escape` })
+    }
+
+    document.addEventListener(`pointerdown`, handle_press, true)
+    if (escape) document.addEventListener(`keydown`, handle_keydown, true)
 
     return () => {
-      document.removeEventListener(`click`, handle_click, true)
+      document.removeEventListener(`pointerdown`, handle_press, true)
+      document.removeEventListener(`keydown`, handle_keydown, true)
     }
   }

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1216,20 +1216,20 @@ export const click_outside =
 
     if (!enabled) return undefined // Early return avoids registering unused listener
 
-    const inside_nodes = inside.filter((item) => item instanceof Element)
+    const inside_nodes = [node, ...inside.filter((item) => item instanceof Element)]
     // Empty entries would make the joined selector invalid and throw on every press
     const inside_selector = inside
       .filter((item): item is string => typeof item === `string` && item !== ``)
       .join(`,`)
     // `path` is empty for the focus check, which has no event to walk
     const is_inside = (target: EventTarget | null, path: EventTarget[] = []): boolean => {
-      if (path.includes(node)) return true
-      // Element (not HTMLElement) so clicks on SVG elements still count; .closest
-      // below exists on all Elements
-      if (!(target instanceof Element)) return false
-      if (node.contains(target)) return true
-      if (inside_nodes.some((el) => path.includes(el) || el.contains(target))) return true
-      const match = inside_selector ? target.closest(inside_selector) : null
+      const node_target = target instanceof Node ? target : null
+      if (inside_nodes.some((el) => path.includes(el) || el.contains(node_target))) {
+        return true
+      }
+      // Element (not HTMLElement) so a press on an SVG child still matches a selector
+      if (!inside_selector || !(target instanceof Element)) return false
+      const match = target.closest(inside_selector)
       return Boolean(match) && (!scope || scope.contains(match))
     }
 
@@ -1287,7 +1287,6 @@ export interface FloatOptions extends PositionOptions {
   // `absolute` survives that at the cost of adding page scroll to every update.
   strategy?: `fixed` | `absolute`
   match_width?: boolean // size the floating box to the anchor, for dropdowns
-  on_position?: (placement: Placement) => void
 }
 
 // Park an element next to an anchor and keep it there while the page moves.
@@ -1301,7 +1300,6 @@ export const float =
       enabled = true,
       strategy = `fixed`,
       match_width = false,
-      on_position,
       ...position_options
     } = options
     if (!enabled || !anchor || !(node instanceof HTMLElement)) return undefined
@@ -1325,7 +1323,6 @@ export const float =
         top: `${top + scroll_y}px`,
       })
       node.dataset.placement = placement
-      on_position?.(placement)
     }
 
     update()
@@ -1410,6 +1407,11 @@ const is_tabbable = (element: Element): boolean => {
 
 const register_trap_layer = key_layer_stack((event) => event.key === `Tab`)
 
+// Element has no focus(), so narrow to the two that do
+const focus_element = (element: Element | null | undefined) => {
+  if (element instanceof HTMLElement || element instanceof SVGElement) element.focus()
+}
+
 // Keep Tab inside a surface and hand focus back when it closes. Pair with
 // click_outside: that one decides when a surface goes away, this one decides where
 // the keyboard is while it is up and where it lands afterwards.
@@ -1441,7 +1443,7 @@ export const focus_trap =
         node.tabIndex = -1
         added_tabindex = true
       }
-      if (target instanceof HTMLElement || target instanceof SVGElement) target.focus()
+      focus_element(target)
     }
 
     const on_tab = (event: KeyboardEvent) => {
@@ -1471,7 +1473,6 @@ export const focus_trap =
       // Don't yank focus if the user already placed it elsewhere. A closing surface
       // usually leaves focus on body, which counts as ours to hand back.
       if (!holds_focus() && document.activeElement !== document.body) return
-      const target = restore ?? focus_origin
-      if (target instanceof HTMLElement || target instanceof SVGElement) target.focus()
+      focus_element(restore ?? focus_origin)
     }
   }

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1,5 +1,6 @@
 import type { Attachment } from 'svelte/attachments'
-import { fuzzy_match_indices, get_uuid } from './utils'
+import type { Hotkey, Placement, PositionOptions } from './utils'
+import { compute_position, fuzzy_match_indices, get_uuid, run_hotkeys } from './utils'
 // Computed CSS lengths resolve to `<number>px`; strip the unit so Number() can coerce.
 // Empty and non-px values (e.g. `none`, `0.5rem`) yield NaN so callers can apply fallbacks.
 const css_px = (css_length: string): number => {
@@ -743,7 +744,6 @@ export const tooltip =
       })
       observer.observe(element, { attributes: true, attributeFilter: tooltip_attrs })
 
-      type Placement = `top` | `right` | `bottom` | `left`
       const opposite: Record<Placement, Placement> = {
         top: `bottom`,
         bottom: `top`,
@@ -903,60 +903,17 @@ export const tooltip =
           }
 
           // Position tooltip after width adjustment so centering uses final dimensions
-          const rect = trigger.getBoundingClientRect()
-          const tooltip_rect = tooltip_el.getBoundingClientRect()
-          const margin = options.offset ?? 12
-
-          const center_h = rect.left + rect.width / 2 - tooltip_rect.width / 2
-          const center_v = rect.top + rect.height / 2 - tooltip_rect.height / 2
-
-          const position_by_placement: Record<Placement, { top: number; left: number }> =
-            {
-              top: { top: rect.top - tooltip_rect.height - margin, left: center_h },
-              bottom: { top: rect.bottom + margin, left: center_h },
-              left: { top: center_v, left: rect.left - tooltip_rect.width - margin },
-              right: { top: center_v, left: rect.right + margin },
-            }
-
-          const fallback_order: Record<Placement, Placement[]> = {
-            bottom: [`bottom`, `top`, `right`, `left`],
-            top: [`top`, `bottom`, `right`, `left`],
-            right: [`right`, `left`, `bottom`, `top`],
-            left: [`left`, `right`, `bottom`, `top`],
-          }
-
-          const min_padding = 8
-          const { innerWidth, innerHeight } = globalThis
-
-          const get_overflow = ({ top, left }: { top: number; left: number }) =>
-            Math.max(0, min_padding - top) +
-            Math.max(0, min_padding - left) +
-            Math.max(0, top + tooltip_rect.height + min_padding - innerHeight) +
-            Math.max(0, left + tooltip_rect.width + min_padding - innerWidth)
-
-          let chosen_placement = requested_placement
-          let best_overflow = Infinity
-          for (const candidate of fallback_order[requested_placement]) {
-            const overflow = get_overflow(position_by_placement[candidate])
-            if (overflow < best_overflow) {
-              chosen_placement = candidate
-              best_overflow = overflow
-            }
-            if (overflow === 0) break
-          }
+          const { top, left, placement } = compute_position(
+            trigger.getBoundingClientRect(),
+            tooltip_el.getBoundingClientRect(),
+            { placement: requested_placement, offset: options.offset ?? 12, padding: 8 },
+          )
 
           // Persist final placement for downstream styling.
-          tooltip_el.setAttribute(`data-placement`, chosen_placement)
-          sync_arrow_styles(tooltip_el, chosen_placement)
+          tooltip_el.setAttribute(`data-placement`, placement)
+          sync_arrow_styles(tooltip_el, placement)
 
-          let { top, left } = position_by_placement[chosen_placement]
-
-          // Keep in viewport
-          const max_left = innerWidth - tooltip_rect.width - min_padding
-          left = Math.max(min_padding, Math.min(left, max_left))
-          const max_top = innerHeight - tooltip_rect.height - min_padding
-          top = Math.max(min_padding, Math.min(top, max_top))
-
+          // The tooltip is absolutely positioned on the body, so add page scroll
           style.left = `${left + globalThis.scrollX}px`
           style.top = `${top + globalThis.scrollY}px`
           style.opacity =
@@ -1159,23 +1116,84 @@ export const tooltip =
     return () => cleanup_functions.forEach((cleanup) => cleanup())
   }
 
-export type ClickOutsideDetail = {
+export type DismissDetail = {
   // Whether focus sat inside the node, so an Escape dismissal can hand focus back
   // to the trigger instead of stranding it on a removed element
   focus_inside: boolean
   via: `pointer` | `escape`
+  event: Event // the press or keydown behind the dismissal, to forward to consumers
 }
 
 export type ClickOutsideConfig<T extends HTMLElement> = {
   enabled?: boolean
-  // Regions that count as inside though they sit outside the node — the trigger
-  // above all, whose own click toggles the surface right after this runs
-  exclude?: string[]
-  // Confines `exclude` matches to one subtree, so a second instance of the same
-  // component cannot shield this one's surface with its own trigger
+  // Regions that count as inside though they sit outside the node: the trigger above
+  // all, whose own click toggles the surface right after this runs, and portalled
+  // content the node no longer contains. Elements beat selectors where you hold a
+  // reference — they cannot collide with another instance's markup.
+  inside?: (Element | string | null | undefined)[]
+  // Confines the selector entries of `inside` to one subtree, so a second instance
+  // of the same component cannot shield this one's surface with its own trigger
   scope?: Element | null
   escape?: boolean // dismiss on Escape as well, reporting where focus was
-  callback?: (node: T, config: ClickOutsideConfig<T>, detail: ClickOutsideDetail) => void
+  // `release` waits for the click, for a surface floating over something draggable:
+  // starting a pan or an orbit behind it should not make it vanish under the cursor.
+  // It gives back the right-click, titlebar-drag and drag-release cases below.
+  dismiss_on?: `press` | `release`
+  callback?: (node: T, config: ClickOutsideConfig<T>, detail: DismissDetail) => void
+}
+
+// Layered keys: only the innermost surface hears one, so Escape closes a dropdown
+// inside a modal and leaves the modal standing, and a dialog opened from a dialog
+// owns Tab. Layers register in attach order, which matches nesting in practice.
+// Capture phase so a handler calling stopPropagation cannot suppress them.
+type KeyLayer = (event: KeyboardEvent) => void
+
+const key_layer_stack = (wants: (event: KeyboardEvent) => boolean) => {
+  const layers: KeyLayer[] = []
+  const handle = (event: KeyboardEvent) => {
+    if (!event.defaultPrevented && wants(event)) layers.at(-1)?.(event)
+  }
+  return (layer: KeyLayer) => {
+    if (layers.length === 0) document.addEventListener(`keydown`, handle, true)
+    layers.push(layer)
+    return () => {
+      const idx = layers.indexOf(layer)
+      if (idx !== -1) layers.splice(idx, 1)
+      if (layers.length === 0) document.removeEventListener(`keydown`, handle, true)
+    }
+  }
+}
+
+// isComposing: Escape cancels an IME composition, it is not a dismissal
+const register_escape_layer = key_layer_stack(
+  (event) => event.key === `Escape` && !event.isComposing,
+)
+
+// A press on a scrollbar reports the scrolling element as its target, which usually
+// sits outside the surface. Without this, reaching for the page scrollbar would
+// dismiss the very dropdown the user is scrolling toward.
+const is_scrollbar_press = (event: Event): boolean => {
+  const target = event.target
+  if (!(event instanceof MouseEvent) || !(target instanceof Element)) return false
+  const root = document.documentElement
+  // Page scrollbars: the root's client box excludes them, so viewport coordinates
+  // beyond it land in the gutter. Zero sizes mean no layout (jsdom), not a hit.
+  if (target === root || target === document.body) {
+    return (
+      (root.clientWidth > 0 && event.clientX > root.clientWidth) ||
+      (root.clientHeight > 0 && event.clientY > root.clientHeight)
+    )
+  }
+  const rect = target.getBoundingClientRect()
+  // clientWidth/Height are 0 for non-scrollable boxes (inline elements above all),
+  // hence the overflow check — otherwise every press right of such a box looks like
+  // a scrollbar hit and silently suppresses dismissal.
+  return (
+    (target.scrollHeight > target.clientHeight &&
+      event.clientX > rect.left + target.clientWidth) ||
+    (target.scrollWidth > target.clientWidth &&
+      event.clientY > rect.top + target.clientHeight)
+  )
 }
 
 // Dismiss a surface when a press lands outside it. Listens for `pointerdown`, not
@@ -1187,11 +1205,22 @@ export type ClickOutsideConfig<T extends HTMLElement> = {
 export const click_outside =
   <T extends HTMLElement>(config: ClickOutsideConfig<T> = {}) =>
   (node: T): (() => void) | undefined => {
-    const { callback, enabled = true, exclude = [], scope, escape = false } = config
+    const {
+      callback,
+      enabled = true,
+      inside = [],
+      scope,
+      escape = false,
+      dismiss_on = `press`,
+    } = config
 
     if (!enabled) return undefined // Early return avoids registering unused listener
 
-    const exclude_selector = exclude.join(`,`)
+    const inside_nodes = inside.filter((item) => item instanceof Element)
+    // Empty entries would make the joined selector invalid and throw on every press
+    const inside_selector = inside
+      .filter((item): item is string => typeof item === `string` && item !== ``)
+      .join(`,`)
     // `path` is empty for the focus check, which has no event to walk
     const is_inside = (target: EventTarget | null, path: EventTarget[] = []): boolean => {
       if (path.includes(node)) return true
@@ -1199,35 +1228,250 @@ export const click_outside =
       // below exists on all Elements
       if (!(target instanceof Element)) return false
       if (node.contains(target)) return true
-      if (!exclude_selector) return false
-      const match = target.closest(exclude_selector)
+      if (inside_nodes.some((el) => path.includes(el) || el.contains(target))) return true
+      const match = inside_selector ? target.closest(inside_selector) : null
       return Boolean(match) && (!scope || scope.contains(match))
     }
 
-    const dismiss = (detail: ClickOutsideDetail) => {
-      callback?.(node, config, detail)
-      node.dispatchEvent(new CustomEvent(`outside-click`, { detail }))
-    }
-
-    function handle_press(event: PointerEvent) {
-      // A press never restores focus — the user already picked where it lands
-      if (!is_inside(event.target, event.composedPath())) {
-        dismiss({ focus_inside: false, via: `pointer` })
+    // document.activeElement reports the outermost shadow host, so descend the focus
+    // chain: the host may be inside the node (containment settles it at the first
+    // step) or the node may itself live in that shadow tree alongside the focus.
+    const focus_is_inside = (): boolean => {
+      let active = document.activeElement
+      while (active) {
+        if (is_inside(active)) return true
+        active = active.shadowRoot?.activeElement ?? null
       }
+      return false
     }
 
-    function handle_keydown(event: KeyboardEvent) {
-      if (event.key !== `Escape` || event.defaultPrevented) return
+    const dismiss = (detail: DismissDetail) => {
+      callback?.(node, config, detail)
+      node.dispatchEvent(new CustomEvent(`dismiss`, { detail }))
+    }
+
+    const handle_press = (event: Event) => {
+      const path = event.composedPath()
+      if (is_scrollbar_press(event) || is_inside(event.target, path)) return
+      // A press never restores focus — the user already picked where it lands
+      dismiss({ focus_inside: false, via: `pointer`, event })
+    }
+
+    const on_escape = (event: KeyboardEvent) => {
+      // Safe to swallow the key: only the innermost layer gets here, so no outer
+      // surface is waiting on it. Cancelling the default keeps a native <dialog>
+      // around the surface open until a second Escape, once this layer is gone.
       event.preventDefault()
       event.stopPropagation()
-      dismiss({ focus_inside: is_inside(document.activeElement), via: `escape` })
+      dismiss({ focus_inside: focus_is_inside(), via: `escape`, event })
     }
 
-    document.addEventListener(`pointerdown`, handle_press, true)
-    if (escape) document.addEventListener(`keydown`, handle_keydown, true)
+    const press_event = dismiss_on === `press` ? `pointerdown` : `click`
+    document.addEventListener(press_event, handle_press, true)
+    const unregister_escape = escape ? register_escape_layer(on_escape) : undefined
 
     return () => {
-      document.removeEventListener(`pointerdown`, handle_press, true)
-      document.removeEventListener(`keydown`, handle_keydown, true)
+      document.removeEventListener(press_event, handle_press, true)
+      unregister_escape?.()
+    }
+  }
+
+export type AnchorRect = { top: number; left: number; bottom: number; right: number }
+
+export interface FloatOptions extends PositionOptions {
+  // A rect instead of an element covers anchors with no markup: the pointer position
+  // a context menu opens at, a text selection, a cell in a canvas.
+  anchor?: Element | AnchorRect | null
+  enabled?: boolean
+  // `fixed` needs no scroll bookkeeping but is clipped by an ancestor's transform;
+  // `absolute` survives that at the cost of adding page scroll to every update.
+  strategy?: `fixed` | `absolute`
+  match_width?: boolean // size the floating box to the anchor, for dropdowns
+  on_position?: (placement: Placement) => void
+}
+
+// Park an element next to an anchor and keep it there while the page moves.
+// Geometry comes from compute_position, the same one the tooltip and the portalled
+// dropdown use, so all three flip and shift alike.
+export const float =
+  (options: FloatOptions = {}) =>
+  (node: Element): (() => void) | undefined => {
+    const {
+      anchor,
+      enabled = true,
+      strategy = `fixed`,
+      match_width = false,
+      on_position,
+      ...position_options
+    } = options
+    if (!enabled || !anchor || !(node instanceof HTMLElement)) return undefined
+
+    const update = () => {
+      // Out of flow before measuring: an in-flow surface is a sibling that pushes the
+      // very anchor it is about to measure, which lands it half its height off.
+      node.style.position = strategy
+      const anchor_rect =
+        anchor instanceof Element ? anchor.getBoundingClientRect() : anchor
+      if (match_width) node.style.width = `${anchor_rect.right - anchor_rect.left}px`
+      const { top, left, placement } = compute_position(
+        anchor_rect,
+        node.getBoundingClientRect(),
+        position_options,
+      )
+      const [scroll_x, scroll_y] =
+        strategy === `absolute` ? [globalThis.scrollX, globalThis.scrollY] : [0, 0]
+      Object.assign(node.style, {
+        left: `${left + scroll_x}px`,
+        top: `${top + scroll_y}px`,
+      })
+      node.dataset.placement = placement
+      on_position?.(placement)
+    }
+
+    update()
+    // capture: a scroll in any ancestor moves the anchor, and scroll does not bubble
+    globalThis.addEventListener(`scroll`, update, true)
+    globalThis.addEventListener(`resize`, update)
+    // the floating box can grow after mount (async content, a filtered list)
+    const observer = new ResizeObserver(update)
+    observer.observe(node)
+    if (anchor instanceof Element) observer.observe(anchor)
+
+    return () => {
+      globalThis.removeEventListener(`scroll`, update, true)
+      globalThis.removeEventListener(`resize`, update)
+      observer.disconnect()
+    }
+  }
+
+export interface HotkeyOptions {
+  bindings: Hotkey[]
+  // Listen on the document rather than the node, for shortcuts that work anywhere.
+  // Node-scoped is the default so a shortcut dies with the surface that owns it.
+  global?: boolean
+  enabled?: boolean
+}
+
+// Declarative keybindings. Matching lives in run_hotkeys so components that already
+// own a window listener (CommandMenu) share the same semantics without an element.
+export const hotkey =
+  (options: HotkeyOptions) =>
+  (node: Element): (() => void) | undefined => {
+    const { bindings, global = false, enabled = true } = options
+    if (!enabled || bindings.length === 0) return undefined
+
+    const target: EventTarget = global ? document : node
+    const handle = (event: Event) => {
+      if (event instanceof KeyboardEvent) run_hotkeys(event, bindings)
+    }
+    target.addEventListener(`keydown`, handle)
+    return () => target.removeEventListener(`keydown`, handle)
+  }
+
+export interface FocusTrapOptions {
+  enabled?: boolean
+  // What to focus on activation: an element, a selector resolved within the node, or
+  // `false` to leave focus where it is. Defaults to the first tabbable descendant.
+  initial?: Element | string | false
+  // Where focus returns on teardown. Defaults to whatever held it on activation;
+  // `false` leaves focus alone, for a trigger the surface itself removed.
+  restore?: Element | false
+  // Further containers the trap covers, for portalled parts of the same surface
+  include?: (Element | null | undefined)[]
+}
+
+// Exported so surfaces can find their own trigger to hand focus back to
+export const tabbable_selector = [
+  `a[href]`,
+  `area[href]`,
+  `button`,
+  `input`,
+  `select`,
+  `textarea`,
+  `summary`,
+  `iframe`,
+  `object`,
+  `embed`,
+  `audio[controls]`,
+  `video[controls]`,
+  `[contenteditable]:not([contenteditable=false])`,
+  `[tabindex]`,
+].join(`,`)
+
+// Visibility read from computed style rather than measured boxes: test DOMs skip
+// layout, so getClientRects would report every candidate as hidden and empty the trap.
+const is_tabbable = (element: Element): boolean => {
+  if (!(element instanceof HTMLElement) && !(element instanceof SVGElement)) return false
+  if (element.closest(`[inert],[hidden],[disabled]`)) return false
+  if (Number(element.getAttribute(`tabindex`) ?? 0) < 0) return false
+  const style = getComputedStyle(element)
+  return style.display !== `none` && style.visibility !== `hidden`
+}
+
+const register_trap_layer = key_layer_stack((event) => event.key === `Tab`)
+
+// Keep Tab inside a surface and hand focus back when it closes. Pair with
+// click_outside: that one decides when a surface goes away, this one decides where
+// the keyboard is while it is up and where it lands afterwards.
+export const focus_trap =
+  (options: FocusTrapOptions = {}) =>
+  (node: Element): (() => void) | undefined => {
+    const { enabled = true, initial, restore, include = [] } = options
+    if (!enabled || !(node instanceof HTMLElement)) return undefined
+
+    const containers = [node, ...include.filter((el) => el instanceof Element)]
+    // Recollected per keystroke: menus grow, filter and disable items while open
+    const tabbables = (): HTMLElement[] =>
+      containers.flatMap((parent) =>
+        [...parent.querySelectorAll<HTMLElement>(tabbable_selector)].filter(is_tabbable),
+      )
+    const holds_focus = () =>
+      containers.some((container) => container.contains(document.activeElement))
+
+    const focus_origin = document.activeElement
+    // The node itself is the fallback focus target, so it needs to accept focus.
+    // Track whether we added tabindex so cleanup can leave the markup as it was.
+    let added_tabindex = false
+
+    if (initial !== false) {
+      const requested =
+        typeof initial === `string` ? node.querySelector(initial) : initial
+      const target = requested ?? tabbables()[0] ?? node
+      if (target === node && !node.hasAttribute(`tabindex`)) {
+        node.tabIndex = -1
+        added_tabindex = true
+      }
+      if (target instanceof HTMLElement || target instanceof SVGElement) target.focus()
+    }
+
+    const on_tab = (event: KeyboardEvent) => {
+      // This is a document-wide capture layer, so without this guard a trap that was
+      // never given focus still confiscates every Tab on the page and drags focus in.
+      // Nav hits that: pinning a submenu leaves focus on the toggle outside it.
+      if (!holds_focus()) return
+      const items = tabbables()
+      event.preventDefault() // even with nothing to focus, Tab must not leave
+      if (items.length === 0) return
+      const step = event.shiftKey ? -1 : 1
+      const active = document.activeElement
+      const idx = active instanceof HTMLElement ? items.indexOf(active) : -1
+      // Focus on the container itself rather than an item enters at the edge Tab
+      // would have reached first
+      const edge = event.shiftKey ? items.at(-1) : items[0]
+      const next = idx === -1 ? edge : items[(idx + step + items.length) % items.length]
+      next?.focus()
+    }
+
+    const unregister = register_trap_layer(on_tab)
+
+    return () => {
+      unregister()
+      if (added_tabindex) node.removeAttribute(`tabindex`)
+      if (restore === false) return
+      // Don't yank focus if the user already placed it elsewhere. A closing surface
+      // usually leaves focus on body, which counts as ours to hand back.
+      if (!holds_focus() && document.activeElement !== document.body) return
+      const target = restore ?? focus_origin
+      if (target instanceof HTMLElement || target instanceof SVGElement) target.focus()
     }
   }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,8 @@
 export * from './heading-anchors'
 export { default as CircleSpinner } from './CircleSpinner.svelte'
 export { default as CommandMenu } from './CommandMenu.svelte'
+export { default as ContextMenu } from './ContextMenu.svelte'
+export { default as Popover } from './Popover.svelte'
 export { default as PageSearch } from './PageSearch.svelte'
 export { default as CodeExample } from './CodeExample.svelte'
 export { default as CopyButton } from './CopyButton.svelte'

--- a/src/lib/portal.ts
+++ b/src/lib/portal.ts
@@ -1,5 +1,6 @@
 import { tick } from 'svelte'
 import type { PortalParams } from './types'
+import { compute_position } from './utils'
 
 type PortalActionParams = PortalParams & { open: boolean }
 
@@ -24,21 +25,21 @@ export function portal_action(node: HTMLElement, initial_params: PortalActionPar
     node.style.width = `${rect.width}px`
     node.hidden = false
     const dropdown_height = node.offsetHeight
-    const space_below = globalThis.innerHeight - rect.bottom
-    const place_above =
-      placement === `top` ||
-      (placement === `auto` &&
-        dropdown_height > 0 &&
-        // kept as an addition rather than `dropdown_height > space_below`: the two are
-        // algebraically equal but can round apart by an ULP at an exact fit
-        rect.bottom + dropdown_height > globalThis.innerHeight &&
-        rect.top > space_below)
-    if (place_above) {
+    // Only ever above or below: a dropdown beside its input is not a dropdown. Height
+    // 0 means the list has not rendered yet, so there is nothing to fit — stay below.
+    // No shift: the list scrolls, and sliding it up would cover the input.
+    const can_flip = placement === `auto` && dropdown_height > 0
+    const { placement: chosen } = compute_position(
+      rect,
+      { width: rect.width, height: dropdown_height },
+      { placement, align: `start`, flip: can_flip && [`bottom`, `top`], shift: false },
+    )
+    if (chosen === `top`) {
       // oxlint-disable-next-line unicorn/prefer-number-coercion -- computed CSS lengths include units
       const margin_top = Number.parseFloat(getComputedStyle(node).marginTop) || 0
       node.style.top = `${Math.max(0, rect.top - dropdown_height - margin_top)}px`
     } else node.style.top = `${rect.bottom}px`
-    node.dataset.placement = place_above ? `top` : `bottom`
+    node.dataset.placement = chosen
   }
 
   const reposition = () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -209,8 +209,37 @@ export function matches_shortcut(
 const is_apple_platform = (): boolean =>
   /mac|iphone|ipad|ipod/iu.test(globalThis.navigator?.userAgent ?? ``)
 
-export const resolve_mod = (shortcut: string): string =>
+const resolve_mod = (shortcut: string): string =>
   shortcut.replaceAll(/\bmod\b/giu, is_apple_platform() ? `meta` : `ctrl`)
+
+// Shortcut segments as display symbols, shared by CommandMenu and ContextMenu.
+// Only `mod` reads the platform; every other segment renders the same everywhere.
+const key_symbols: Record<string, string> = {
+  meta: `⌘`,
+  cmd: `⌘`,
+  shift: `⇧`,
+  alt: `⌥`,
+  ctrl: `Ctrl`,
+  enter: `↵`,
+  backspace: `⌫`,
+  delete: `⌦`,
+  escape: `Esc`,
+  arrowup: `↑`,
+  arrowdown: `↓`,
+  arrowleft: `←`,
+  arrowright: `→`,
+}
+
+export const format_shortcut = (shortcut: string): string[] =>
+  split_shortcut(resolve_mod(shortcut)).map((part) => {
+    const key_segment = part.trim().toLowerCase()
+    // title-case unknown multi-char segments, upper-case single chars (empty stays empty)
+    const title_case = key_segment.charAt(0).toUpperCase() + key_segment.slice(1)
+    return (
+      key_symbols[key_segment] ??
+      (key_segment.length > 1 ? title_case : key_segment.toUpperCase())
+    )
+  })
 
 export type Hotkey = {
   keys: string | string[] // e.g. `mod+k`, `ctrl+shift+p`, `Escape`

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -79,6 +79,88 @@ export function get_style(
   return css_str
 }
 
+// === Floating geometry ===
+// "Pick a side that fits, then stay on screen": tooltip, portalled dropdown, `float`.
+
+export type Placement = `top` | `right` | `bottom` | `left`
+
+export type PositionOptions = {
+  placement?: Placement | `auto` // `auto` prefers bottom, then flips
+  // `start` lines the floating box up with the anchor's edge (dropdowns), `center`
+  // centres it on the anchor (tooltips)
+  align?: `center` | `start`
+  offset?: number // gap between anchor and floating box
+  padding?: number // closest the floating box may come to a viewport edge
+  // `true` tries the opposite side then the perpendicular ones; pass an explicit
+  // list to keep a dropdown from ever landing beside its input
+  flip?: boolean | Placement[]
+  shift?: boolean // slide along the viewport edge rather than overflow it
+}
+
+const FLIP_ORDER: Record<Placement, Placement[]> = {
+  bottom: [`bottom`, `top`, `right`, `left`],
+  top: [`top`, `bottom`, `right`, `left`],
+  right: [`right`, `left`, `bottom`, `top`],
+  left: [`left`, `right`, `bottom`, `top`],
+}
+
+// Viewport coordinates; callers add scroll offsets when positioning absolutely.
+export function compute_position(
+  anchor: { top: number; left: number; bottom: number; right: number },
+  floating: { width: number; height: number },
+  options: PositionOptions = {},
+): { top: number; left: number; placement: Placement } {
+  const {
+    placement = `bottom`,
+    align = `center`,
+    offset = 0,
+    padding = 0,
+    flip = true,
+    shift = true,
+  } = options
+  const { innerWidth, innerHeight } = globalThis
+  const requested = placement === `auto` ? `bottom` : placement
+  const anchor_width = anchor.right - anchor.left
+  const anchor_height = anchor.bottom - anchor.top
+  // Cross-axis offset: the side being tried only fixes the main axis
+  const cross_x =
+    align === `start` ? anchor.left : anchor.left + (anchor_width - floating.width) / 2
+  const cross_y =
+    align === `start` ? anchor.top : anchor.top + (anchor_height - floating.height) / 2
+
+  const coords: Record<Placement, { top: number; left: number }> = {
+    top: { top: anchor.top - floating.height - offset, left: cross_x },
+    bottom: { top: anchor.bottom + offset, left: cross_x },
+    left: { top: cross_y, left: anchor.left - floating.width - offset },
+    right: { top: cross_y, left: anchor.right + offset },
+  }
+
+  const overflow = ({ top, left }: { top: number; left: number }) =>
+    Math.max(0, padding - top) +
+    Math.max(0, padding - left) +
+    Math.max(0, top + floating.height + padding - innerHeight) +
+    Math.max(0, left + floating.width + padding - innerWidth)
+
+  let chosen = requested
+  if (flip !== false) {
+    let least_overflow = Infinity
+    for (const candidate of Array.isArray(flip) ? flip : FLIP_ORDER[requested]) {
+      const candidate_overflow = overflow(coords[candidate])
+      if (candidate_overflow < least_overflow) {
+        chosen = candidate
+        least_overflow = candidate_overflow
+      }
+    }
+  }
+
+  let { top, left } = coords[chosen]
+  if (shift) {
+    left = Math.max(padding, Math.min(left, innerWidth - floating.width - padding))
+    top = Math.max(padding, Math.min(top, innerHeight - floating.height - padding))
+  }
+  return { top, left, placement: chosen }
+}
+
 export function split_shortcut(shortcut: string): string[] {
   const parts = shortcut
     .toLowerCase()
@@ -121,6 +203,41 @@ export function matches_shortcut(
     event.altKey === alt &&
     event.metaKey === meta
   )
+}
+
+// `mod` is Cmd on Apple keyboards and Ctrl everywhere else, so one binding covers both
+const is_apple_platform = (): boolean =>
+  /mac|iphone|ipad|ipod/iu.test(globalThis.navigator?.userAgent ?? ``)
+
+export const resolve_mod = (shortcut: string): string =>
+  shortcut.replaceAll(/\bmod\b/giu, is_apple_platform() ? `meta` : `ctrl`)
+
+export type Hotkey = {
+  keys: string | string[] // e.g. `mod+k`, `ctrl+shift+p`, `Escape`
+  handler: (event: KeyboardEvent) => void
+  enabled?: boolean
+  // Bare keys are ignored while typing in a text field, where they are just
+  // characters. Chords always fire. Set true for keys that must work either way.
+  allow_in_inputs?: boolean
+  prevent_default?: boolean // default true
+}
+
+// Runs the first binding whose shortcut matches and reports whether one fired.
+// Shared by the `hotkey` attachment and components that own a window listener.
+export function run_hotkeys(event: KeyboardEvent, bindings: Hotkey[]): boolean {
+  if (event.isComposing) return false // mid-IME the keystroke belongs to the editor
+  // Outside a chord a bare key in a text field is ordinary typing, not a shortcut
+  const typing = !is_modifier_chord(event) && is_editable_event_target(event.target)
+  for (const binding of bindings) {
+    if (binding.enabled === false) continue
+    const keys = Array.isArray(binding.keys) ? binding.keys : [binding.keys]
+    if (!keys.some((key) => matches_shortcut(event, resolve_mod(key)))) continue
+    if (typing && !binding.allow_in_inputs) continue
+    if (binding.prevent_default !== false) event.preventDefault()
+    binding.handler(event)
+    return true
+  }
+  return false
 }
 
 // True when the event came from a text-entry control, where a bare key is typing

--- a/src/routes/(demos)/(components)/components/+page.svelte
+++ b/src/routes/(demos)/(components)/components/+page.svelte
@@ -9,5 +9,10 @@
   subpages={[
     [`Nav`, resolve(`/nav`), `Configurable navigation component patterns.`],
     [`CommandMenu`, resolve(`/command-menu`), `Command menu built on MultiSelect.`],
+    [
+      `Popover & ContextMenu`,
+      resolve(`/popover`),
+      `Floating surfaces built from the dismissal, focus and positioning attachments.`,
+    ],
   ]}
 />

--- a/src/routes/(demos)/(components)/popover/+page.md
+++ b/src/routes/(demos)/(components)/popover/+page.md
@@ -1,8 +1,8 @@
 ## Popover & ContextMenu
 
-Two surfaces built from the same three attachments: [`float`](/attachments#float) puts
-them where they fit, [`click_outside`](/attachments#click_outside) takes them away, and
-[`focus_trap`](/attachments#focus_trap) owns the keyboard while they are up.
+Two surfaces built from the same three attachments: [`float`](attachments#float) puts
+them where they fit, [`click_outside`](attachments#click_outside) takes them away, and
+[`focus_trap`](attachments#focus_trap) owns the keyboard while they are up.
 
 ### `Popover`
 

--- a/src/routes/(demos)/(components)/popover/+page.md
+++ b/src/routes/(demos)/(components)/popover/+page.md
@@ -1,0 +1,91 @@
+## Popover & ContextMenu
+
+Two surfaces built from the same three attachments: [`float`](/attachments#float) puts
+them where they fit, [`click_outside`](/attachments#click_outside) takes them away, and
+[`focus_trap`](/attachments#focus_trap) owns the keyboard while they are up.
+
+### `Popover`
+
+The `trigger` snippet receives the attributes to spread onto whatever you want to open
+it with — the click handler and the `aria-expanded`/`aria-haspopup`/`aria-controls`
+wiring. Dismissal happens on the press, so a right-click anywhere else closes it too,
+and Escape closes the innermost surface only.
+
+```svelte example id="popover-basic"
+<script lang="ts">
+  import { Popover } from '$lib'
+  import type { Placement } from '$lib/utils'
+
+  let placement = $state<Placement>(`bottom`)
+  let last_close = $state(``)
+</script>
+
+<label>
+  Placement
+  <select bind:value={placement}>
+    {#each [`top`, `right`, `bottom`, `left`] as side (side)}<option>{side}</option
+      >{/each}
+  </select>
+</label>
+
+<div style="display: flex; gap: 1em; margin: 2em 0; align-items: center">
+  <Popover {placement} on_close={({ via }) => (last_close = via)}>
+    {#snippet trigger(props)}
+      <button {...props}>Open popover</button>
+    {/snippet}
+    <p style="margin: 0 0 6pt">Tab is trapped in here.</p>
+    <label>Name <input placeholder="type something" /></label>
+  </Popover>
+
+  <Popover placement="right" align="start">
+    {#snippet trigger(props)}
+      <button {...props}>Second popover</button>
+    {/snippet}
+    <p style="margin: 0">Escape closes whichever one you opened last.</p>
+  </Popover>
+
+  {#if last_close}<small>last closed via <code>{last_close}</code></small>{/if}
+</div>
+```
+
+`escape={false}` and `trap_focus={false}` opt out of those behaviors,
+`strategy="absolute"` survives a transformed ancestor at the cost of tracking page
+scroll, and `match_width` sizes the surface to the trigger for dropdown-like menus.
+
+### `ContextMenu`
+
+Right-click a region to replace the browser's own menu. Actions are
+[`CmdAction`](https://github.com/janosh/svelte-multiselect/blob/main/src/lib/types.ts)s,
+the same shape `CommandMenu` takes, so a command can appear in both.
+
+```svelte example id="context-menu-basic"
+<script lang="ts">
+  import { ContextMenu } from '$lib'
+  import type { CmdAction } from '$lib/types'
+
+  let log = $state<string[]>([])
+  const record = (label: string) => (log = [label, ...log].slice(0, 4))
+  const actions: CmdAction[] = [
+    { label: `Cut`, shortcut: `mod+x`, action: record },
+    { label: `Copy`, shortcut: `mod+c`, action: record },
+    { label: `Paste`, shortcut: `mod+v`, action: record },
+    { label: `Delete`, action: record, disabled: true },
+  ]
+</script>
+
+<ContextMenu {actions}>
+  <div
+    style="display: grid; place-items: center; height: 8em; border: 1px dashed gray; border-radius: 5pt"
+  >
+    Right-click me
+  </div>
+</ContextMenu>
+
+<ol>
+  {#each log as entry, idx (idx)}<li>{entry}</li>{/each}
+</ol>
+```
+
+Drop the region and the whole page qualifies. Bind `at` to open the menu yourself from
+a long-press or a keyboard shortcut, and pass an `item` snippet to render rows your own
+way.

--- a/src/routes/(demos)/(integration)/attachments/+page.md
+++ b/src/routes/(demos)/(integration)/attachments/+page.md
@@ -7,6 +7,9 @@ Exported from `svelte-multiselect/attachments`:
 - [`sortable`](#sortable)
 - [`highlight_matches`](#highlight_matches)
 - [`click_outside`](#click_outside)
+- [`focus_trap`](#focus_trap)
+- [`hotkey`](#hotkey)
+- [`float`](#float)
 
 ### `tooltip`
 
@@ -335,7 +338,8 @@ receives ranges without the CSS Highlight API and reruns when observed content c
     <div
       class="dropdown"
       {@attach click_outside({
-        exclude: ['.toggle'],
+        inside: ['.toggle'],
+        escape: true,
         callback: () => (open_menu = false),
       })}
     >
@@ -343,7 +347,7 @@ receives ranges without the CSS Highlight API and reruns when observed content c
         <li><a href="#one">First</a></li>
         <li><a href="#two">Second</a></li>
         <li>
-          <a href="#noop" class="toggle">Clicking me won’t close (excluded)</a>
+          <a href="#noop" class="toggle">Clicking me won’t close (counts as inside)</a>
         </li>
       </ul>
     </div>
@@ -379,11 +383,126 @@ receives ranges without the CSS Highlight API and reruns when observed content c
 ```
 
 Dismissal happens on `pointerdown`, not `click`, so a right-click or a press the OS
-turns into a window drag still closes the surface. Pass `scope` to confine `exclude`
-matches to one subtree when several instances of a component share trigger selectors,
-and `escape: true` to also dismiss on Escape. `callback` receives
-`(node, config, detail)` where `detail` is `{ focus_inside, via }` — `focus_inside`
-tells an Escape handler whether to move focus back to the trigger.
+turns into a window drag still closes the surface. Presses that land in a scrollbar
+gutter are ignored, so reaching for the scrollbar does not close what you are
+scrolling toward. A surface floating over something draggable can pass
+`dismiss_on: 'release'` to wait for the click instead, so starting a pan behind it
+does not make it vanish mid-drag.
+
+Pass `inside` for regions that count as inside though they sit outside the node:
+elements for portalled content the node no longer contains, selectors for triggers.
+`scope` confines the selector entries to one subtree when several instances of a
+component share trigger selectors, and `escape: true` also dismisses on Escape. Escape
+dismisses one surface at a time — the most recently attached one — so a dropdown
+inside a modal closes the dropdown and leaves the modal standing.
+
+`callback` receives `(node, config, detail)` and the node also fires a `dismiss`
+event carrying the same `detail` of `{ focus_inside, via, event }`. `focus_inside`
+tells an Escape handler whether to move focus back to the trigger, and `event` is the
+press or keydown behind the dismissal, to forward to your own close handler.
+
+### `focus_trap`
+
+Keeps Tab inside a surface and hands the keyboard back when it closes — the other half
+of what `click_outside` starts. Nested traps stack like Escape layers: only the
+innermost one steers Tab.
+
+```svelte example id="attachments-focus-trap"
+<script lang="ts">
+  import { click_outside, focus_trap } from '$lib/attachments'
+
+  let open = $state(false)
+  let trigger = $state<HTMLButtonElement | null>(null)
+</script>
+
+<button bind:this={trigger} onclick={() => (open = true)}>Open panel</button>
+
+{#if open}
+  <div
+    role="dialog"
+    aria-label="Trapped panel"
+    style="display: grid; gap: 6pt; max-width: 20em; margin-top: 1ex; padding: 1ex 1em; border: 1px solid gray; border-radius: 5pt"
+    {@attach focus_trap({ restore: trigger })}
+    {@attach click_outside({ escape: true, callback: () => (open = false) })}
+  >
+    <input placeholder="Tab cycles between these" />
+    <input placeholder="…and never leaves the panel" />
+    <button onclick={() => (open = false)}>Close</button>
+  </div>
+{/if}
+```
+
+`initial` picks the entry point (an element, a selector, or `false` to leave focus
+alone) and `restore` the exit point, defaulting to whatever held focus when the trap
+went up. `include` extends the trap over portalled parts of the same surface.
+
+### `hotkey`
+
+Declarative keybindings over the same matcher `CommandMenu` uses. `mod` is Cmd on Apple
+keyboards and Ctrl elsewhere. Bare keys stay out of the way while you type in a field;
+chords always fire.
+
+```svelte example id="attachments-hotkey"
+<script lang="ts">
+  import { hotkey } from '$lib/attachments'
+
+  let log = $state<string[]>([])
+  const record = (label: string) => (log = [label, ...log].slice(0, 5))
+</script>
+
+<div
+  style="display: grid; gap: 6pt"
+  {@attach hotkey({
+    global: true,
+    bindings: [
+      { keys: `mod+b`, handler: () => record(`bold`) },
+      { keys: [`?`, `shift+/`], handler: () => record(`help`) },
+      { keys: `Enter`, handler: () => record(`submit`), allow_in_inputs: true },
+    ],
+  })}
+>
+  <input placeholder="mod+b works here, ? does not, Enter does" />
+  <ol>
+    {#each log as entry, idx (idx)}<li>{entry}</li>{/each}
+  </ol>
+</div>
+```
+
+Pass `global: false` (the default) to scope a binding to the node it is attached to, so
+a shortcut dies with the surface that owns it.
+
+### `float`
+
+Parks an element next to an anchor and keeps it there while the page scrolls or
+resizes. The geometry — flip to the side that fits, then shift to stay on screen —
+comes from `compute_position` in `svelte-multiselect/utils`, which the tooltip and the
+portalled dropdown also use. The anchor can be a plain rect instead of an element,
+which is how `ContextMenu` hangs a menu off the pointer.
+
+```svelte example id="attachments-float"
+<script lang="ts">
+  import { float } from '$lib/attachments'
+  import type { Placement } from '$lib/utils'
+
+  let anchor = $state<HTMLElement | null>(null)
+  let placement = $state<Placement>(`bottom`)
+</script>
+
+<select bind:value={placement}>
+  {#each [`top`, `right`, `bottom`, `left`] as side (side)}<option>{side}</option>{/each}
+</select>
+
+<div style="display: grid; place-items: center; height: 12em">
+  <span bind:this={anchor} style="padding: 1ex 1em; border: 1px dashed gray">anchor</span>
+</div>
+
+<div
+  style="background: teal; color: white; padding: 2pt 6pt; border-radius: 4pt"
+  {@attach float({ anchor, placement, offset: 8, padding: 8 })}
+>
+  floating
+</div>
+```
 
 ### `sortable`
 

--- a/src/routes/(demos)/(integration)/attachments/+page.md
+++ b/src/routes/(demos)/(integration)/attachments/+page.md
@@ -378,6 +378,13 @@ receives ranges without the CSS Highlight API and reruns when observed content c
 </style>
 ```
 
+Dismissal happens on `pointerdown`, not `click`, so a right-click or a press the OS
+turns into a window drag still closes the surface. Pass `scope` to confine `exclude`
+matches to one subtree when several instances of a component share trigger selectors,
+and `escape: true` to also dismiss on Escape. `callback` receives
+`(node, config, detail)` where `detail` is `{ focus_inside, via }` — `focus_inside`
+tells an Escape handler whether to move focus back to the trigger.
+
 ### `sortable`
 
 ```svelte example id="attachments-sortable"

--- a/tests/vitest/ContextMenu.svelte.test.ts
+++ b/tests/vitest/ContextMenu.svelte.test.ts
@@ -1,0 +1,99 @@
+import { ContextMenu } from '$lib'
+import type { CmdAction } from '$lib/types'
+import { mount, tick, unmount } from 'svelte'
+import { afterEach, describe, expect, test, vi } from 'vite-plus/test'
+import { doc_query } from './index'
+
+describe(`ContextMenu`, () => {
+  const make_actions = (): CmdAction[] => [
+    { label: `Copy`, action: vi.fn(), shortcut: `mod+c` },
+    { label: `Delete`, action: vi.fn(), disabled: true },
+  ]
+  // svelte:body listeners outlive document.body.innerHTML = '', so unmount for real
+  // or a previous test's menu keeps answering right-clicks
+  const mounted: Record<string, unknown>[] = []
+  afterEach(() => {
+    for (const app of mounted.splice(0)) void unmount(app)
+  })
+  const mount_menu = (actions: CmdAction[], extra = {}) => {
+    const props = $state({ actions, ...extra })
+    mounted.push(mount(ContextMenu, { target: document.body, props }))
+  }
+  const right_click = (target: EventTarget, clientX = 120, clientY = 240) => {
+    const event = new MouseEvent(`contextmenu`, {
+      bubbles: true,
+      cancelable: true,
+      clientX,
+      clientY,
+    })
+    target.dispatchEvent(event)
+    return event
+  }
+  // mounts a menu and right-clicks the page to open it, returning the contextmenu event
+  const open_menu = async (actions = make_actions(), extra = {}) => {
+    mount_menu(actions, extra)
+    const event = right_click(document.body)
+    await tick()
+    return event
+  }
+  const menu = () => document.querySelector(`menu[role="menu"]`)
+  const items = () =>
+    Array.from(document.querySelectorAll<HTMLButtonElement>(`[role="menuitem"]`))
+
+  test(`a right-click opens the menu at the pointer, replacing the native one`, async () => {
+    mount_menu(make_actions())
+    expect(menu()).toBeNull()
+
+    const event = right_click(document.body)
+    await tick()
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(items().map((item) => item.querySelector(`span`)?.textContent)).toEqual([
+      `Copy`,
+      `Delete`,
+    ])
+    expect([...items()[0].querySelectorAll(`kbd`)].map((key) => key.textContent)).toEqual(
+      [`mod`, `c`],
+    )
+    // float anchored the menu on the pointer rather than on any element
+    const { position, left, top } = doc_query(`menu[role="menu"]`).style
+    expect([position, left, top]).toEqual([`fixed`, `120px`, `240px`])
+  })
+
+  test(`choosing an action runs it and closes, disabled ones do neither`, async () => {
+    const actions = make_actions()
+    await open_menu(actions)
+
+    items()[1].click() // disabled
+    await tick()
+    expect(actions[1].action).not.toHaveBeenCalled()
+    expect(menu()).not.toBeNull()
+
+    items()[0].click()
+    await tick()
+    expect(actions[0].action).toHaveBeenCalledWith(`Copy`)
+    expect(menu()).toBeNull()
+  })
+
+  // both bubble to the document listeners that own dismissal
+  test.each([
+    [`Escape`, () => new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true })],
+    [`a press outside`, () => new PointerEvent(`pointerdown`, { bubbles: true })],
+  ])(`%s dismisses the menu`, async (_desc, make_event) => {
+    await open_menu()
+    expect(menu()).not.toBeNull()
+
+    document.body.dispatchEvent(make_event())
+    await tick()
+    expect(menu()).toBeNull()
+  })
+
+  test(`stays shut when disabled or when there is nothing to show`, async () => {
+    const event = await open_menu(make_actions(), { disabled: true })
+    expect(menu()).toBeNull()
+    expect(event.defaultPrevented).toBe(false) // the browser menu still opens
+
+    await open_menu([])
+    expect(menu()).toBeNull()
+  })
+})

--- a/tests/vitest/ContextMenu.svelte.test.ts
+++ b/tests/vitest/ContextMenu.svelte.test.ts
@@ -1,10 +1,12 @@
 import { ContextMenu } from '$lib'
 import type { CmdAction } from '$lib/types'
-import { mount, tick, unmount } from 'svelte'
+import type { ComponentProps } from 'svelte'
+import { createRawSnippet, mount, tick, unmount } from 'svelte'
 import { afterEach, describe, expect, test, vi } from 'vite-plus/test'
 import { doc_query } from './index'
 
 describe(`ContextMenu`, () => {
+  type MenuProps = Partial<Omit<ComponentProps<typeof ContextMenu>, `actions`>>
   const make_actions = (): CmdAction[] => [
     { label: `Copy`, action: vi.fn(), shortcut: `mod+c` },
     { label: `Delete`, action: vi.fn(), disabled: true },
@@ -15,7 +17,7 @@ describe(`ContextMenu`, () => {
   afterEach(() => {
     for (const app of mounted.splice(0)) void unmount(app)
   })
-  const mount_menu = (actions: CmdAction[], extra = {}) => {
+  const mount_menu = (actions: CmdAction[], extra: MenuProps = {}) => {
     const props = $state({ actions, ...extra })
     mounted.push(mount(ContextMenu, { target: document.body, props }))
   }
@@ -30,7 +32,7 @@ describe(`ContextMenu`, () => {
     return event
   }
   // mounts a menu and right-clicks the page to open it, returning the contextmenu event
-  const open_menu = async (actions = make_actions(), extra = {}) => {
+  const open_menu = async (actions = make_actions(), extra: MenuProps = {}) => {
     mount_menu(actions, extra)
     const event = right_click(document.body)
     await tick()
@@ -41,7 +43,7 @@ describe(`ContextMenu`, () => {
     Array.from(document.querySelectorAll<HTMLButtonElement>(`[role="menuitem"]`))
 
   test(`a right-click opens the menu at the pointer, replacing the native one`, async () => {
-    mount_menu(make_actions())
+    mount_menu(make_actions(), { class: `consumer-class` })
     expect(menu()).toBeNull()
 
     const event = right_click(document.body)
@@ -53,8 +55,41 @@ describe(`ContextMenu`, () => {
       `Delete`,
     ])
     // float anchored the menu on the pointer rather than on any element
-    const { position, left, top } = doc_query(`menu[role="menu"]`).style
+    const surface = doc_query(`menu[role="menu"]`)
+    const { position, left, top } = surface.style
     expect([position, left, top]).toEqual([`fixed`, `120px`, `240px`])
+    // .context-menu comes after the {...rest} spread, so a consumer class adds to the
+    // styling hook instead of replacing it
+    expect(surface.classList.contains(`context-menu`)).toBe(true)
+    expect(surface.classList.contains(`consumer-class`)).toBe(true)
+  })
+
+  // with a region, svelte:body's handler is dropped, so the rest of the page keeps
+  // the browser's own menu
+  test(`a children region scopes the right-click to itself`, async () => {
+    const children = createRawSnippet(() => ({
+      render: () => `<div data-testid="region">region</div>`,
+    }))
+    mount_menu(make_actions(), { children })
+
+    const outside = right_click(document.body)
+    await tick()
+    expect(menu()).toBeNull()
+    expect(outside.defaultPrevented).toBe(false)
+
+    right_click(doc_query(`[data-testid="region"]`))
+    await tick()
+    expect(menu()).not.toBeNull()
+  })
+
+  test(`an item snippet replaces the default label and shortcut markup`, async () => {
+    const item = createRawSnippet<[{ action: CmdAction }]>((get_params) => ({
+      render: () => `<span data-testid="custom">${get_params().action.label}!</span>`,
+    }))
+    await open_menu(make_actions(), { item })
+
+    expect(items().map((btn) => btn.textContent?.trim())).toEqual([`Copy!`, `Delete!`])
+    expect(document.querySelector(`kbd`)).toBeNull() // default shortcut markup is gone
   })
 
   test.each([
@@ -75,16 +110,19 @@ describe(`ContextMenu`, () => {
 
   test(`choosing an action runs it and closes, disabled ones do neither`, async () => {
     const actions = make_actions()
-    await open_menu(actions)
+    const on_select = vi.fn()
+    await open_menu(actions, { on_select })
 
     items()[1].click() // disabled
     await tick()
     expect(actions[1].action).not.toHaveBeenCalled()
+    expect(on_select).not.toHaveBeenCalled()
     expect(menu()).not.toBeNull()
 
     items()[0].click()
     await tick()
     expect(actions[0].action).toHaveBeenCalledWith(`Copy`)
+    expect(on_select).toHaveBeenCalledWith(actions[0])
     expect(menu()).toBeNull()
   })
 

--- a/tests/vitest/ContextMenu.svelte.test.ts
+++ b/tests/vitest/ContextMenu.svelte.test.ts
@@ -52,12 +52,24 @@ describe(`ContextMenu`, () => {
       `Copy`,
       `Delete`,
     ])
-    expect([...items()[0].querySelectorAll(`kbd`)].map((key) => key.textContent)).toEqual(
-      [`mod`, `c`],
-    )
     // float anchored the menu on the pointer rather than on any element
     const { position, left, top } = doc_query(`menu[role="menu"]`).style
     expect([position, left, top]).toEqual([`fixed`, `120px`, `240px`])
+  })
+
+  test.each([
+    [`Macintosh; Intel Mac OS X 10_15`, [`⌘`, `C`]],
+    [`X11; Linux x86_64`, [`Ctrl`, `C`]],
+  ])(`renders mod as the platform's key (%s)`, async (user_agent, expected) => {
+    Object.defineProperty(globalThis.navigator, `userAgent`, {
+      value: user_agent,
+      configurable: true,
+    })
+    await open_menu()
+
+    expect([...items()[0].querySelectorAll(`kbd`)].map((key) => key.textContent))
+      .toEqual(expected)
+    Reflect.deleteProperty(globalThis.navigator, `userAgent`)
   })
 
   test(`choosing an action runs it and closes, disabled ones do neither`, async () => {

--- a/tests/vitest/ContextMenu.svelte.test.ts
+++ b/tests/vitest/ContextMenu.svelte.test.ts
@@ -67,8 +67,9 @@ describe(`ContextMenu`, () => {
     })
     await open_menu()
 
-    expect([...items()[0].querySelectorAll(`kbd`)].map((key) => key.textContent))
-      .toEqual(expected)
+    expect([...items()[0].querySelectorAll(`kbd`)].map((key) => key.textContent)).toEqual(
+      expected,
+    )
     Reflect.deleteProperty(globalThis.navigator, `userAgent`)
   })
 

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -8586,7 +8586,8 @@ test(`press on the portalled dropdown does not close it`, async () => {
     open: true,
     portal: { active: true },
   })
-  mount(MultiSelect, { target: document.body, props })
+  // unmount for real: clearing innerHTML would leave the document press listener
+  const app = mount(MultiSelect, { target: document.body, props })
   await tick()
 
   const portalled = doc_query<HTMLUListElement>(`body > ul.options`)
@@ -8601,6 +8602,7 @@ test(`press on the portalled dropdown does not close it`, async () => {
   await tick()
   expect(doc_query(`div.multiselect`).classList.contains(`open`)).toBe(false)
   outside.remove()
+  await unmount(app)
 })
 
 test(`searchExpandsCollapsedGroups: manually collapsed group stays collapsed until the search changes`, async () => {

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -8577,6 +8577,32 @@ test(`toggling portal.active at runtime portals and un-portals the dropdown`, as
   expect(back_inside.dataset.placement).toBeUndefined()
 })
 
+// The click_outside attachment receives `inside: [ul_options]`, which is undefined
+// until bind:this lands. Attachments re-run on reactive reads, so the portalled list
+// must count as inside once bound — otherwise pressing it would close the dropdown.
+test(`press on the portalled dropdown does not close it`, async () => {
+  const props = $state<MultiSelectProps>({
+    options: [1, 2, 3],
+    open: true,
+    portal: { active: true },
+  })
+  mount(MultiSelect, { target: document.body, props })
+  await tick()
+
+  const portalled = doc_query<HTMLUListElement>(`body > ul.options`)
+  portalled.dispatchEvent(new PointerEvent(`pointerdown`, { bubbles: true }))
+  await tick()
+  expect(doc_query(`div.multiselect`).classList.contains(`open`)).toBe(true)
+
+  // control: a press with no relation to the component does close it
+  const outside = document.createElement(`div`)
+  document.body.append(outside)
+  outside.dispatchEvent(new PointerEvent(`pointerdown`, { bubbles: true }))
+  await tick()
+  expect(doc_query(`div.multiselect`).classList.contains(`open`)).toBe(false)
+  outside.remove()
+})
+
 test(`searchExpandsCollapsedGroups: manually collapsed group stays collapsed until the search changes`, async () => {
   mount(MultiSelect, {
     target: document.body,

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -35,10 +35,11 @@ describe(`Nav`, () => {
     el.dispatchEvent(new FocusEvent(`focusin`, { bubbles: true }))
   const focus_out = (el: Element, relatedTarget: EventTarget | null) =>
     el.dispatchEvent(new FocusEvent(`focusout`, { bubbles: true, relatedTarget }))
+  // the attachment dismisses on the press, not the click
   const click_outside = async () => {
     const outside = document.createElement(`div`)
     document.body.append(outside)
-    outside.dispatchEvent(new MouseEvent(`click`, { bubbles: true, cancelable: true }))
+    outside.dispatchEvent(new PointerEvent(`pointerdown`, { bubbles: true }))
     await tick()
     outside.remove()
   }

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -15,6 +15,8 @@ describe(`Nav`, () => {
     [`/second`, [`/second`, `/second/child`]],
   ]
   const parent_other: NavRoute[] = [...single_dropdown_route, [`/other`, [`/other`]]]
+  // two submenu links, so Tab/ArrowDown have somewhere to move
+  const two_child_route: NavRoute[] = [[`/p`, [`/p`, `/p/child1`, `/p/child2`]]]
   const mount_nav = (props: ComponentProps<typeof Nav>) =>
     mount(Nav, { target: document.body, props })
   const click = (el?: Element | null) => {
@@ -955,8 +957,7 @@ describe(`Nav`, () => {
     )
 
     test(`ArrowDown navigates within pinned dropdown after mouse leave`, async () => {
-      const routes: NavRoute[] = [[`/p`, [`/p`, `/p/child1`, `/p/child2`]]]
-      mount_nav({ routes, dropdown_cooldown: 0 })
+      mount_nav({ routes: two_child_route, dropdown_cooldown: 0 })
       const { dropdown, dropdown_menu } = query_dropdown_elements()
       const toggle = doc_query(`[data-dropdown-toggle]`)
 
@@ -974,8 +975,39 @@ describe(`Nav`, () => {
       expect(document.activeElement).toBe(dropdown_menu.querySelector(`a`))
     })
 
+    test(`Escape on a submenu link closes it for good and restores focus`, async () => {
+      mount_nav({ routes: two_child_route, dropdown_cooldown: 0 })
+      const { dropdown_menu } = query_dropdown_elements()
+      const toggle = doc_query(`[data-dropdown-toggle]`)
+
+      await click(toggle)
+      const first_link = doc_query<HTMLAnchorElement>(`[data-submenu] a`)
+      first_link.focus()
+      keydown(`Escape`, first_link)
+      await next_task()
+
+      expect(document.activeElement).toBe(toggle)
+      // handing focus back lands on the toggle, whose focusin must not reopen it
+      expect(is_visible(dropdown_menu)).toBe(false)
+    })
+
+    test(`Tab cycles within a pinned submenu instead of leaving it`, async () => {
+      mount_nav({ routes: two_child_route, dropdown_cooldown: 0 })
+      const { dropdown_menu } = query_dropdown_elements()
+
+      await click(doc_query(`[data-dropdown-toggle]`))
+      const links = [...dropdown_menu.querySelectorAll(`a`)]
+      expect(links).toHaveLength(2)
+
+      links[0].focus()
+      keydown(`Tab`, links[0])
+      expect(document.activeElement).toBe(links[1])
+      keydown(`Tab`, links[1])
+      expect(document.activeElement).toBe(links[0])
+    })
+
     test(`pinned dropdown stays open on focus out`, async () => {
-      mount_nav({ routes: [[`/p`, [`/p`, `/p/child1`, `/p/child2`]]] })
+      mount_nav({ routes: two_child_route })
       const { dropdown, dropdown_menu } = query_dropdown_elements()
 
       await click(doc_query(`[data-dropdown-toggle]`))

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -811,7 +811,9 @@ describe(`Nav`, () => {
       afterEach(() => vi.useRealTimers())
 
       test.each([0, 100])(`cooldown=%dms closes after timeout`, async (cooldown) => {
-        const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown: cooldown })
+        const { dropdown, dropdown_menu } = mount_dropdown({
+          dropdown_cooldown: cooldown,
+        })
 
         mouse_enter(dropdown)
         await tick()
@@ -941,7 +943,9 @@ describe(`Nav`, () => {
     test.each([`Enter`, ` `, `ArrowDown`])(
       `keyboard %s pins dropdown open`,
       async (key) => {
-        const { dropdown, dropdown_menu, toggle } = mount_dropdown({ dropdown_cooldown: 0 })
+        const { dropdown, dropdown_menu, toggle } = mount_dropdown({
+          dropdown_cooldown: 0,
+        })
 
         keydown(key, toggle)
         await next_task()

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -17,6 +17,9 @@ describe(`Nav`, () => {
   const parent_other: NavRoute[] = [...single_dropdown_route, [`/other`, [`/other`]]]
   // two submenu links, so Tab/ArrowDown have somewhere to move
   const two_child_route: NavRoute[] = [[`/p`, [`/p`, `/p/child1`, `/p/child2`]]]
+  const one_child_route: NavRoute[] = [[`/p`, [`/p`, `/p/1`]]]
+  // no hover cooldown, so a menu still open afterwards is open because it was pinned
+  const pinned_props = { routes: two_child_route, dropdown_cooldown: 0 }
   const mount_nav = (props: ComponentProps<typeof Nav>) =>
     mount(Nav, { target: document.body, props })
   const click = (el?: Element | null) => {
@@ -56,6 +59,14 @@ describe(`Nav`, () => {
     const dropdown_menu = dropdown.querySelector<HTMLElement>(`[data-submenu]`)
     assert(dropdown_menu !== null, `No dropdown menu found`)
     return { dropdown, dropdown_menu }
+  }
+  // mounts a nav with a single dropdown and hands back the parts most tests need
+  const mount_dropdown = (props: Partial<ComponentProps<typeof Nav>> = {}) => {
+    mount_nav({ routes: single_dropdown_route, ...props })
+    const { dropdown, dropdown_menu } = query_dropdown_elements()
+    const toggle = dropdown.querySelector<HTMLElement>(`[data-dropdown-toggle]`)
+    assert(toggle !== null, `No dropdown toggle found`)
+    return { dropdown, dropdown_menu, toggle }
   }
   // all dropdowns with their submenus (for multi-dropdown tests)
   const query_all_dropdowns = () =>
@@ -167,14 +178,12 @@ describe(`Nav`, () => {
   })
 
   test(`click outside closes burger menu and dropdowns, inside click does not`, async () => {
-    mount_nav({ routes: single_dropdown_route })
+    const { dropdown_menu, toggle } = mount_dropdown()
     const burger_button = doc_query(`.burger`)
-    const toggle_button = doc_query(`[data-dropdown-toggle]`)
-    const { dropdown_menu } = query_dropdown_elements()
 
     // Open burger menu and dropdown
     await click(burger_button)
-    await click(toggle_button)
+    await click(toggle)
     expect(burger_button.getAttribute(`aria-expanded`)).toBe(`true`)
     expect(is_visible(dropdown_menu)).toBe(true)
 
@@ -195,8 +204,7 @@ describe(`Nav`, () => {
     [`menu panel`, (_dropdown: Element, menu: Element) => menu],
   ])(`dropdown opens/closes via mouse hover on %s`, async (_desc, get_target) => {
     vi.useFakeTimers()
-    mount_nav({ routes: single_dropdown_route })
-    const { dropdown, dropdown_menu } = query_dropdown_elements()
+    const { dropdown, dropdown_menu } = mount_dropdown()
     const target = get_target(dropdown, dropdown_menu)
     expect(is_visible(dropdown_menu)).toBe(false)
 
@@ -211,10 +219,10 @@ describe(`Nav`, () => {
   })
 
   test(`parent link and toggle button work independently`, async () => {
-    mount_nav({ routes: [[`/p`, [`/p`, `/p/c`]]] })
-    const { dropdown, dropdown_menu } = query_dropdown_elements()
+    const { dropdown, dropdown_menu, toggle } = mount_dropdown({
+      routes: [[`/p`, [`/p`, `/p/c`]]],
+    })
     const parent_link = dropdown.querySelector<HTMLElement>(`div:first-child > a`)
-    const toggle = doc_query(`[data-dropdown-toggle]`)
 
     await click(parent_link)
     expect(is_visible(dropdown_menu)).toBe(false)
@@ -309,9 +317,10 @@ describe(`Nav`, () => {
 
   test(`keyboard navigation: Enter/Space/ArrowDown open, arrows navigate, Escape closes`, async () => {
     const link_props = { onkeydown: vi.fn() }
-    mount_nav({ routes: [[`/p`, [`/p`, `/p/1`, `/p/2`]]], link_props })
-    const toggle_button = doc_query(`[data-dropdown-toggle]`)
-    const { dropdown_menu: menu } = query_dropdown_elements()
+    const { dropdown_menu: menu, toggle: toggle_button } = mount_dropdown({
+      routes: two_child_route,
+      link_props,
+    })
 
     // Enter/Space/ArrowDown all open and focus first item
     for (const open_key of [`Enter`, ` `, `ArrowDown`]) {
@@ -344,8 +353,7 @@ describe(`Nav`, () => {
   })
 
   test(`dropdown focus behavior`, async () => {
-    mount_nav({ routes: [[`/p`, [`/p`, `/p/1`]]] })
-    const { dropdown, dropdown_menu: menu } = query_dropdown_elements()
+    const { dropdown, dropdown_menu: menu } = mount_dropdown({ routes: one_child_route })
 
     focus_in(dropdown)
     await tick()
@@ -412,9 +420,9 @@ describe(`Nav`, () => {
   })
 
   test(`dropdown accessibility uses native navigation links and labelled toggles`, () => {
-    mount_nav({ routes: [[`/docs`, [`/docs`, `/docs/intro`]]] })
-
-    const { dropdown, dropdown_menu } = query_dropdown_elements()
+    const { dropdown, dropdown_menu, toggle } = mount_dropdown({
+      routes: [[`/docs`, [`/docs`, `/docs/intro`]]],
+    })
     const links = [...dropdown_menu.querySelectorAll(`a`)]
     // parent /docs is filtered out of the submenu
     expect(links.map((link) => link.getAttribute(`href`))).toEqual([`/docs/intro`])
@@ -422,7 +430,6 @@ describe(`Nav`, () => {
     const roles = [dropdown, dropdown_menu, ...links].map((el) => el.getAttribute(`role`))
     expect(roles).toEqual([null, null, null])
 
-    const toggle = doc_query(`[data-dropdown-toggle]`)
     expect([
       toggle.tagName,
       toggle.getAttribute(`aria-label`),
@@ -780,9 +787,7 @@ describe(`Nav`, () => {
   describe(`pinned dropdown feature`, () => {
     test(`click toggles pinned state and aria-expanded`, async () => {
       // cooldown 0 so an unpinned dropdown would hide within one macrotask
-      mount_nav({ routes: single_dropdown_route, dropdown_cooldown: 0 })
-      const { dropdown, dropdown_menu } = query_dropdown_elements()
-      const toggle = doc_query(`[data-dropdown-toggle]`)
+      const { dropdown, dropdown_menu, toggle } = mount_dropdown({ dropdown_cooldown: 0 })
 
       expect(is_visible(dropdown_menu)).toBe(false)
       expect(toggle.getAttribute(`aria-expanded`)).toBe(`false`)
@@ -806,8 +811,7 @@ describe(`Nav`, () => {
       afterEach(() => vi.useRealTimers())
 
       test.each([0, 100])(`cooldown=%dms closes after timeout`, async (cooldown) => {
-        mount_nav({ routes: single_dropdown_route, dropdown_cooldown: cooldown })
-        const { dropdown, dropdown_menu } = query_dropdown_elements()
+        const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown: cooldown })
 
         mouse_enter(dropdown)
         await tick()
@@ -823,8 +827,7 @@ describe(`Nav`, () => {
       })
 
       test(`multiple rapid enter/leave cycles reset cooldown each time`, async () => {
-        mount_nav({ routes: single_dropdown_route, dropdown_cooldown: 100 })
-        const { dropdown, dropdown_menu } = query_dropdown_elements()
+        const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown: 100 })
 
         for (let idx = 0; idx < 3; idx++) {
           mouse_enter(dropdown)
@@ -843,8 +846,7 @@ describe(`Nav`, () => {
         [`re-entering menu`, (_dropdown: Element, menu: Element) => mouse_enter(menu)],
         [`keyboard focus`, (dropdown: Element) => focus_in(dropdown)],
       ])(`%s during cooldown cancels hide`, async (_desc, reinteract) => {
-        mount_nav({ routes: single_dropdown_route, dropdown_cooldown: 150 })
-        const { dropdown, dropdown_menu } = query_dropdown_elements()
+        const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown: 150 })
 
         mouse_enter(dropdown)
         await tick()
@@ -857,8 +859,7 @@ describe(`Nav`, () => {
       })
 
       test(`pinned dropdown ignores cooldown on mouseleave`, async () => {
-        mount_nav({ routes: single_dropdown_route, dropdown_cooldown: 150 })
-        const { dropdown, dropdown_menu } = query_dropdown_elements()
+        const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown: 150 })
         const toggle = dropdown.querySelector<HTMLElement>(`[data-dropdown-toggle]`)
 
         await click(toggle)
@@ -909,9 +910,8 @@ describe(`Nav`, () => {
       ],
       [`Escape key`, escape],
     ])(`pinned dropdown closes on %s`, async (_trigger, close_action) => {
-      mount_nav({ routes: single_dropdown_route })
-      const { dropdown_menu } = query_dropdown_elements()
-      await click(doc_query(`[data-dropdown-toggle]`))
+      const { dropdown_menu, toggle } = mount_dropdown()
+      await click(toggle)
       expect(is_visible(dropdown_menu)).toBe(true)
       await close_action(dropdown_menu)
       expect(is_visible(dropdown_menu)).toBe(false)
@@ -941,9 +941,7 @@ describe(`Nav`, () => {
     test.each([`Enter`, ` `, `ArrowDown`])(
       `keyboard %s pins dropdown open`,
       async (key) => {
-        mount_nav({ routes: single_dropdown_route, dropdown_cooldown: 0 })
-        const { dropdown, dropdown_menu } = query_dropdown_elements()
-        const toggle = doc_query(`[data-dropdown-toggle]`)
+        const { dropdown, dropdown_menu, toggle } = mount_dropdown({ dropdown_cooldown: 0 })
 
         keydown(key, toggle)
         await next_task()
@@ -957,9 +955,7 @@ describe(`Nav`, () => {
     )
 
     test(`ArrowDown navigates within pinned dropdown after mouse leave`, async () => {
-      mount_nav({ routes: two_child_route, dropdown_cooldown: 0 })
-      const { dropdown, dropdown_menu } = query_dropdown_elements()
-      const toggle = doc_query(`[data-dropdown-toggle]`)
+      const { dropdown, dropdown_menu, toggle } = mount_dropdown(pinned_props)
 
       await click(toggle) // pin open, then leave with the mouse
       expect(is_visible(dropdown_menu)).toBe(true)
@@ -976,9 +972,7 @@ describe(`Nav`, () => {
     })
 
     test(`Escape on a submenu link closes it for good and restores focus`, async () => {
-      mount_nav({ routes: two_child_route, dropdown_cooldown: 0 })
-      const { dropdown_menu } = query_dropdown_elements()
-      const toggle = doc_query(`[data-dropdown-toggle]`)
+      const { dropdown_menu, toggle } = mount_dropdown(pinned_props)
 
       await click(toggle)
       const first_link = doc_query<HTMLAnchorElement>(`[data-submenu] a`)
@@ -992,8 +986,7 @@ describe(`Nav`, () => {
     })
 
     test(`Tab cycles within a pinned submenu instead of leaving it`, async () => {
-      mount_nav({ routes: two_child_route, dropdown_cooldown: 0 })
-      const { dropdown_menu } = query_dropdown_elements()
+      const { dropdown_menu } = mount_dropdown(pinned_props)
 
       await click(doc_query(`[data-dropdown-toggle]`))
       const links = [...dropdown_menu.querySelectorAll(`a`)]
@@ -1007,8 +1000,7 @@ describe(`Nav`, () => {
     })
 
     test(`pinned dropdown stays open on focus out`, async () => {
-      mount_nav({ routes: two_child_route })
-      const { dropdown, dropdown_menu } = query_dropdown_elements()
+      const { dropdown, dropdown_menu } = mount_dropdown({ routes: two_child_route })
 
       await click(doc_query(`[data-dropdown-toggle]`))
       expect(is_visible(dropdown_menu)).toBe(true)
@@ -1028,12 +1020,9 @@ describe(`Nav`, () => {
 
     test(`pinned state clears when burger menu closes`, async () => {
       set_window_width(500)
-      mount_nav({ routes: single_dropdown_route, breakpoint: 767 })
+      const { dropdown_menu, toggle } = mount_dropdown({ breakpoint: 767 })
       await tick()
-
       const burger = doc_query(`.burger`)
-      const { dropdown_menu } = query_dropdown_elements()
-      const toggle = doc_query(`[data-dropdown-toggle]`)
 
       await click(burger)
       await click(toggle)
@@ -1070,8 +1059,7 @@ describe(`Nav`, () => {
 
     // Open dropdown and enter the panel, returning elements for assertions
     const open_and_enter_panel = async () => {
-      mount_nav({ routes: single_dropdown_route, dropdown_cooldown: 50 })
-      const { dropdown, dropdown_menu } = query_dropdown_elements()
+      const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown: 50 })
       mouse_enter(dropdown)
       await tick()
       mouse_enter(dropdown_menu)
@@ -1182,18 +1170,17 @@ describe(`Nav`, () => {
     afterEach(() => vi.unstubAllGlobals())
 
     test(`mouse hover does not open dropdowns on mobile touch devices`, async () => {
-      vi.stubGlobal(`ontouchstart`, () => {}) // makes 'ontouchstart' in globalThis true
+      vi.stubGlobal(`ontouchstart`, () => {}) // makes `ontouchstart` in globalThis true
       set_window_width(500)
-      mount_nav({ routes: single_dropdown_route })
+      const { dropdown, dropdown_menu, toggle } = mount_dropdown()
       await tick()
 
-      const { dropdown, dropdown_menu } = query_dropdown_elements()
       mouse_enter(dropdown)
       await tick()
       expect(is_visible(dropdown_menu)).toBe(false)
 
       // explicit toggle click still opens the dropdown on touch devices
-      await click(doc_query(`[data-dropdown-toggle]`))
+      await click(toggle)
       expect(is_visible(dropdown_menu)).toBe(true)
     })
 
@@ -1201,10 +1188,9 @@ describe(`Nav`, () => {
       vi.useFakeTimers()
       vi.stubGlobal(`ontouchstart`, () => {})
       // desktop width: hover-open is only blocked when touch AND mobile
-      mount_nav({ routes: single_dropdown_route, dropdown_cooldown: 0 })
+      const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown: 0 })
       await tick()
 
-      const { dropdown, dropdown_menu } = query_dropdown_elements()
       mouse_enter(dropdown)
       await tick()
       expect(is_visible(dropdown_menu)).toBe(true)

--- a/tests/vitest/Popover.svelte.test.ts
+++ b/tests/vitest/Popover.svelte.test.ts
@@ -1,0 +1,119 @@
+import type { ComponentProps } from 'svelte'
+import { mount, tick, unmount } from 'svelte'
+import { afterEach, describe, expect, test, vi } from 'vite-plus/test'
+import type Popover from '$lib/Popover.svelte'
+import { doc_query } from './index'
+import TestPopover from './TestPopover.svelte'
+
+describe(`Popover`, () => {
+  type PopoverProps = Omit<ComponentProps<typeof Popover>, `children`>
+  // click_outside and focus_trap register document listeners that outlive
+  // document.body.innerHTML = '', so unmount for real between cases
+  const mounted: Record<string, unknown>[] = []
+  afterEach(() => {
+    for (const app of mounted.splice(0)) void unmount(app)
+  })
+  const mount_popover = (extra: Partial<PopoverProps> = {}) => {
+    const props = $state({ ...extra })
+    mounted.push(mount(TestPopover, { target: document.body, props }))
+  }
+  const trigger = () => doc_query<HTMLButtonElement>(`[data-testid="popover-trigger"]`)
+  const surface = () => document.querySelector(`[role="dialog"]`)
+  const press = (target: EventTarget) =>
+    target.dispatchEvent(new PointerEvent(`pointerdown`, { bubbles: true }))
+
+  test(`trigger opens the surface and wires the aria attributes`, async () => {
+    mount_popover()
+    expect(surface()).toBeNull()
+    expect(trigger().getAttribute(`aria-expanded`)).toBe(`false`)
+
+    trigger().click()
+    await tick()
+
+    expect(trigger().getAttribute(`aria-expanded`)).toBe(`true`)
+    expect(surface()?.id).toBe(trigger().getAttribute(`aria-controls`))
+    // focus_trap moved the keyboard into the surface
+    expect(document.activeElement).toBe(doc_query(`[data-testid="popover-item"]`))
+  })
+
+  // The wrapper around the trigger snippet is `display: contents` and measures 0x0,
+  // so anchoring to it would pin every popover to the viewport corner
+  test(`positions against the trigger, not the wrapper around it`, async () => {
+    mount_popover({ offset: 8 })
+    const rect = { top: 20, bottom: 50, left: 100, right: 200, width: 100, height: 30 }
+    trigger().getBoundingClientRect = vi.fn(() => rect as DOMRect)
+
+    trigger().click()
+    await tick()
+
+    expect(doc_query(`[role="dialog"]`).style.top).toBe(`58px`) // 50 + 8
+  })
+
+  test.each([
+    [`a press outside`, `pointer`, () => press(document.body)],
+    [
+      `Escape`,
+      `escape`,
+      () =>
+        document.dispatchEvent(
+          new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }),
+        ),
+    ],
+  ] as const)(`%s closes it, reporting via=%s`, async (_desc, via, dismiss) => {
+    const on_close = vi.fn()
+    mount_popover({ on_close })
+    trigger().click()
+    await tick()
+
+    dismiss()
+    await tick()
+
+    expect(surface()).toBeNull()
+    expect(on_close).toHaveBeenCalledWith({ via })
+    // the trap handed the keyboard back to where it came from
+    expect(document.activeElement).toBe(trigger())
+  })
+
+  test(`pressing the trigger closes instead of reopening on the same gesture`, async () => {
+    mount_popover()
+    trigger().click()
+    await tick()
+
+    // the press counts as inside, so only the click that follows acts
+    press(trigger())
+    await tick()
+    expect(surface()).not.toBeNull()
+
+    trigger().click()
+    await tick()
+    expect(surface()).toBeNull()
+  })
+
+  test(`a press inside the surface leaves it open`, async () => {
+    mount_popover()
+    trigger().click()
+    await tick()
+
+    press(doc_query(`[data-testid="popover-item"]`))
+    await tick()
+    expect(surface()).not.toBeNull()
+  })
+
+  test.each([
+    [`escape: false`, { escape: false }],
+    [`trap_focus: false`, { trap_focus: false }],
+  ] as const)(`%s opts out`, async (_desc, options) => {
+    mount_popover(options)
+    trigger().focus()
+    trigger().click()
+    await tick()
+
+    if (`trap_focus` in options) {
+      expect(document.activeElement).toBe(trigger()) // focus stayed put
+      return
+    }
+    document.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
+    await tick()
+    expect(surface()).not.toBeNull()
+  })
+})

--- a/tests/vitest/Popover.svelte.test.ts
+++ b/tests/vitest/Popover.svelte.test.ts
@@ -36,6 +36,14 @@ describe(`Popover`, () => {
     expect(document.activeElement).toBe(doc_query(`[data-testid="popover-item"]`))
   })
 
+  test(`keeps its own id so a consumer's cannot break the aria linkage`, async () => {
+    mount_popover({ id: `consumer-id` })
+    trigger().click()
+    await tick()
+
+    expect(surface()?.id).toBe(trigger().getAttribute(`aria-controls`))
+  })
+
   // The wrapper around the trigger snippet is `display: contents` and measures 0x0,
   // so anchoring to it would pin every popover to the viewport corner
   test(`positions against the trigger, not the wrapper around it`, async () => {

--- a/tests/vitest/Popover.svelte.test.ts
+++ b/tests/vitest/Popover.svelte.test.ts
@@ -36,12 +36,18 @@ describe(`Popover`, () => {
     expect(document.activeElement).toBe(doc_query(`[data-testid="popover-item"]`))
   })
 
-  test(`keeps its own id so a consumer's cannot break the aria linkage`, async () => {
-    mount_popover({ id: `consumer-id` })
+  // both live after the {...rest} spread, so a consumer prop cannot clobber the aria
+  // linkage or drop the .popover class every bit of the styling hangs off
+  test(`keeps its own id and class alongside a consumer's`, async () => {
+    mount_popover({ id: `consumer-id`, class: `consumer-class` })
     trigger().click()
     await tick()
 
-    expect(surface()?.id).toBe(trigger().getAttribute(`aria-controls`))
+    const dialog = doc_query(`[role="dialog"]`)
+    expect(dialog.id).toBe(trigger().getAttribute(`aria-controls`))
+    // svelte adds its own scoping hash, so check membership not the whole list
+    expect(dialog.classList.contains(`popover`)).toBe(true)
+    expect(dialog.classList.contains(`consumer-class`)).toBe(true)
   })
 
   // The wrapper around the trigger snippet is `display: contents` and measures 0x0,
@@ -82,46 +88,42 @@ describe(`Popover`, () => {
     expect(document.activeElement).toBe(trigger())
   })
 
-  test(`pressing the trigger closes instead of reopening on the same gesture`, async () => {
-    mount_popover()
+  test(`presses inside leave it open, so the trigger click can close it`, async () => {
+    const on_close = vi.fn()
+    mount_popover({ on_close })
     trigger().click()
     await tick()
 
-    // the press counts as inside, so only the click that follows acts
+    // the trigger sits in click_outside's inside list and the item is in the surface,
+    // so neither press dismisses and only the click that follows acts
     press(trigger())
+    press(doc_query(`[data-testid="popover-item"]`))
     await tick()
     expect(surface()).not.toBeNull()
+    expect(on_close).not.toHaveBeenCalled()
 
     trigger().click()
     await tick()
     expect(surface()).toBeNull()
+    expect(on_close).toHaveBeenCalledWith({ via: `trigger` })
   })
 
-  test(`a press inside the surface leaves it open`, async () => {
-    mount_popover()
+  test(`escape: false leaves Escape to the consumer`, async () => {
+    mount_popover({ escape: false })
     trigger().click()
     await tick()
 
-    press(doc_query(`[data-testid="popover-item"]`))
+    document.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
     await tick()
     expect(surface()).not.toBeNull()
   })
 
-  test.each([
-    [`escape: false`, { escape: false }],
-    [`trap_focus: false`, { trap_focus: false }],
-  ] as const)(`%s opts out`, async (_desc, options) => {
-    mount_popover(options)
+  test(`trap_focus: false leaves focus where it was`, async () => {
+    mount_popover({ trap_focus: false })
     trigger().focus()
     trigger().click()
     await tick()
 
-    if (`trap_focus` in options) {
-      expect(document.activeElement).toBe(trigger()) // focus stayed put
-      return
-    }
-    document.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
-    await tick()
-    expect(surface()).not.toBeNull()
+    expect(document.activeElement).toBe(trigger())
   })
 })

--- a/tests/vitest/TestPopover.svelte
+++ b/tests/vitest/TestPopover.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Popover from '$lib/Popover.svelte'
+  import type { ComponentProps } from 'svelte'
+
+  // Kept out of TestSnippetHarness: one more branch there makes the discriminated
+  // union too complex for TS to narrow, which mistypes every other branch.
+  let props: Omit<ComponentProps<typeof Popover>, `children`> = $props()
+</script>
+
+<Popover {...props}>
+  {#snippet trigger(trigger_props)}
+    <button data-testid="popover-trigger" {...trigger_props}>open</button>
+  {/snippet}
+  <button data-testid="popover-item">inside</button>
+</Popover>

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -1237,7 +1237,10 @@ describe(`hotkey`, () => {
   afterEach(() => {
     for (const cleanup of cleanups.splice(0)) cleanup()
   })
-  const attach_hotkey = (options: Parameters<typeof hotkey>[0], node = create_element()) => {
+  const attach_hotkey = (
+    options: Parameters<typeof hotkey>[0],
+    node = create_element(),
+  ) => {
     const cleanup = hotkey(options)(node)
     if (cleanup) cleanups.push(cleanup)
     return { node, cleanup }

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -1,3 +1,4 @@
+import type { FocusTrapOptions } from '$lib/attachments'
 import {
   click_outside,
   draggable,
@@ -341,11 +342,6 @@ describe(`tooltip`, () => {
       trigger_tooltip(element)
       expect(document.querySelector(`.custom-tooltip`)).toBeNull()
     })
-  })
-
-  describe(`Configuration Options`, () => {
-    beforeEach(() => vi.useFakeTimers())
-    afterEach(() => vi.useRealTimers())
 
     it(`should handle disabled option`, () => {
       const [element, cleanup] = attach_tooltip(`Disabled tooltip`, { disabled: true })
@@ -399,6 +395,12 @@ describe(`tooltip`, () => {
   })
 
   describe(`Event Handling and Cleanup`, () => {
+    it(`should handle an invalid element gracefully`, () => {
+      const attach = tooltip()
+      // @ts-expect-error testing a null input
+      expect(attach(null)).toBeUndefined()
+    })
+
     it(`should restore original title on cleanup`, () => {
       const element = create_element()
       element.title = `Original title`
@@ -438,14 +440,6 @@ describe(`tooltip`, () => {
       cleanup?.()
       expect(element.getAttribute(`title`)).toBe(`Late title`)
       expect(element.hasAttribute(`data-original-title`)).toBe(false)
-    })
-  })
-
-  describe(`Error Handling`, () => {
-    it(`should handle an invalid element gracefully`, () => {
-      const attach = tooltip()
-      // @ts-expect-error testing a null input
-      expect(attach(null)).toBeUndefined()
     })
   })
 
@@ -550,7 +544,7 @@ describe(`tooltip`, () => {
     })
   })
 
-  describe(`New Features`, () => {
+  describe(`Placement, Styling and Content`, () => {
     beforeEach(() => vi.useFakeTimers())
 
     it.each([
@@ -1238,10 +1232,20 @@ describe(`hotkey`, () => {
     return event
   }
 
+  // a global binding outlives document.body.innerHTML = '', so dispose every one
+  const cleanups: (() => void)[] = []
+  afterEach(() => {
+    for (const cleanup of cleanups.splice(0)) cleanup()
+  })
+  const attach_hotkey = (options: Parameters<typeof hotkey>[0], node = create_element()) => {
+    const cleanup = hotkey(options)(node)
+    if (cleanup) cleanups.push(cleanup)
+    return { node, cleanup }
+  }
+
   it(`fires on the node it is attached to, not on the rest of the page`, () => {
-    const node = create_element()
     const handler = vi.fn()
-    const cleanup = hotkey({ bindings: [{ keys: `ctrl+k`, handler }] })(node)
+    const { node, cleanup } = attach_hotkey({ bindings: [{ keys: `ctrl+k`, handler }] })
 
     const event = keydown(node, `k`, { ctrlKey: true })
     expect(handler).toHaveBeenCalledTimes(1)
@@ -1257,26 +1261,23 @@ describe(`hotkey`, () => {
 
   it(`global listens anywhere on the page`, () => {
     const handler = vi.fn()
-    const cleanup = hotkey({ bindings: [{ keys: `ctrl+k`, handler }], global: true })(
-      create_element(),
-    )
+    attach_hotkey({ bindings: [{ keys: `ctrl+k`, handler }], global: true })
 
     keydown(create_element(), `k`, { ctrlKey: true })
     expect(handler).toHaveBeenCalledTimes(1)
-    cleanup?.()
   })
 
   it(`leaves bare keys to text fields unless told otherwise`, () => {
     const input = create_element(`input`)
     const [typed, forced, chord] = [vi.fn(), vi.fn(), vi.fn()]
-    const cleanup = hotkey({
+    attach_hotkey({
       global: true,
       bindings: [
         { keys: `/`, handler: typed },
         { keys: `?`, handler: forced, allow_in_inputs: true },
         { keys: `ctrl+/`, handler: chord },
       ],
-    })(create_element())
+    })
 
     keydown(input, `/`)
     expect(typed).not.toHaveBeenCalled() // the user is typing a slash
@@ -1286,26 +1287,23 @@ describe(`hotkey`, () => {
 
     keydown(input, `/`, { ctrlKey: true })
     expect(chord).toHaveBeenCalledTimes(1) // a chord is never typing
-    cleanup?.()
   })
 
   it(`runs the first enabled match only and can leave the default alone`, () => {
-    const node = create_element()
     const [off, first, second] = [vi.fn(), vi.fn(), vi.fn()]
-    const cleanup = hotkey({
+    const { node } = attach_hotkey({
       bindings: [
         { keys: `ctrl+k`, handler: off, enabled: false },
         { keys: [`ctrl+j`, `ctrl+k`], handler: first, prevent_default: false },
         { keys: `ctrl+k`, handler: second },
       ],
-    })(node)
+    })
 
     const event = keydown(node, `k`, { ctrlKey: true })
     expect(off).not.toHaveBeenCalled()
     expect(first).toHaveBeenCalledTimes(1)
     expect(second).not.toHaveBeenCalled()
     expect(event.defaultPrevented).toBe(false)
-    cleanup?.()
   })
 
   it.each([
@@ -1316,9 +1314,8 @@ describe(`hotkey`, () => {
       value: user_agent,
       configurable: true,
     })
-    const node = create_element()
     const handler = vi.fn()
-    const cleanup = hotkey({ bindings: [{ keys: `mod+k`, handler }] })(node)
+    const { node } = attach_hotkey({ bindings: [{ keys: `mod+k`, handler }] })
 
     keydown(node, `k`, other)
     expect(handler).not.toHaveBeenCalled()
@@ -1326,25 +1323,25 @@ describe(`hotkey`, () => {
     keydown(node, `k`, matching)
     expect(handler).toHaveBeenCalledTimes(1)
 
-    cleanup?.()
     Reflect.deleteProperty(globalThis.navigator, `userAgent`)
   })
 
   it(`stays quiet mid IME composition and when disabled`, () => {
     const node = create_element()
     const handler = vi.fn()
-    expect(
-      hotkey({ bindings: [{ keys: `ctrl+k`, handler }], enabled: false })(node),
-    ).toBeUndefined()
+    const { cleanup } = attach_hotkey(
+      { bindings: [{ keys: `ctrl+k`, handler }], enabled: false },
+      node,
+    )
+    expect(cleanup).toBeUndefined()
     keydown(node, `k`, { ctrlKey: true })
     expect(handler).not.toHaveBeenCalled()
 
-    const cleanup = hotkey({ bindings: [{ keys: `Enter`, handler }] })(node)
+    attach_hotkey({ bindings: [{ keys: `Enter`, handler }] }, node)
     keydown(node, `Enter`, { isComposing: true })
     expect(handler).not.toHaveBeenCalled()
     keydown(node, `Enter`)
     expect(handler).toHaveBeenCalledTimes(1)
-    cleanup?.()
   })
 })
 
@@ -1359,19 +1356,32 @@ describe(`focus_trap`, () => {
     return { surface, buttons }
   }
 
-  const press_tab = (shiftKey = false) =>
-    document.dispatchEvent(
-      new KeyboardEvent(`keydown`, {
-        key: `Tab`,
-        bubbles: true,
-        cancelable: true,
-        shiftKey,
-      }),
-    )
+  // returned so callers can assert the browser still gets its Tab
+  const press_tab = (shiftKey = false) => {
+    const event = new KeyboardEvent(`keydown`, {
+      key: `Tab`,
+      bubbles: true,
+      cancelable: true,
+      shiftKey,
+    })
+    document.dispatchEvent(event)
+    return event
+  }
+
+  // the trap layer stack is module-global, so a leaked trap steers a later test's Tab
+  const cleanups: (() => void)[] = []
+  afterEach(() => {
+    for (const cleanup of cleanups.splice(0)) cleanup()
+  })
+  const attach_trap = (surface: HTMLElement, options: FocusTrapOptions = {}) => {
+    const cleanup = focus_trap(options)(surface)
+    if (cleanup) cleanups.push(cleanup)
+    return cleanup
+  }
 
   it(`focuses the first tabbable, then cycles Tab both ways past the ends`, () => {
     const { surface, buttons } = make_surface()
-    const cleanup = focus_trap()(surface)
+    attach_trap(surface)
     expect(document.activeElement).toBe(buttons[0])
 
     press_tab()
@@ -1381,7 +1391,6 @@ describe(`focus_trap`, () => {
     expect(document.activeElement).toBe(buttons[0]) // wrapped past the last
     press_tab(true)
     expect(document.activeElement).toBe(buttons[2]) // and back past the first
-    cleanup?.()
   })
 
   it(`skips candidates the keyboard cannot reach`, () => {
@@ -1392,11 +1401,10 @@ describe(`focus_trap`, () => {
     reachable.href = `#target`
     surface.append(reachable)
 
-    const cleanup = focus_trap()(surface)
+    attach_trap(surface)
     expect(document.activeElement).toBe(buttons[0])
     press_tab()
     expect(document.activeElement).toBe(reachable)
-    cleanup?.()
   })
 
   it.each([
@@ -1408,9 +1416,8 @@ describe(`focus_trap`, () => {
     const outside = create_element(`button`)
     outside.focus()
 
-    const cleanup = focus_trap({ initial })(surface)
+    attach_trap(surface, { initial })
     expect(document.activeElement).toBe(initial === false ? outside : buttons[2])
-    cleanup?.()
   })
 
   it(`hands focus back to where it came from, or to a named element`, () => {
@@ -1441,8 +1448,8 @@ describe(`focus_trap`, () => {
   it(`gives Tab to the innermost trap only`, () => {
     const outer = make_surface()
     const inner = make_surface()
-    const cleanup_outer = focus_trap()(outer.surface)
-    const cleanup_inner = focus_trap()(inner.surface)
+    attach_trap(outer.surface)
+    const cleanup_inner = attach_trap(inner.surface)
     expect(document.activeElement).toBe(inner.buttons[0])
 
     press_tab()
@@ -1453,7 +1460,6 @@ describe(`focus_trap`, () => {
     outer.buttons[0].focus()
     press_tab()
     expect(document.activeElement).toBe(outer.buttons[1])
-    cleanup_outer?.()
   })
 
   // The trap listens on the document, so a surface that was never given focus must
@@ -1464,16 +1470,10 @@ describe(`focus_trap`, () => {
     const outside = create_element(`button`)
     outside.focus()
 
-    const cleanup = focus_trap({ initial: false })(surface)
+    attach_trap(surface, { initial: false })
     expect(document.activeElement).toBe(outside) // initial: false kept focus put
 
-    const event = new KeyboardEvent(`keydown`, {
-      key: `Tab`,
-      bubbles: true,
-      cancelable: true,
-    })
-    document.dispatchEvent(event)
-
+    const event = press_tab()
     expect(document.activeElement).toBe(outside) // not dragged into the surface
     expect(event.defaultPrevented).toBe(false) // the browser still gets its Tab
 
@@ -1481,7 +1481,6 @@ describe(`focus_trap`, () => {
     buttons[0].focus()
     press_tab()
     expect(document.activeElement).toBe(buttons[1])
-    cleanup?.()
   })
 
   it(`covers portalled parts of the same surface via include`, () => {
@@ -1490,11 +1489,10 @@ describe(`focus_trap`, () => {
     const portalled_button = document.createElement(`button`)
     portalled.append(portalled_button)
 
-    const cleanup = focus_trap({ include: [null, portalled] })(surface)
+    attach_trap(surface, { include: [null, portalled] })
     expect(document.activeElement).toBe(buttons[0])
     press_tab()
     expect(document.activeElement).toBe(portalled_button)
-    cleanup?.()
   })
 
   it(`does nothing when disabled`, () => {
@@ -1510,10 +1508,16 @@ describe(`focus_trap`, () => {
 })
 
 describe(`draggable`, () => {
+  // fixed positioning makes the attachment read getBoundingClientRect, which mock_rect
+  // controls; the offset* fallback path has its own case below
+  const create_fixed_box = (rect = { left: 10, top: 20 }) => {
+    const element = create_element(`div`, { position: `fixed` })
+    mock_rect(element, rect)
+    return element
+  }
+
   it(`should update position, callbacks, cursor, and userSelect while dragging`, () => {
-    const element = create_element()
-    element.style.position = `fixed`
-    mock_rect(element, { left: 10, top: 20 })
+    const element = create_fixed_box()
     const [on_drag_start, on_drag, on_drag_end] = [vi.fn(), vi.fn(), vi.fn()]
 
     const cleanup = draggable({ on_drag_start, on_drag, on_drag_end })(element)
@@ -1543,9 +1547,7 @@ describe(`draggable`, () => {
 
   it(`should not start dragging on a non-primary mouse button`, () => {
     // the context menu can swallow the mouseup, leaving the element stuck to the cursor
-    const element = create_element()
-    element.style.position = `fixed`
-    mock_rect(element, { left: 10, top: 20 })
+    const element = create_fixed_box()
     draggable({})(element)
 
     element.dispatchEvent(mouse_event(`mousedown`, 5, 5, 2))
@@ -1554,9 +1556,7 @@ describe(`draggable`, () => {
   })
 
   it(`should not set up dragging when disabled`, () => {
-    const element = create_element()
-    element.style.position = `fixed`
-    mock_rect(element, { left: 10, top: 20 })
+    const element = create_fixed_box()
     const cleanup = draggable({ disabled: true })(element)
     expect(cleanup).toBeUndefined()
     expect(element.style.cursor).toBe(``)
@@ -1578,9 +1578,7 @@ describe(`draggable`, () => {
   })
 
   it(`should only drag when event originates from handle_selector`, () => {
-    const element = create_element()
-    element.style.position = `fixed`
-    mock_rect(element, { left: 0, top: 0 })
+    const element = create_fixed_box({ left: 0, top: 0 })
 
     const handle = document.createElement(`div`)
     handle.className = `drag-handle`
@@ -1636,9 +1634,7 @@ describe(`draggable`, () => {
   })
 
   it(`should reset body userSelect and cursor when cleaned up mid-drag`, () => {
-    const element = create_element()
-    element.style.position = `fixed`
-    mock_rect(element, { left: 0, top: 0 })
+    const element = create_fixed_box({ left: 0, top: 0 })
 
     const cleanup = draggable()(element)
     element.dispatchEvent(mouse_event(`mousedown`, 5, 5))
@@ -2187,7 +2183,12 @@ describe(`sortable`, () => {
 })
 
 describe(`resizable`, () => {
-  const create_box = () => create_element(`div`, { width: `200px`, height: `150px` })
+  // every case resizes the same 200x150 box unless it needs its own position
+  const create_box = (rect = { left: 0, top: 0, width: 200, height: 150 }) => {
+    const element = create_element(`div`, { width: `200px`, height: `150px` })
+    mock_rect(element, rect)
+    return element
+  }
 
   it.each([
     [`right`, undefined, 195, 75, `ew-resize`],
@@ -2198,7 +2199,6 @@ describe(`resizable`, () => {
     `should apply resize cursor on %s edge hover`,
     (_edge, edges, clientX, clientY, expected_cursor) => {
       const element = create_box()
-      mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
       resizable(edges ? { edges: [...edges] } : {})(element)
 
       element.dispatchEvent(mouse_event(`mousemove`, clientX, clientY))
@@ -2209,7 +2209,6 @@ describe(`resizable`, () => {
 
   it(`should use custom handle_size and reset the cursor away from edges`, () => {
     const element = create_box()
-    mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
     const cleanup = resizable({ handle_size: 20 })(element)
 
     element.dispatchEvent(mouse_event(`mousemove`, 185, 75))
@@ -2239,7 +2238,6 @@ describe(`resizable`, () => {
       expected_value,
     ) => {
       const element = create_box()
-      mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
       resizable(options)(element)
 
       element.dispatchEvent(mouse_event(`mousedown`, start_client_x, start_client_y))
@@ -2253,7 +2251,6 @@ describe(`resizable`, () => {
 
   it(`should not start resizing on a non-primary mouse button`, () => {
     const element = create_box()
-    mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
     const on_resize_start = vi.fn()
     resizable({ on_resize_start })(element)
 
@@ -2263,7 +2260,6 @@ describe(`resizable`, () => {
 
   it(`should fire on_resize_start, on_resize, and on_resize_end callbacks`, () => {
     const element = create_box()
-    mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
 
     const on_resize_start = vi.fn()
     const on_resize = vi.fn()
@@ -2320,8 +2316,7 @@ describe(`resizable`, () => {
       [drag_client_x, drag_client_y],
       expected_styles,
     ) => {
-      const element = create_box()
-      mock_rect(element, rect)
+      const element = create_box(rect)
       resizable({ edges: [_edge] })(element)
 
       element.dispatchEvent(mouse_event(`mousedown`, start_client_x, start_client_y))
@@ -2337,7 +2332,6 @@ describe(`resizable`, () => {
 
   it(`should do nothing when disabled`, () => {
     const element = create_box()
-    mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
     const on_resize_start = vi.fn()
     const cleanup = resizable({ disabled: true, on_resize_start })(element)
 
@@ -2378,7 +2372,6 @@ describe(`resizable`, () => {
   ])(`position %s initializes as %s`, (initial_position, expected_position) => {
     const element = create_box()
     element.style.position = initial_position
-    mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
 
     resizable()(element)
 
@@ -2387,7 +2380,6 @@ describe(`resizable`, () => {
 
   it(`should not start resizing when clicking outside edge areas`, () => {
     const element = create_box()
-    mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
     const on_resize_start = vi.fn()
     resizable({ on_resize_start })(element)
 
@@ -2410,7 +2402,6 @@ describe(`resizable`, () => {
 
   it(`should reset body userSelect when cleaned up mid-resize`, () => {
     const element = create_box()
-    mock_rect(element, { left: 0, top: 0, width: 200, height: 150 })
     const on_resize = vi.fn()
 
     const cleanup = resizable({ on_resize })(element)

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -1,8 +1,10 @@
 import {
   click_outside,
   draggable,
+  focus_trap,
   get_html_sort_value,
   highlight_matches,
+  hotkey,
   resizable,
   sortable,
   tooltip,
@@ -920,8 +922,12 @@ describe(`tooltip`, () => {
 })
 
 describe(`click_outside`, () => {
-  const dispatch_press = (target: Element, path: EventTarget[] = []) => {
-    const event = new Event(`pointerdown`, { bubbles: true })
+  const dispatch_press = (
+    target: Element,
+    path: EventTarget[] = [],
+    kind = `pointerdown`,
+  ) => {
+    const event = new Event(kind, { bubbles: true })
     Object.defineProperty(event, `target`, { value: target })
     Object.defineProperty(event, `composedPath`, {
       value: () =>
@@ -933,14 +939,32 @@ describe(`click_outside`, () => {
     return event
   }
 
+  // returns the event so callers can assert on identity or defaultPrevented
+  const press_escape = (init: KeyboardEventInit = {}) => {
+    const event = new KeyboardEvent(`keydown`, {
+      key: `Escape`,
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    })
+    document.dispatchEvent(event)
+    return event
+  }
+
+  // attaches click_outside to a fresh element wired to a spy callback
+  const attach_outside = (config: Parameters<typeof click_outside>[0] = {}) => {
+    const element = create_element()
+    const callback = vi.fn()
+    const cleanup = click_outside({ callback, ...config })(element)
+    return { element, callback, cleanup }
+  }
+
   it.each([
     [`outside click`, true, true, 1],
     [`inside click`, false, true, 0],
     [`disabled`, true, false, 0],
   ])(`%s triggers callback %s times`, (_desc, is_outside, enabled, expected_calls) => {
-    const element = create_element()
-    const callback = vi.fn()
-    click_outside({ callback, enabled })(element)
+    const { element, callback } = attach_outside({ enabled })
 
     const target = is_outside ? create_element() : element
     const path = is_outside
@@ -951,34 +975,30 @@ describe(`click_outside`, () => {
     expect(callback).toHaveBeenCalledTimes(expected_calls)
   })
 
-  it(`should handle exclude selectors (single, multiple, nested)`, () => {
-    const element = create_element()
-    const [excluded1, excluded2, nested] = [
+  it(`inside selectors keep matching regions from dismissing (single, multiple, nested)`, () => {
+    const [modal, popover, nested] = [
       create_element(),
       create_element(),
       create_element(),
     ]
-    excluded1.className = `modal`
-    excluded2.className = `popover`
-    excluded1.append(nested)
+    modal.className = `modal`
+    popover.className = `popover`
+    modal.append(nested)
 
-    const callback = vi.fn()
-    click_outside({ callback, exclude: [`.modal`, `.popover`] })(element)
+    const { callback } = attach_outside({ inside: [`.modal`, `.popover`] })
 
-    dispatch_press(excluded1)
-    dispatch_press(excluded2)
+    dispatch_press(modal)
+    dispatch_press(popover)
     dispatch_press(nested)
     expect(callback).not.toHaveBeenCalled()
 
-    // control: proves the silence above is the exclude list, not a dead listener
+    // control: proves the silence above is the inside list, not a dead listener
     dispatch_press(create_element())
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
   it(`should trigger on clicks landing on SVG elements outside the node`, () => {
-    const element = create_element()
-    const callback = vi.fn()
-    click_outside({ callback })(element)
+    const { callback } = attach_outside()
 
     const svg = document.createElementNS(`http://www.w3.org/2000/svg`, `svg`)
     document.body.append(svg)
@@ -990,16 +1010,14 @@ describe(`click_outside`, () => {
   it(`should dispatch custom event without a callback`, () => {
     const element = create_element()
     const listener = vi.fn()
-    element.addEventListener(`outside-click`, listener)
+    element.addEventListener(`dismiss`, listener)
     click_outside({})(element) // no callback
     dispatch_press(create_element())
     expect(listener).toHaveBeenCalled()
   })
 
   it(`cleanup stops triggering callbacks`, () => {
-    const element = create_element()
-    const callback = vi.fn()
-    const cleanup = click_outside({ callback })(element)
+    const { callback, cleanup } = attach_outside()
 
     dispatch_press(create_element())
     expect(callback).toHaveBeenCalledTimes(1)
@@ -1010,20 +1028,24 @@ describe(`click_outside`, () => {
   })
 
   it(`dismisses on the press, not on a following click`, () => {
-    const element = create_element()
-    const callback = vi.fn()
-    click_outside({ callback })(element)
+    const { callback } = attach_outside()
 
     const outside = create_element()
-    dispatch_press(outside)
+    const event = dispatch_press(outside)
     expect(callback).toHaveBeenCalledTimes(1)
+    // the press comes along so consumers can forward it to their own onclose
+    expect(callback.mock.calls[0][2]).toEqual({
+      focus_inside: false,
+      via: `pointer`,
+      event,
+    })
 
     // right-clicks and OS-captured drags never send this click, hence pointerdown
     outside.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  it(`scope confines exclude matches to one subtree`, () => {
+  it(`scope confines inside selectors to one subtree`, () => {
     const [own_scope, own_trigger, other_trigger] = [
       create_element(),
       create_element(),
@@ -1033,9 +1055,7 @@ describe(`click_outside`, () => {
     other_trigger.className = `trigger`
     own_scope.append(own_trigger)
 
-    const element = create_element()
-    const callback = vi.fn()
-    click_outside({ callback, exclude: [`.trigger`], scope: own_scope })(element)
+    const { callback } = attach_outside({ inside: [`.trigger`], scope: own_scope })
 
     dispatch_press(own_trigger)
     expect(callback).not.toHaveBeenCalled()
@@ -1045,29 +1065,438 @@ describe(`click_outside`, () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
+  it(`an element in inside counts as part of the surface`, () => {
+    const portalled = create_element() // sibling in body, no longer a descendant
+    const nested = document.createElement(`button`)
+    portalled.append(nested)
+
+    // null entries are the norm: the portal target binds after the first render
+    const { callback } = attach_outside({ inside: [null, portalled] })
+
+    dispatch_press(portalled)
+    dispatch_press(nested)
+    expect(callback).not.toHaveBeenCalled()
+
+    dispatch_press(create_element())
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it(`escape dismisses only the innermost layer`, () => {
+    const outer = attach_outside({ escape: true })
+    const inner = attach_outside({ escape: true })
+
+    press_escape()
+    expect(inner.callback).toHaveBeenCalledTimes(1)
+    expect(outer.callback).not.toHaveBeenCalled()
+
+    // with the inner surface gone, the next Escape reaches the one behind it
+    inner.cleanup?.()
+    press_escape()
+    expect(inner.callback).toHaveBeenCalledTimes(1)
+    expect(outer.callback).toHaveBeenCalledTimes(1)
+    outer.cleanup?.()
+  })
+
+  it(`escape stops at the top layer instead of reaching page handlers`, () => {
+    const page_handler = vi.fn()
+    document.addEventListener(`keydown`, page_handler)
+    const { cleanup } = attach_outside({ escape: true })
+
+    const event = press_escape()
+
+    expect(page_handler).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true) // a native <dialog> stays open
+
+    cleanup?.()
+    press_escape()
+    expect(page_handler).toHaveBeenCalledTimes(1)
+    document.removeEventListener(`keydown`, page_handler)
+  })
+
+  it(`ignores a press on the page scrollbar`, () => {
+    const { callback } = attach_outside()
+
+    // jsdom does no layout, so give the root a client box the gutter can sit outside
+    const root = document.documentElement
+    for (const [prop, value] of [
+      [`clientWidth`, 800],
+      [`clientHeight`, 600],
+    ] as const) {
+      Object.defineProperty(root, prop, { value, configurable: true })
+    }
+    const press = (clientX: number, clientY: number) =>
+      document.body.dispatchEvent(
+        new PointerEvent(`pointerdown`, { bubbles: true, clientX, clientY }),
+      )
+
+    press(820, 300) // vertical scrollbar gutter
+    press(400, 620) // horizontal scrollbar gutter
+    expect(callback).not.toHaveBeenCalled()
+
+    press(400, 300) // control: same target inside the client box does dismiss
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    for (const prop of [`clientWidth`, `clientHeight`]) Reflect.deleteProperty(root, prop)
+  })
+
+  it(`ignores Escape that is only ending an IME composition`, () => {
+    const { callback, cleanup } = attach_outside({ escape: true })
+
+    press_escape({ isComposing: true })
+    expect(callback).not.toHaveBeenCalled()
+
+    press_escape()
+    expect(callback).toHaveBeenCalledTimes(1)
+    cleanup?.()
+  })
+
+  it(`tolerates an empty inside selector instead of throwing on every press`, () => {
+    // a trailing empty entry makes the joined selector invalid, which would throw
+    // out of the capture listener for every press anywhere on the page
+    const { callback, cleanup } = attach_outside({ inside: [`.modal`, ``] })
+
+    expect(() => dispatch_press(create_element())).not.toThrow()
+    expect(callback).toHaveBeenCalledTimes(1)
+    cleanup?.()
+  })
+
   it.each([true, false])(`escape reports focus_inside=%s`, (focus_inside) => {
-    const element = create_element()
+    const { element, callback, cleanup } = attach_outside({ escape: true })
     const inner = create_element()
     element.append(inner)
     const focus_target = focus_inside ? inner : create_element()
     focus_target.setAttribute(`tabindex`, `0`)
     focus_target.focus()
 
-    const callback = vi.fn()
-    click_outside({ callback, escape: true })(element)
-    document.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
+    const event = press_escape()
 
     expect(callback).toHaveBeenCalledTimes(1)
-    expect(callback.mock.calls[0][2]).toEqual({ focus_inside, via: `escape` })
+    expect(callback.mock.calls[0][2]).toEqual({ focus_inside, via: `escape`, event })
+    cleanup?.()
+  })
+
+  // A surface living inside a shadow tree: document.activeElement reports the host,
+  // which the surface does not contain, so only descending the chain finds the focus
+  it(`escape sees focus on a node that shares the surface's shadow tree`, () => {
+    const host = create_element()
+    const surface = document.createElement(`div`)
+    const inner = document.createElement(`button`)
+    surface.append(inner)
+    host.attachShadow({ mode: `open` }).append(surface)
+    inner.focus()
+
+    const callback = vi.fn()
+    const cleanup = click_outside({ callback, escape: true })(surface)
+    const event = press_escape()
+
+    expect(callback.mock.calls[0][2]).toEqual({
+      focus_inside: true,
+      via: `escape`,
+      event,
+    })
+    cleanup?.()
+  })
+
+  // A surface over a pannable plot or a 3D viewport wants release semantics:
+  // pressing to start a drag behind it should not make it vanish under the cursor.
+  it(`dismiss_on: 'release' waits for the click and ignores the press`, () => {
+    const { callback } = attach_outside({ dismiss_on: `release` })
+
+    dispatch_press(create_element())
+    expect(callback).not.toHaveBeenCalled()
+
+    dispatch_press(create_element(), [], `click`)
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 
   it(`ignores Escape unless asked, so existing keydown chains keep their order`, () => {
-    const element = create_element()
-    const callback = vi.fn()
-    click_outside({ callback })(element)
+    const { callback } = attach_outside()
 
-    document.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
+    press_escape()
     expect(callback).not.toHaveBeenCalled()
+  })
+})
+
+describe(`hotkey`, () => {
+  const keydown = (target: EventTarget, key: string, modifiers = {}) => {
+    const event = new KeyboardEvent(`keydown`, {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...modifiers,
+    })
+    target.dispatchEvent(event)
+    return event
+  }
+
+  it(`fires on the node it is attached to, not on the rest of the page`, () => {
+    const node = create_element()
+    const handler = vi.fn()
+    const cleanup = hotkey({ bindings: [{ keys: `ctrl+k`, handler }] })(node)
+
+    const event = keydown(node, `k`, { ctrlKey: true })
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(event.defaultPrevented).toBe(true)
+
+    keydown(create_element(), `k`, { ctrlKey: true })
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    cleanup?.()
+    keydown(node, `k`, { ctrlKey: true })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it(`global listens anywhere on the page`, () => {
+    const handler = vi.fn()
+    const cleanup = hotkey({ bindings: [{ keys: `ctrl+k`, handler }], global: true })(
+      create_element(),
+    )
+
+    keydown(create_element(), `k`, { ctrlKey: true })
+    expect(handler).toHaveBeenCalledTimes(1)
+    cleanup?.()
+  })
+
+  it(`leaves bare keys to text fields unless told otherwise`, () => {
+    const input = create_element(`input`)
+    const [typed, forced, chord] = [vi.fn(), vi.fn(), vi.fn()]
+    const cleanup = hotkey({
+      global: true,
+      bindings: [
+        { keys: `/`, handler: typed },
+        { keys: `?`, handler: forced, allow_in_inputs: true },
+        { keys: `ctrl+/`, handler: chord },
+      ],
+    })(create_element())
+
+    keydown(input, `/`)
+    expect(typed).not.toHaveBeenCalled() // the user is typing a slash
+
+    keydown(input, `?`)
+    expect(forced).toHaveBeenCalledTimes(1)
+
+    keydown(input, `/`, { ctrlKey: true })
+    expect(chord).toHaveBeenCalledTimes(1) // a chord is never typing
+    cleanup?.()
+  })
+
+  it(`runs the first enabled match only and can leave the default alone`, () => {
+    const node = create_element()
+    const [off, first, second] = [vi.fn(), vi.fn(), vi.fn()]
+    const cleanup = hotkey({
+      bindings: [
+        { keys: `ctrl+k`, handler: off, enabled: false },
+        { keys: [`ctrl+j`, `ctrl+k`], handler: first, prevent_default: false },
+        { keys: `ctrl+k`, handler: second },
+      ],
+    })(node)
+
+    const event = keydown(node, `k`, { ctrlKey: true })
+    expect(off).not.toHaveBeenCalled()
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+    cleanup?.()
+  })
+
+  it.each([
+    [`Macintosh; Intel Mac OS X 10_15`, { metaKey: true }, { ctrlKey: true }],
+    [`X11; Linux x86_64`, { ctrlKey: true }, { metaKey: true }],
+  ])(`mod follows the platform (%s)`, (user_agent, matching, other) => {
+    Object.defineProperty(globalThis.navigator, `userAgent`, {
+      value: user_agent,
+      configurable: true,
+    })
+    const node = create_element()
+    const handler = vi.fn()
+    const cleanup = hotkey({ bindings: [{ keys: `mod+k`, handler }] })(node)
+
+    keydown(node, `k`, other)
+    expect(handler).not.toHaveBeenCalled()
+
+    keydown(node, `k`, matching)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    cleanup?.()
+    Reflect.deleteProperty(globalThis.navigator, `userAgent`)
+  })
+
+  it(`stays quiet mid IME composition and when disabled`, () => {
+    const node = create_element()
+    const handler = vi.fn()
+    expect(
+      hotkey({ bindings: [{ keys: `ctrl+k`, handler }], enabled: false })(node),
+    ).toBeUndefined()
+    keydown(node, `k`, { ctrlKey: true })
+    expect(handler).not.toHaveBeenCalled()
+
+    const cleanup = hotkey({ bindings: [{ keys: `Enter`, handler }] })(node)
+    keydown(node, `Enter`, { isComposing: true })
+    expect(handler).not.toHaveBeenCalled()
+    keydown(node, `Enter`)
+    expect(handler).toHaveBeenCalledTimes(1)
+    cleanup?.()
+  })
+})
+
+describe(`focus_trap`, () => {
+  const make_surface = (count = 3) => {
+    const surface = create_element()
+    const buttons = Array.from({ length: count }, () => {
+      const button = document.createElement(`button`)
+      surface.append(button)
+      return button
+    })
+    return { surface, buttons }
+  }
+
+  const press_tab = (shiftKey = false) =>
+    document.dispatchEvent(
+      new KeyboardEvent(`keydown`, {
+        key: `Tab`,
+        bubbles: true,
+        cancelable: true,
+        shiftKey,
+      }),
+    )
+
+  it(`focuses the first tabbable, then cycles Tab both ways past the ends`, () => {
+    const { surface, buttons } = make_surface()
+    const cleanup = focus_trap()(surface)
+    expect(document.activeElement).toBe(buttons[0])
+
+    press_tab()
+    expect(document.activeElement).toBe(buttons[1])
+    press_tab()
+    press_tab()
+    expect(document.activeElement).toBe(buttons[0]) // wrapped past the last
+    press_tab(true)
+    expect(document.activeElement).toBe(buttons[2]) // and back past the first
+    cleanup?.()
+  })
+
+  it(`skips candidates the keyboard cannot reach`, () => {
+    const { surface, buttons } = make_surface()
+    buttons[1].disabled = true
+    buttons[2].tabIndex = -1
+    const reachable = document.createElement(`a`)
+    reachable.href = `#target`
+    surface.append(reachable)
+
+    const cleanup = focus_trap()(surface)
+    expect(document.activeElement).toBe(buttons[0])
+    press_tab()
+    expect(document.activeElement).toBe(reachable)
+    cleanup?.()
+  })
+
+  it.each([
+    [`a selector`, `.wanted`],
+    [`no initial focus`, false],
+  ] as const)(`initial: %s`, (_desc, initial) => {
+    const { surface, buttons } = make_surface()
+    buttons[2].className = `wanted`
+    const outside = create_element(`button`)
+    outside.focus()
+
+    const cleanup = focus_trap({ initial })(surface)
+    expect(document.activeElement).toBe(initial === false ? outside : buttons[2])
+    cleanup?.()
+  })
+
+  it(`hands focus back to where it came from, or to a named element`, () => {
+    const trigger = create_element(`button`)
+    trigger.focus()
+    const { surface } = make_surface()
+    focus_trap()(surface)?.()
+    expect(document.activeElement).toBe(trigger)
+
+    const elsewhere = create_element(`button`)
+    focus_trap({ restore: elsewhere })(surface)?.()
+    expect(document.activeElement).toBe(elsewhere)
+  })
+
+  it(`leaves focus alone when the user already moved it out`, () => {
+    const trigger = create_element(`button`)
+    trigger.focus()
+    const { surface } = make_surface()
+    const cleanup = focus_trap()(surface)
+
+    const elsewhere = create_element(`button`)
+    elsewhere.focus()
+    cleanup?.()
+
+    expect(document.activeElement).toBe(elsewhere)
+  })
+
+  it(`gives Tab to the innermost trap only`, () => {
+    const outer = make_surface()
+    const inner = make_surface()
+    const cleanup_outer = focus_trap()(outer.surface)
+    const cleanup_inner = focus_trap()(inner.surface)
+    expect(document.activeElement).toBe(inner.buttons[0])
+
+    press_tab()
+    expect(document.activeElement).toBe(inner.buttons[1])
+
+    // the outer trap takes over once the inner surface is gone
+    cleanup_inner?.()
+    outer.buttons[0].focus()
+    press_tab()
+    expect(document.activeElement).toBe(outer.buttons[1])
+    cleanup_outer?.()
+  })
+
+  // The trap listens on the document, so a surface that was never given focus must
+  // not confiscate Tab from the rest of the page. Nav pins a submenu while focus
+  // stays on the toggle outside it, and Tab there has to keep walking the page.
+  it(`leaves Tab alone while focus sits outside the trap`, () => {
+    const { surface, buttons } = make_surface()
+    const outside = create_element(`button`)
+    outside.focus()
+
+    const cleanup = focus_trap({ initial: false })(surface)
+    expect(document.activeElement).toBe(outside) // initial: false kept focus put
+
+    const event = new KeyboardEvent(`keydown`, {
+      key: `Tab`,
+      bubbles: true,
+      cancelable: true,
+    })
+    document.dispatchEvent(event)
+
+    expect(document.activeElement).toBe(outside) // not dragged into the surface
+    expect(event.defaultPrevented).toBe(false) // the browser still gets its Tab
+
+    // once focus is inside, the trap takes over again
+    buttons[0].focus()
+    press_tab()
+    expect(document.activeElement).toBe(buttons[1])
+    cleanup?.()
+  })
+
+  it(`covers portalled parts of the same surface via include`, () => {
+    const { surface, buttons } = make_surface(1)
+    const portalled = create_element() // moved to body, no longer a descendant
+    const portalled_button = document.createElement(`button`)
+    portalled.append(portalled_button)
+
+    const cleanup = focus_trap({ include: [null, portalled] })(surface)
+    expect(document.activeElement).toBe(buttons[0])
+    press_tab()
+    expect(document.activeElement).toBe(portalled_button)
+    cleanup?.()
+  })
+
+  it(`does nothing when disabled`, () => {
+    const { surface } = make_surface()
+    const outside = create_element(`button`)
+    outside.focus()
+
+    expect(focus_trap({ enabled: false })(surface)).toBeUndefined()
+    expect(document.activeElement).toBe(outside)
+    press_tab()
+    expect(document.activeElement).toBe(outside)
   })
 })
 

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -951,11 +951,19 @@ describe(`click_outside`, () => {
     return event
   }
 
+  // document.body.innerHTML = '' leaves click_outside's document capture listeners
+  // and Escape layers behind, which would decide later tests' assertions
+  const cleanups: (() => void)[] = []
+  afterEach(() => {
+    for (const cleanup of cleanups.splice(0)) cleanup()
+  })
+
   // attaches click_outside to a fresh element wired to a spy callback
   const attach_outside = (config: Parameters<typeof click_outside>[0] = {}) => {
     const element = create_element()
     const callback = vi.fn()
     const cleanup = click_outside({ callback, ...config })(element)
+    if (cleanup) cleanups.push(cleanup)
     return { element, callback, cleanup }
   }
 
@@ -1011,7 +1019,8 @@ describe(`click_outside`, () => {
     const element = create_element()
     const listener = vi.fn()
     element.addEventListener(`dismiss`, listener)
-    click_outside({})(element) // no callback
+    const cleanup = click_outside({})(element) // no callback
+    if (cleanup) cleanups.push(cleanup)
     dispatch_press(create_element())
     expect(listener).toHaveBeenCalled()
   })
@@ -1187,6 +1196,7 @@ describe(`click_outside`, () => {
 
     const callback = vi.fn()
     const cleanup = click_outside({ callback, escape: true })(surface)
+    if (cleanup) cleanups.push(cleanup)
     const event = press_escape()
 
     expect(callback.mock.calls[0][2]).toEqual({
@@ -1194,7 +1204,6 @@ describe(`click_outside`, () => {
       via: `escape`,
       event,
     })
-    cleanup?.()
   })
 
   // A surface over a pannable plot or a 3D viewport wants release semantics:

--- a/tests/vitest/attachments.test.ts
+++ b/tests/vitest/attachments.test.ts
@@ -920,8 +920,8 @@ describe(`tooltip`, () => {
 })
 
 describe(`click_outside`, () => {
-  const dispatch_click = (target: Element, path: EventTarget[] = []) => {
-    const event = new Event(`click`, { bubbles: true })
+  const dispatch_press = (target: Element, path: EventTarget[] = []) => {
+    const event = new Event(`pointerdown`, { bubbles: true })
     Object.defineProperty(event, `target`, { value: target })
     Object.defineProperty(event, `composedPath`, {
       value: () =>
@@ -946,7 +946,7 @@ describe(`click_outside`, () => {
     const path = is_outside
       ? []
       : [element, document.body, document.documentElement, document, globalThis]
-    dispatch_click(target, path)
+    dispatch_press(target, path)
 
     expect(callback).toHaveBeenCalledTimes(expected_calls)
   })
@@ -965,13 +965,13 @@ describe(`click_outside`, () => {
     const callback = vi.fn()
     click_outside({ callback, exclude: [`.modal`, `.popover`] })(element)
 
-    dispatch_click(excluded1)
-    dispatch_click(excluded2)
-    dispatch_click(nested)
+    dispatch_press(excluded1)
+    dispatch_press(excluded2)
+    dispatch_press(nested)
     expect(callback).not.toHaveBeenCalled()
 
     // control: proves the silence above is the exclude list, not a dead listener
-    dispatch_click(create_element())
+    dispatch_press(create_element())
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
@@ -982,7 +982,7 @@ describe(`click_outside`, () => {
 
     const svg = document.createElementNS(`http://www.w3.org/2000/svg`, `svg`)
     document.body.append(svg)
-    dispatch_click(svg)
+    dispatch_press(svg)
 
     expect(callback).toHaveBeenCalledTimes(1)
   })
@@ -992,7 +992,7 @@ describe(`click_outside`, () => {
     const listener = vi.fn()
     element.addEventListener(`outside-click`, listener)
     click_outside({})(element) // no callback
-    dispatch_click(create_element())
+    dispatch_press(create_element())
     expect(listener).toHaveBeenCalled()
   })
 
@@ -1001,12 +1001,73 @@ describe(`click_outside`, () => {
     const callback = vi.fn()
     const cleanup = click_outside({ callback })(element)
 
-    dispatch_click(create_element())
+    dispatch_press(create_element())
     expect(callback).toHaveBeenCalledTimes(1)
 
     cleanup?.()
-    dispatch_click(create_element())
+    dispatch_press(create_element())
     expect(callback).toHaveBeenCalledTimes(1) // Still 1, not called again
+  })
+
+  it(`dismisses on the press, not on a following click`, () => {
+    const element = create_element()
+    const callback = vi.fn()
+    click_outside({ callback })(element)
+
+    const outside = create_element()
+    dispatch_press(outside)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // right-clicks and OS-captured drags never send this click, hence pointerdown
+    outside.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it(`scope confines exclude matches to one subtree`, () => {
+    const [own_scope, own_trigger, other_trigger] = [
+      create_element(),
+      create_element(),
+      create_element(),
+    ]
+    own_trigger.className = `trigger`
+    other_trigger.className = `trigger`
+    own_scope.append(own_trigger)
+
+    const element = create_element()
+    const callback = vi.fn()
+    click_outside({ callback, exclude: [`.trigger`], scope: own_scope })(element)
+
+    dispatch_press(own_trigger)
+    expect(callback).not.toHaveBeenCalled()
+
+    // Same selector, another instance's trigger: it must not shield this surface
+    dispatch_press(other_trigger)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([true, false])(`escape reports focus_inside=%s`, (focus_inside) => {
+    const element = create_element()
+    const inner = create_element()
+    element.append(inner)
+    const focus_target = focus_inside ? inner : create_element()
+    focus_target.setAttribute(`tabindex`, `0`)
+    focus_target.focus()
+
+    const callback = vi.fn()
+    click_outside({ callback, escape: true })(element)
+    document.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback.mock.calls[0][2]).toEqual({ focus_inside, via: `escape` })
+  })
+
+  it(`ignores Escape unless asked, so existing keydown chains keep their order`, () => {
+    const element = create_element()
+    const callback = vi.fn()
+    click_outside({ callback })(element)
+
+    document.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }))
+    expect(callback).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -56,7 +56,9 @@ describe(`get_label`, () => {
     [undefined, `undefined`, false],
     [{ value: 42, name: `Test` }, undefined, true],
   ])(`handles option %j correctly`, (input, expected, should_log_error) => {
-    console.error = vi.fn<typeof console.error>()
+    // spyOn, not assignment: only a spy is undone by the suite's restoreAllMocks,
+    // otherwise console.error stays mocked for every later test in the file
+    vi.spyOn(console, `error`).mockImplementation(() => {})
     // @ts-expect-error testing runtime behavior with non-Option types
     const result = get_label(input)
     expect(result).toBe(expected)
@@ -109,7 +111,7 @@ describe(`get_style`, () => {
   ] as const)(
     `object style %j with key %s returns %j (logs error: %s)`,
     (style, key, expected, should_log_error) => {
-      console.error = vi.fn<typeof console.error>()
+      vi.spyOn(console, `error`).mockImplementation(() => {})
       const option = { label: `test`, style }
       // @ts-expect-error style objects with unknown keys test runtime validation
       expect(get_style(option, key)).toBe(expected)
@@ -126,7 +128,7 @@ describe(`get_style`, () => {
     [{ style: `color: red;` }], // string style must not leak through for unknown keys
     [{ style: option_style }],
   ])(`logs error and returns empty string for invalid key with style %j`, (option) => {
-    console.error = vi.fn<typeof console.error>()
+    vi.spyOn(console, `error`).mockImplementation(() => {})
     // @ts-expect-error invalid key
     expect(get_style(option, `invalid_key`)).toBe(``)
     expect(console.error).toHaveBeenCalledWith(
@@ -235,7 +237,6 @@ describe(`is_object`, () => {
 describe(`has_group`, () => {
   test.each([
     [{ label: `Test`, group: `Group1` }, true],
-    [{ label: `Test`, group: `Frontend` }, true],
     [{ label: `Test`, group: `` }, true], // empty string is still a string
     [{ label: `Test` }, false],
     [{ label: `Test`, group: undefined }, false],
@@ -256,8 +257,6 @@ describe(`get_option_key`, () => {
     // Object options with value - returns value directly (preserves identity)
     [{ label: `Apple`, value: 1 }, 1],
     [{ label: `Apple`, value: `uuid-123` }, `uuid-123`],
-    [{ label: `pd`, value: `uuid-1` }, `uuid-1`],
-    [{ label: `PD`, value: `uuid-2` }, `uuid-2`],
     // Object options without value - falls back to label
     [{ label: `Apple` }, `Apple`],
     [{ label: `Apple`, value: undefined }, `Apple`],
@@ -379,10 +378,6 @@ describe(`chain_handlers`, () => {
     ],
     [[undefined, `a`], [`a`]],
     [[null, undefined], []],
-    [
-      [`a`, `b`, `c`],
-      [`a`, `b`, `c`],
-    ],
   ])(`runs %s in order, skipping nullish`, (names, expected) => {
     const calls: string[] = []
     const handlers = names.map((name) => (name == null ? name : () => calls.push(name)))

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -1,6 +1,7 @@
 import type { Option, OptionStyle } from '$lib'
 import {
   chain_handlers,
+  compute_position,
   fuzzy_match,
   get_label,
   get_option_key,
@@ -283,6 +284,90 @@ describe(`get_option_key`, () => {
     expect(get_option_key(opt1)).toBe(obj1)
     expect(get_option_key(opt2)).toBe(obj2)
     expect(get_option_key(opt1)).not.toBe(get_option_key(opt2))
+  })
+})
+
+describe(`compute_position`, () => {
+  const viewport = (width: number, height: number) => {
+    const sizes = { innerWidth: width, innerHeight: height }
+    for (const [prop, value] of Object.entries(sizes)) {
+      Object.defineProperty(globalThis, prop, { value, writable: true })
+    }
+  }
+  const rect = (top: number, height: number, left = 100, width = 200) => ({
+    top,
+    left,
+    bottom: top + height,
+    right: left + width,
+  })
+
+  test(`keeps the preferred side when the box fits`, () => {
+    viewport(1000, 800)
+    const box = { width: 200, height: 100 }
+    const placed = compute_position(rect(100, 30), box, {
+      placement: `bottom`,
+      offset: 8,
+    })
+    expect(placed).toEqual({ top: 138, left: 100, placement: `bottom` })
+  })
+
+  test(`flips to the side with room, and centre vs start line up differently`, () => {
+    viewport(1000, 800)
+    const anchor = rect(700, 30) // only 70px below, 700px above
+    const box = { width: 300, height: 200 }
+
+    const centered = compute_position(anchor, box, { placement: `bottom` })
+    expect(centered.placement).toBe(`top`)
+    expect(centered.top).toBe(500) // 700 - 200
+    expect(centered.left).toBe(50) // centred on an anchor spanning 100..300
+
+    const aligned = compute_position(anchor, box, { placement: `bottom`, align: `start` })
+    expect(aligned.left).toBe(100) // flush with the anchor's left edge
+  })
+
+  test(`shift pulls the box back inside the viewport, padding included`, () => {
+    viewport(400, 800)
+    const anchor = rect(100, 30, 380, 20) // near the right edge
+    const box = { width: 300, height: 100 }
+
+    // flip off, else the box would simply move to the anchor's left where it fits
+    const opts = { placement: `bottom`, padding: 8, flip: false } as const
+    expect(compute_position(anchor, box, opts).left).toBe(92) // 400 - 300 - 8
+    // centred, hanging off the right edge
+    expect(compute_position(anchor, box, { ...opts, shift: false }).left).toBe(240)
+  })
+
+  // The portalled dropdown used to carry its own above/below rule. Its replacement
+  // has to agree everywhere, including with the anchor scrolled out of view.
+  test(`reproduces the dropdown's above/below rule across a grid`, () => {
+    const view_height = 800
+    viewport(1000, view_height)
+    const legacy_place_above = (
+      anchor: { top: number; bottom: number },
+      height: number,
+    ) =>
+      height > 0 &&
+      anchor.bottom + height > view_height &&
+      anchor.top > view_height - anchor.bottom
+
+    const mismatches: string[] = []
+    for (const top of [-200, -30, 0, 50, 400, 700, 780, 900]) {
+      for (const anchor_height of [0, 30, 120]) {
+        for (const box_height of [1, 50, 200, 600, 1200]) {
+          const anchor = rect(top, anchor_height)
+          const { placement } = compute_position(
+            anchor,
+            { width: 200, height: box_height },
+            { placement: `auto`, align: `start`, flip: [`bottom`, `top`], shift: false },
+          )
+          const expected = legacy_place_above(anchor, box_height) ? `top` : `bottom`
+          if (placement !== expected) {
+            mismatches.push(`top=${top} h=${anchor_height} box=${box_height}`)
+          }
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
   })
 })
 


### PR DESCRIPTION
Consolidates three divergent outside-dismissal implementations into the exported `click_outside` attachment: this package's, the one matterviz uses in 7 places, and a downstream consumer's hand-rolled `src/dismiss.ts`.

## Why `pointerdown` instead of `click`

Three real bugs in that consumer, all cases where the expected `click` never arrives or arrives on the wrong element:

- A right-click fires no `click` at all, so the surface stayed open under the context menu.
- A press on a custom titlebar hands the drag to the OS, so no `click` follows either.
- A drag released outside the surface reports its `click` on the nearest common ancestor, dismissing a popover the user was only resizing.

## New options

- `escape?: boolean` (default `false`) adds Escape dismissal. Off by default because it registers a global capture-phase `keydown` listener and swallows the key, which would reorder existing keydown chains for consumers that never asked for it.
- `scope?: Element | null` confines `exclude` matches to one subtree, so a second instance of the same component cannot shield this one's surface with its own trigger.

Kept from the existing implementation: the `composedPath()` containment check (survives shadow DOM and a target detached mid-dispatch) and the capture-phase listener (a handler calling `stopPropagation` cannot suppress dismissal).

## Behavior change for existing consumers

- Dismissal now happens on press rather than release. Anything relying on the `click` timing (e.g. a trigger whose own `onclick` toggles the surface) sees the callback fire earlier in the sequence.
- `callback` gained a third argument, `detail: ClickOutsideDetail = { focus_inside: boolean; via: 'pointer' | 'escape' }`, and the `outside-click` `CustomEvent` now carries the same detail. `focus_inside` lets an Escape dismissal hand focus back to the trigger instead of stranding it on a removed element.
- `callback`'s second argument is now the config object as passed, no longer a copy with defaults filled in.

## Related additions

- Add `Popover` and `ContextMenu` with floating positioning, focus management, and Escape handling.
- Add `compute_position` and `run_hotkeys` utilities.
- Improve tooltip and portal positioning for more reliable viewport fit.

matterviz and that consumer will adopt this once released, dropping their local copies.