### PR TITLE
Fix tooltip arrow centering and 10 more widget correctness bugs

### DIFF
--- a/src/lib/DraggablePane.svelte
+++ b/src/lib/DraggablePane.svelte
@@ -141,17 +141,26 @@
       }
     }
 
-    const ancestor_rect = toggle_btn.offsetParent?.getBoundingClientRect()
+    const ancestor = toggle_btn.offsetParent
     // No positioned ancestor means the pane is placed against the document
-    if (!ancestor_rect) {
+    if (!ancestor) {
       return {
         left: toggle_rect.right - pane_width + offset_x + globalThis.scrollX,
         top: toggle_rect.bottom + offset_y + globalThis.scrollY,
       }
     }
+    // left/top on an absolute child resolve against the ancestor's padding box, whereas
+    // its rect is the border box, so the border comes off. clientLeft/clientTop are that
+    // border, already in used-value terms.
+    const ancestor_rect = ancestor.getBoundingClientRect()
     return {
-      left: toggle_rect.right - ancestor_rect.left - pane_width + offset_x,
-      top: toggle_rect.bottom - ancestor_rect.top + offset_y,
+      left:
+        toggle_rect.right -
+        ancestor_rect.left -
+        ancestor.clientLeft -
+        pane_width +
+        offset_x,
+      top: toggle_rect.bottom - ancestor_rect.top - ancestor.clientTop + offset_y,
     }
   }
 

--- a/src/lib/DraggablePane.svelte
+++ b/src/lib/DraggablePane.svelte
@@ -141,7 +141,11 @@
       }
     }
 
-    const ancestor = toggle_btn.offsetParent
+    // The pane's containing block, not the toggle's: they are siblings and normally share
+    // one, but toggle_props can position the toggle independently, and it is the pane's
+    // own left/top being computed here. Always laid out at this point — every caller
+    // either holds an open pane or is a control inside it.
+    const ancestor = pane?.offsetParent
     // No positioned ancestor means the pane is placed against the document
     if (!ancestor) {
       return {

--- a/src/lib/DraggablePane.svelte
+++ b/src/lib/DraggablePane.svelte
@@ -127,15 +127,19 @@
     const toggle_rect = toggle_btn.getBoundingClientRect()
     const pane_width = pane?.getBoundingClientRect().width || default_pane_width_px
     const [offset_x, offset_y] = [offset.x ?? 5, offset.y ?? 5]
+    // The anchor in viewport coordinates; each strategy below only restates it in the
+    // space its own left/top are read in.
+    const left = toggle_rect.right - pane_width + offset_x
+    const top = toggle_rect.bottom + offset_y
 
     if (position === `fixed`) {
       return {
         left: clamp_to_viewport(
-          toggle_rect.right - pane_width + offset_x,
+          left,
           globalThis.innerWidth - pane_width - viewport_margin_px,
         ),
         top: clamp_to_viewport(
-          toggle_rect.bottom + offset_y,
+          top,
           globalThis.innerHeight - min_reachable_height_px - viewport_margin_px,
         ),
       }
@@ -148,23 +152,15 @@
     const ancestor = pane?.offsetParent
     // No positioned ancestor means the pane is placed against the document
     if (!ancestor) {
-      return {
-        left: toggle_rect.right - pane_width + offset_x + globalThis.scrollX,
-        top: toggle_rect.bottom + offset_y + globalThis.scrollY,
-      }
+      return { left: left + globalThis.scrollX, top: top + globalThis.scrollY }
     }
-    // left/top on an absolute child resolve against the ancestor's padding box, whereas
-    // its rect is the border box, so the border comes off. clientLeft/clientTop are that
+    // An absolute child's insets resolve against the ancestor's padding box, whereas its
+    // rect is the border box, so the border comes off too. clientLeft/clientTop are that
     // border, already in used-value terms.
     const ancestor_rect = ancestor.getBoundingClientRect()
     return {
-      left:
-        toggle_rect.right -
-        ancestor_rect.left -
-        ancestor.clientLeft -
-        pane_width +
-        offset_x,
-      top: toggle_rect.bottom - ancestor_rect.top - ancestor.clientTop + offset_y,
+      left: left - ancestor_rect.left - ancestor.clientLeft,
+      top: top - ancestor_rect.top - ancestor.clientTop,
     }
   }
 

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -366,9 +366,11 @@
     prefix_heights.map((ph) => {
       if (!can_virtualize) return { start: 0, end: ph.length, pad_top: 0, pad_bottom: 0 }
       const start = Math.max(0, binary_search_ge(ph, scroll_top) - 1 - overscan)
+      // The item found at the viewport's bottom edge straddles it, so it is on screen and
+      // the exclusive end has to clear it — mirroring the row of margin `start` takes.
       const end = Math.min(
         ph.length,
-        binary_search_ge(ph, scroll_top + container_height) + overscan,
+        binary_search_ge(ph, scroll_top + container_height) + 1 + overscan,
       )
       return {
         start,

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -136,7 +136,10 @@
   }
 
   function schedule_hide(href: string, is_pinned: boolean) {
-    if (is_touch_device || is_pinned) return
+    // Same gate as the hover-open above: a touchscreen laptop opens dropdowns on hover
+    // like any desktop, so suppressing the hide on touch support alone would strand them
+    // open. Only the mobile layout, where a tap is what opened the menu, keeps them.
+    if ((is_touch_device && is_mobile) || is_pinned) return
     if (hide_timeout) clearTimeout(hide_timeout)
     hide_timeout = setTimeout(() => {
       if (hovered_dropdown === href) hovered_dropdown = null

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -746,9 +746,14 @@
     padding: 1pt 8pt;
   }
   /* Fill the pill, matching the flex:1 that dropdown rows already give their link, so the
-     whole row is tappable rather than just the text */
+     whole row is tappable rather than just the text. flex:1 only fills the content box, so
+     the negative margin pulls the link back out over the span's padding and its own padding
+     puts the text back where it was — otherwise the padding is a dead band inside the
+     painted pill. The padding stays on the span so a custom `item` snippet still gets it. */
   nav.mobile .menu > span > a {
     flex: 1;
+    margin: -1pt -8pt;
+    padding: 1pt 8pt;
   }
   /* Mobile separator */
   nav.mobile .menu > .separator {

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -666,8 +666,8 @@
     flex-direction: column;
     justify-content: space-around;
     /* 1.4rem bars inside a ~2.4rem hit area: a finger-sized target without moving the bars */
-    width: 1.4rem;
-    height: 1.4rem;
+    width: var(--nav-burger-size, 1.4rem);
+    height: var(--nav-burger-size, 1.4rem);
     box-sizing: content-box;
     padding: 0.5rem;
     margin: -0.5rem;
@@ -685,14 +685,18 @@
       transform 0.2s linear;
     transform-origin: center;
   }
+  /* Both strokes must land on the box's centre line or the X reads as lopsided. Under
+     `space-around` with three equal bars, adjacent bar centres are exactly height/3 apart —
+     the outer bars are one step from the middle one, which is already centred. A hardcoded
+     offset (0.4rem against a 1.4rem box) left them ~1px shy of meeting. */
   .burger[aria-expanded='true'] span:first-child {
-    transform: translateY(0.4rem) rotate(45deg);
+    transform: translateY(calc(var(--nav-burger-size, 1.4rem) / 3)) rotate(45deg);
   }
   .burger[aria-expanded='true'] span:nth-child(2) {
     opacity: 0;
   }
   .burger[aria-expanded='true'] span:nth-child(3) {
-    transform: translateY(-0.4rem) rotate(-45deg);
+    transform: translateY(calc(var(--nav-burger-size, 1.4rem) / -3)) rotate(-45deg);
   }
   /* Mobile styles - using .mobile class set via JS based on breakpoint prop */
   nav.mobile .burger {
@@ -701,7 +705,11 @@
   nav.mobile .menu {
     position: fixed;
     top: 3rem;
-    inset-inline-start: 1rem;
+    /* Span the viewport rather than hugging its content: a content-width panel anchored to
+       one side leaves page text visible right beside the open menu, which reads as a stray
+       box instead of a menu. Hosts wanting the old floating panel can set --nav-mobile-inset
+       to `1rem auto` (or any inset-inline pair) and cap it with a max-width of their own. */
+    inset-inline: var(--nav-mobile-inset, 0.5rem);
     background-color: var(--nav-surface-bg);
     border: 1px solid var(--nav-surface-border);
     box-shadow: var(--nav-surface-shadow);
@@ -718,7 +726,6 @@
     align-items: stretch;
     justify-content: start;
     gap: 0.2em;
-    max-width: 90vw;
     max-height: calc(100dvh - 4rem);
     overflow-y: auto;
     overscroll-behavior: contain;
@@ -728,8 +735,17 @@
     opacity: 1;
     visibility: visible;
   }
-  nav.mobile :is(.menu > span, .menu > span > a, .dropdown) {
-    padding: 2pt 8pt;
+  /* `.menu > span` and `.dropdown > div:first-child` are the two elements that paint a row's
+     highlight. Padding must land on both or neither: padding `.dropdown` instead of its inner
+     wrapper grew the row around the pill rather than the pill itself, so plain links rendered
+     visibly wider and taller pills than dropdown rows. */
+  nav.mobile :is(.menu > span, .dropdown > div:first-child) {
+    padding: 1pt 8pt;
+  }
+  /* Fill the pill, matching the flex:1 that dropdown rows already give their link, so the
+     whole row is tappable rather than just the text */
+  nav.mobile .menu > span > a {
+    flex: 1;
   }
   /* Mobile separator */
   nav.mobile .menu > .separator {
@@ -752,7 +768,9 @@
     border-radius: var(--nav-border-radius);
   }
   nav.mobile .dropdown > div:first-child > button {
-    padding: 4pt 8pt;
+    /* Sit against the row's trailing edge: the row's own padding is the only gap wanted,
+       so the caret's trailing padding would double it */
+    padding: 4pt 0 4pt 8pt;
     border-radius: var(--nav-border-radius);
     opacity: 0.6;
   }
@@ -770,7 +788,8 @@
   nav.mobile .dropdown > div:last-child a {
     padding-block: 4pt;
     padding-inline: 6pt 8pt;
-    margin-inline-start: 8pt;
+    /* 8pt of its own indent plus the 8pt the `.dropdown` padding used to contribute */
+    margin-inline-start: 16pt;
     border-inline-start: 2px solid transparent;
     font-size: 0.9em;
   }

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -544,8 +544,10 @@
 
   function scroll_to_active_toc_item(behavior: `auto` | `smooth` | `instant` = `smooth`) {
     if (keepActiveTocItemInView && activeTocLi && nav) {
-      // scroll the active ToC item into the middle of the ToC container
-      const top = activeTocLi.offsetTop - nav.offsetHeight / 2
+      // scroll the active ToC item into the middle of the ToC container. offsetTop and
+      // scrollTop both count from the padding box, so the height to halve is the
+      // scrollport's (clientHeight), not the border box's.
+      const top = activeTocLi.offsetTop - nav.clientHeight / 2
       nav.scrollTo?.({ top, behavior })
     }
   }

--- a/src/lib/attachments/click-outside.ts
+++ b/src/lib/attachments/click-outside.ts
@@ -59,12 +59,13 @@ const is_scrollbar_press = (event: Event): boolean => {
   const rect = target.getBoundingClientRect()
   // clientWidth/Height are 0 for non-scrollable boxes (inline elements above all),
   // hence the overflow check — otherwise every press right of such a box looks like
-  // a scrollbar hit and silently suppresses dismissal.
+  // a scrollbar hit and silently suppresses dismissal. The gutter starts past the
+  // border too, which the border-box rect includes but clientWidth/Height do not.
   return (
     (target.scrollHeight > target.clientHeight &&
-      event.clientX > rect.left + target.clientWidth) ||
+      event.clientX > rect.left + target.clientLeft + target.clientWidth) ||
     (target.scrollWidth > target.clientWidth &&
-      event.clientY > rect.top + target.clientHeight)
+      event.clientY > rect.top + target.clientTop + target.clientHeight)
   )
 }
 

--- a/src/lib/attachments/draggable.ts
+++ b/src/lib/attachments/draggable.ts
@@ -60,8 +60,12 @@ export const draggable =
             ? { left: node.offsetLeft, top: node.offsetTop }
             : { left: css_px(styles.left) || 0, top: css_px(styles.top) || 0 }
       if (styles.position === `static`) node.style.position = `relative`
-      initial.left = origin.left
-      initial.top = origin.top
+      // A rect and offsetLeft both report the border edge, but left/top place the margin
+      // edge, so an out-of-flow node with margins would jump by them on the first press.
+      // The in-flow branch read the insets themselves, so it is already in that space.
+      const out_of_flow = [`fixed`, `absolute`].includes(styles.position)
+      initial.left = origin.left - (out_of_flow ? css_px(styles.marginLeft) || 0 : 0)
+      initial.top = origin.top - (out_of_flow ? css_px(styles.marginTop) || 0 : 0)
 
       if (move_x) {
         node.style.left = `${initial.left}px`

--- a/src/lib/attachments/tooltip.ts
+++ b/src/lib/attachments/tooltip.ts
@@ -206,20 +206,19 @@ const sync_arrow_styles = (
     ? `var(--tooltip-bg, light-dark(#fff, #2a2a2e))`
     : background
   const border_color = styles.borderTopColor
-  const border_width = is_transparent(border_color)
-    ? 0
-    : css_px_or(styles.borderTopWidth, 0)
+  // The width the surface's border actually occupies, per side. `border_width` is the
+  // painted one: the same measurement, zeroed on a see-through color, which is what the
+  // arrow draws on itself. A transparent border still takes up layout, so the two differ.
+  const layout_border = (side: string) =>
+    css_px_or(styles.getPropertyValue(`border-${side}-width`), 0)
+  const border_width = is_transparent(border_color) ? 0 : layout_border(`top`)
   const arrow_side = (arrow_px + border_width) * Math.SQRT2
   const [inset_side, rotation_deg] = ARROW_PLACEMENT[placement]
   arrow.style.cssText = `position: absolute; box-sizing: border-box; width: ${arrow_side}px; height: ${arrow_side}px; pointer-events: none; background: ${fill_color}; border: ${border_width}px solid ${border_color}; clip-path: polygon(0 0, 100% 0, 100% 100%); transform: rotate(${rotation_deg}deg);`
   const set = (property: string, value: string) =>
     arrow.style.setProperty(property, value)
-  // Absolute insets resolve against the padding box, but everything measured above is in
-  // border-box space, so both axes have to put the surface's border back. A transparent
-  // border still takes up layout, so this is the computed width rather than
-  // `border_width`, which is the painted one and goes to zero on a see-through color.
-  const layout_border = (side: string) =>
-    css_px_or(styles.getPropertyValue(`border-${side}-width`), 0)
+  // Absolute insets resolve against the padding box while everything measured above is in
+  // border-box space, so both axes have to put the surface's border back.
   const cross_side = vertical ? `left` : `top`
   set(cross_side, `${cross_axis_center - arrow_side / 2 - layout_border(cross_side)}px`)
   // On the main axis the square's center lands on the border edge, which puts the tip

--- a/src/lib/attachments/tooltip.ts
+++ b/src/lib/attachments/tooltip.ts
@@ -214,8 +214,17 @@ const sync_arrow_styles = (
   arrow.style.cssText = `position: absolute; box-sizing: border-box; width: ${arrow_side}px; height: ${arrow_side}px; pointer-events: none; background: ${fill_color}; border: ${border_width}px solid ${border_color}; clip-path: polygon(0 0, 100% 0, 100% 100%); transform: rotate(${rotation_deg}deg);`
   const set = (property: string, value: string) =>
     arrow.style.setProperty(property, value)
-  set(vertical ? `left` : `top`, `${cross_axis_center - arrow_side / 2}px`)
-  set(inset_side, `${-arrow_side / 2}px`)
+  // Absolute insets resolve against the padding box, but everything measured above is in
+  // border-box space, so both axes have to put the surface's border back. A transparent
+  // border still takes up layout, so this is the computed width rather than
+  // `border_width`, which is the painted one and goes to zero on a see-through color.
+  const layout_border = (side: string) =>
+    css_px_or(styles.getPropertyValue(`border-${side}-width`), 0)
+  const cross_side = vertical ? `left` : `top`
+  set(cross_side, `${cross_axis_center - arrow_side / 2 - layout_border(cross_side)}px`)
+  // On the main axis the square's center lands on the border edge, which puts the tip
+  // exactly `arrow_px` clear of the surface — the painted border covers the overlap.
+  set(inset_side, `${-arrow_side / 2 - (layout_border(inset_side) - border_width)}px`)
 }
 
 const remember_and_strip_title = (
@@ -705,14 +714,17 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     // Re-entering during the close delay supersedes the pending close.
     clear_close_timeout()
     if (!active || active.phase === `dismissed` || active.open) return
-    clear_open_timeout()
     const { options } = active.registration
     const elapsed_since_close = Date.now() - last_closed_at
     const warm =
       elapsed_since_close >= 0 && elapsed_since_close <= (options.skip_delay_ms ?? 300)
     const delay = reason === `pointer` && !warm ? (options.open_delay_ms ?? 100) : 0
-    if (delay === 0) show_active(reason)
-    else open_timeout = setTimeout(() => show_active(reason), delay)
+    // show_active clears the pending timer itself, so an immediate open supersedes it.
+    if (delay === 0) return show_active(reason)
+    // `pointerover` fires again on every crossing between the trigger's own children, so
+    // a pending open rides out its original delay: restarting it here would keep a
+    // tooltip on a trigger built from several elements from ever reaching its deadline.
+    open_timeout ??= setTimeout(() => show_active(reason), delay)
   }
 
   function close_if_interaction_ended(reason: `pointer` | `blur`): void {

--- a/src/lib/code-editor/edit-ops.ts
+++ b/src/lib/code-editor/edit-ops.ts
@@ -38,7 +38,11 @@ const touched_line_range = (
       : sel_end
   return [block_start, model.line_at(effective_end).to]
 }
-const leading_whitespace = (line: string): string => /^[ \t]*/.exec(line)?.[0] ?? ``
+// Every whitespace character trimStart() would take except the line terminators, so the
+// commented-ness test and the width the uncomment slices off agree. Counting only [ \t]
+// let an exotic indent (a non-breaking space, a form feed) shift the slice into the token
+// and leave half of it behind.
+const leading_whitespace = (line: string): string => /^[^\S\r\n]*/u.exec(line)?.[0] ?? ``
 const map_rewritten_column = (
   line: string,
   next_line: string,

--- a/src/lib/toast-queue.svelte.ts
+++ b/src/lib/toast-queue.svelte.ts
@@ -144,6 +144,17 @@ const pause_visibility_timeout = <Priority extends string>(
             : Math.max(0, toast.expires_at_ms - now_ms),
       }
 
+// A budget beats a deadline (see ToastRequest.visible_duration_ms), so a queued toast
+// carrying both stops running its wall clock. The budget itself is untouched: nothing has
+// been spent yet, and banking here would mistake the caller's deadline for one this queue
+// had derived and adopt the distance to it as the budget.
+const drop_unseen_deadline = <Priority extends string>(
+  toast: ToastItem<Priority>,
+): ToastItem<Priority> =>
+  toast.visible_duration_ms === undefined || toast.expires_at_ms === null
+    ? toast
+    : { ...toast, expires_at_ms: null }
+
 const start_visibility_timeout = <Priority extends string>(
   toast: ToastItem<Priority>,
   now_ms: number,
@@ -163,7 +174,7 @@ const rebalance_queue = <Priority extends string>(
     rank(right) - rank(left) ||
     left.created_at_ms - right.created_at_ms ||
     left.seq - right.seq
-  const pending = queue.pending.map((toast) => pause_visibility_timeout(toast, now_ms))
+  const pending = queue.pending.map(drop_unseen_deadline)
   pending.sort(highest_first)
   if (!active_toast) {
     const promoted = pending.shift()

--- a/tests/playwright/DraggablePane.test.ts
+++ b/tests/playwright/DraggablePane.test.ts
@@ -59,6 +59,35 @@ test(`the outermost pixel of the right edge still resizes`, async ({ page }) => 
   expect(Math.round(after.width - before.width)).toBe(-70)
 })
 
+// The pane's left/top resolve against the positioned ancestor's padding box, but it is
+// anchored from that ancestor's border-box rect, so a bordered host used to push the pane
+// off the toggle by the border width. Only a browser knows where the padding box starts.
+test(`a bordered positioned ancestor keeps the pane anchored to its toggle`, async ({
+  page,
+}) => {
+  const { pane } = await open_pane(page)
+  const toggle = page.locator(`button.pane-toggle`).first()
+  const anchoring_error = async () => {
+    const [pane_box, toggle_box] = await Promise.all([box_of(pane), box_of(toggle)])
+    return {
+      // the default offset={ x: 5, y: 5 } hangs the pane off the toggle's bottom right
+      right: pane_box.x + pane_box.width - (toggle_box.x + toggle_box.width + 5),
+      top: pane_box.y - (toggle_box.y + toggle_box.height + 5),
+    }
+  }
+  expect(await anchoring_error()).toEqual({ right: 0, top: 0 })
+
+  await toggle.evaluate((element: HTMLElement) => {
+    const ancestor = element.offsetParent as HTMLElement
+    ancestor.style.border = `10px solid transparent`
+  })
+  // reset_position() reruns the anchoring maths against the now-bordered ancestor
+  await toggle.click()
+  await toggle.click()
+  await expect(pane).toBeVisible()
+  expect(await anchoring_error()).toEqual({ right: 0, top: 0 })
+})
+
 // Which handle a corner press lands on is a browser hit-test fact; happy-dom cannot decide
 // it. The corner has its own square handle painted over the two edge strips it overlaps, so
 // it drives BOTH axes — the edge strips still drive one axis each.

--- a/tests/playwright/DraggablePane.test.ts
+++ b/tests/playwright/DraggablePane.test.ts
@@ -88,6 +88,38 @@ test(`a bordered positioned ancestor keeps the pane anchored to its toggle`, asy
   expect(await anchoring_error()).toEqual({ right: 0, top: 0 })
 })
 
+// toggle_props can position the toggle out of the pane's containing block, at which point
+// the toggle's offsetParent is null (viewport) while the pane's is still the host. Reading
+// the toggle's would take the document-coordinate branch and write those as host-local
+// insets, dropping the pane by the host's offset down the page.
+test(`a fixed toggle still anchors the pane to its own offset parent`, async ({
+  page,
+}) => {
+  const { pane } = await open_pane(page)
+  const toggle = page.locator(`button.pane-toggle`).first()
+
+  await toggle.evaluate((element: HTMLElement) => {
+    const host = element.offsetParent as HTMLElement
+    // push the host well down the page so a document/host mix-up cannot coincide
+    host.style.marginTop = `400px`
+    const { top, left } = element.getBoundingClientRect()
+    Object.assign(element.style, {
+      position: `fixed`,
+      top: `${top}px`,
+      left: `${left}px`,
+    })
+  })
+  await toggle.click()
+  await toggle.click()
+  await expect(pane).toBeVisible()
+
+  const [pane_box, toggle_box] = await Promise.all([box_of(pane), box_of(toggle)])
+  expect({
+    right: pane_box.x + pane_box.width - (toggle_box.x + toggle_box.width + 5),
+    top: pane_box.y - (toggle_box.y + toggle_box.height + 5),
+  }).toEqual({ right: 0, top: 0 })
+})
+
 // Which handle a corner press lands on is a browser hit-test fact; happy-dom cannot decide
 // it. The corner has its own square handle painted over the two edge strips it overlaps, so
 // it drives BOTH axes — the edge strips still drive one axis each.

--- a/tests/playwright/Nav.test.ts
+++ b/tests/playwright/Nav.test.ts
@@ -153,3 +153,39 @@ test.describe(`Nav dropdown`, () => {
     await expect(menu).toHaveCSS(`display`, `none`)
   })
 })
+
+// The pill is painted on `.menu > span`, but the link inside it is `flex: 1`, which fills
+// only the content box. Without the link stretching back over the span's padding, that
+// padding is a dead band inside the visible row. Only a browser resolves these boxes.
+test(`the whole painted mobile row is part of its link's hit area`, async ({ page }) => {
+  await page.setViewportSize({ width: 420, height: 800 })
+  await page.goto(`/nav`, { waitUntil: `networkidle` })
+
+  // .click() here races a decorative overlay for the press; the burger's own hit area is
+  // not what this test is about, so open the menu directly
+  await page
+    .locator(`nav.mobile button.burger`)
+    .first()
+    .evaluate((element: HTMLElement) => element.click())
+  const row = page
+    .locator(`nav.mobile .menu > span`)
+    .filter({ has: page.locator(`a`) })
+    .first()
+  const link = row.locator(`> a`).first()
+  await expect(link).toBeVisible()
+
+  const [row_box, link_box] = await Promise.all([row.boundingBox(), link.boundingBox()])
+  if (!row_box || !link_box) throw new Error(`Missing mobile nav row geometry`)
+  // the link covers the pill exactly: no padding band left over on any side
+  for (const [edge, delta] of Object.entries({
+    left: link_box.x - row_box.x,
+    top: link_box.y - row_box.y,
+    right: row_box.x + row_box.width - (link_box.x + link_box.width),
+    bottom: row_box.y + row_box.height - (link_box.y + link_box.height),
+  })) {
+    expect(
+      Math.abs(delta),
+      `${edge} of the pill is outside the link`,
+    ).toBeLessThanOrEqual(0.5)
+  }
+})

--- a/tests/playwright/attachments.test.ts
+++ b/tests/playwright/attachments.test.ts
@@ -172,6 +172,61 @@ test.describe(`tooltip layout and lifecycle`, () => {
     expect(cross_axis_error).toBeLessThanOrEqual(3)
   })
 
+  // The arrow's absolute insets resolve against the padding box while its geometry is
+  // measured in border-box space, so both axes have to add the surface's border back.
+  // A transparent border still occupies layout, hence the second case.
+  for (const border of [`unset`, `4px solid transparent`]) {
+    test(`arrow tip clears and centers on the trigger on every side (border: ${border})`, async ({
+      page,
+    }) => {
+      const demo = page.locator(`#attachments-tooltip-placement`)
+      const button = demo.getByRole(`button`, { name: `Hover the target` })
+      await button.evaluate(
+        (element, value) => element.style.setProperty(`--tooltip-border`, value),
+        border,
+      )
+      const tooltip_el = page.locator(`.custom-tooltip`)
+
+      for (const placement of [`top`, `right`, `bottom`, `left`] as const) {
+        await demo.getByLabel(`placement`).selectOption(placement)
+        await expect(async () => {
+          await page.mouse.move(0, 0) // move off the button so pointerover re-fires
+          await button.hover()
+          await expect(tooltip_el).toHaveAttribute(`data-placement`, placement, {
+            timeout: 1000,
+          })
+        }).toPass({ timeout: 15_000 })
+        await expect(tooltip_el).toHaveCSS(`opacity`, `1`)
+
+        const [button_box, arrow_box, surface_box] = await Promise.all([
+          button.boundingBox(),
+          tooltip_el.locator(`.custom-tooltip-arrow`).boundingBox(),
+          tooltip_el.boundingBox(),
+        ])
+        if (!button_box || !arrow_box || !surface_box) {
+          throw new Error(`Missing ${placement} arrow geometry`)
+        }
+        // A square rotated 45° has a bounding box centred on its tip, so the box's cross
+        // axis gives the tip's position and its leading edge gives the tip itself.
+        const vertical = placement === `top` || placement === `bottom`
+        const cross = (box: typeof arrow_box) =>
+          vertical ? box.x + box.width / 2 : box.y + box.height / 2
+        expect(
+          Math.abs(cross(arrow_box) - cross(button_box)),
+          `${placement} arrow off the trigger's center`,
+        ).toBeLessThanOrEqual(0.5)
+        // The tip stands the default 6px --tooltip-arrow-size clear of the surface.
+        const protrusion = {
+          top: arrow_box.y + arrow_box.height - surface_box.y - surface_box.height,
+          bottom: surface_box.y - arrow_box.y,
+          left: arrow_box.x + arrow_box.width - surface_box.x - surface_box.width,
+          right: surface_box.x - arrow_box.x,
+        }[placement]
+        expect(protrusion, `${placement} arrow protrusion`).toBeCloseTo(6, 0)
+      }
+    })
+  }
+
   test(`active attribute content rerenders without leaving the viewport`, async ({
     page,
   }) => {

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -11,10 +11,13 @@ const mock_actions = [
 
 const menu_input = () => doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
 
-// Passes props straight through rather than merging in defaults: several tests mount a
-// $state proxy and then mutate it, which spreading into a fresh object would sever.
-const mount_menu = (props: ComponentProps<typeof CommandMenu>) =>
-  mount(CommandMenu, { target: document.body, props })
+// Fades are off unless a test is about them, so the dialog opens and closes synchronously.
+// Filled in on the caller's own object rather than a merged copy: several tests mount a
+// $state proxy and then mutate it, and spreading into a fresh object would sever that.
+const mount_menu = (props: ComponentProps<typeof CommandMenu>) => {
+  props.fade_duration_ms ??= 0
+  return mount(CommandMenu, { target: document.body, props })
+}
 
 async function type_search(text: string): Promise<HTMLInputElement> {
   const input = menu_input()
@@ -71,7 +74,6 @@ test.each([
       open: false,
       triggers,
       actions: mock_actions,
-      fade_duration_ms: 0,
     })
     mount_menu(props)
 
@@ -131,7 +133,6 @@ test.each([
       open: true,
       close_keys,
       actions: mock_actions,
-      fade_duration_ms: 0,
       dialog_props,
     })
     mount_menu(props)
@@ -159,7 +160,6 @@ test.each([`Escape`, `x`])(
       open: true,
       close_keys: [close_key],
       actions: [{ label: `Close action`, shortcut: close_key, action }],
-      fade_duration_ms: 0,
       onkeydown,
     })
     mount_menu(props)
@@ -213,7 +213,6 @@ test.each([
       close_keys,
       actions: mock_actions,
       dialog_props: { oncancel, closedby },
-      fade_duration_ms: 0,
     })
     await tick()
 
@@ -235,7 +234,6 @@ test(`opens a labeled native light-dismiss dialog`, async () => {
     open: true,
     backdrop_dim: false,
     backdrop_blur: true,
-    fade_duration_ms: 0,
   })
   await tick()
 
@@ -259,7 +257,6 @@ test(`handles action selection and execution`, async () => {
     actions: actions_with_spies,
     activeIndex: null as number | null,
     searchText: `action`,
-    fade_duration_ms: 0,
     onadd,
   })
   mount_menu(props)
@@ -290,7 +287,6 @@ test(`ignores user-created options without action handlers`, async () => {
     open: true,
     actions: [{ label: `existing action`, action }],
     allowUserOptions: true,
-    fade_duration_ms: 0,
   })
   mount_menu(props)
   await tick()
@@ -363,7 +359,7 @@ test(`an onclose callback can reopen without another close event`, async () => {
 })
 
 test(`a stale native close cannot close a reopened menu`, async () => {
-  const props = $state({ open: true, actions: mock_actions, fade_duration_ms: 0 })
+  const props = $state({ open: true, actions: mock_actions })
   mount_menu(props)
   await tick()
   const old_dialog = doc_query<HTMLDialogElement>(`dialog`)
@@ -423,7 +419,6 @@ test(`native dialog close resets state and forwards dialog_props.onclose`, async
     activeOption: mock_actions[1],
     searchText: `action`,
     actions: mock_actions,
-    fade_duration_ms: 0,
     dialog_props: { class: `custom-dialog`, onclose: on_close },
   })
   mount_menu(props)
@@ -446,13 +441,13 @@ test(`native dialog close resets state and forwards dialog_props.onclose`, async
 })
 
 test(`rejects an empty static action list`, () => {
-  expect(() => mount_menu({ open: true, actions: [], fade_duration_ms: 0 })).toThrow(
+  expect(() => mount_menu({ open: true, actions: [] })).toThrow(
     `MultiSelect: received no options`,
   )
 })
 
 test(`remains open when trigger keys are pressed while already open`, async () => {
-  const props = $state({ open: true, actions: mock_actions, fade_duration_ms: 0 })
+  const props = $state({ open: true, actions: mock_actions })
   mount_menu(props)
 
   expect(props.open).toBe(true)
@@ -466,7 +461,7 @@ test(`remains open when trigger keys are pressed while already open`, async () =
 })
 
 test(`lets command menu dropdown overflow dialog box`, async () => {
-  mount_menu({ open: true, actions: mock_actions, fade_duration_ms: 0 })
+  mount_menu({ open: true, actions: mock_actions })
   await tick()
 
   const dialog = doc_query<HTMLDialogElement>(`dialog`)
@@ -508,7 +503,7 @@ test.each([
     { label: `delete file`, action: vi.fn() },
     { label: `update config`, action: vi.fn() },
   ]
-  mount_menu({ open: true, actions, fuzzy, fade_duration_ms: 0 })
+  mount_menu({ open: true, actions, fuzzy })
 
   await type_search(search)
 
@@ -526,7 +521,6 @@ test(`handles bindable props correctly`, async () => {
     actions: mock_actions,
     dialog: null,
     input: null,
-    fade_duration_ms: 0,
   })
   mount_menu(props)
 
@@ -553,7 +547,6 @@ test(`selects the first enabled action and preserves pointer selection across gr
     open: true,
     actions,
     activeIndex: null as number | null,
-    fade_duration_ms: 0,
   })
   mount_menu(props)
   await tick()
@@ -593,7 +586,6 @@ test(`auto-active considers only visible enabled actions`, async () => {
     ],
     activeIndex: 0,
     maxOptions: 1,
-    fade_duration_ms: 0,
   })
   mount_menu(props)
   await tick()
@@ -627,7 +619,6 @@ test(`preserves duplicate action identity across independent key changes`, async
     open: true,
     actions: [first_action, second_action, third_action],
     activeIndex: 1,
-    fade_duration_ms: 0,
   })
   mount_menu(props)
   await tick()
@@ -671,7 +662,6 @@ test(`does not retain an ambiguous index when duplicate actions are rebuilt`, as
     open: true,
     actions: make_actions(),
     activeIndex: 1,
-    fade_duration_ms: 0,
   })
   mount_menu(props)
   await tick()
@@ -692,7 +682,6 @@ test(`preserves the active action by its unique ID amid rebuilt duplicates`, asy
       { id: `duplicate`, label: `Second duplicate`, action: vi.fn() },
     ],
     activeIndex: 1,
-    fade_duration_ms: 0,
   })
   mount_menu(props)
   await tick()
@@ -727,7 +716,6 @@ test(`groupSelectAll selects a whole action group without executing actions or c
     actions,
     groupSelectAll: true,
     onselectAll: on_select_all,
-    fade_duration_ms: 0,
   })
   mount_menu(props)
   await tick()
@@ -771,7 +759,7 @@ test(`renders and searches action descriptions, metadata, badges, and keywords`,
     },
     { label: `quit`, action: vi.fn() },
   ]
-  mount_menu({ open: true, actions, fade_duration_ms: 0 })
+  mount_menu({ open: true, actions })
   await tick()
 
   expect(doc_query(`.cmd-description`).textContent).toBe(`Write buffer to disk`)
@@ -1195,7 +1183,6 @@ test.each([
 ])(`renders shortcut %s as %j`, async (shortcut, expected_parts) => {
   mount_menu({
     open: true,
-    fade_duration_ms: 0,
     actions: [{ label: `zoom in`, action: vi.fn(), shortcut }],
   })
   await tick()
@@ -1204,7 +1191,7 @@ test.each([
 })
 
 test(`plain actions without shortcut/description use default option rendering`, async () => {
-  mount_menu({ open: true, actions: mock_actions, fade_duration_ms: 0 })
+  mount_menu({ open: true, actions: mock_actions })
   await tick()
   expect(document.querySelector(`.cmd-action`)).toBeNull()
 })
@@ -1246,7 +1233,7 @@ test.each([
         shortcut: `ctrl+shift+s`,
       },
     ]
-    mount_menu({ actions, open, global_shortcuts, fade_duration_ms: 0 })
+    mount_menu({ actions, open, global_shortcuts })
     await tick()
 
     globalThis.dispatchEvent(
@@ -1268,7 +1255,6 @@ test(`global shortcuts ignore events consumed by editable controls`, () => {
   const action = vi.fn()
   mount_menu({
     actions: [{ label: `save`, action, shortcut: `ctrl+shift+s` }],
-    fade_duration_ms: 0,
   })
   const textarea = document.createElement(`textarea`)
   textarea.addEventListener(`keydown`, (event) => event.preventDefault())
@@ -1296,7 +1282,6 @@ test.each([`n`, `shift+n`])(
     const action = vi.fn()
     mount_menu({
       actions: [{ label: `new note`, action, shortcut }],
-      fade_duration_ms: 0,
     })
     const press = (tag: string) => {
       const target = document.createElement(tag)
@@ -1351,7 +1336,6 @@ test(`recent_actions_key ranks, persists, and reloads recently triggered actions
     open: true,
     actions,
     recent_actions_key: storage_key,
-    fade_duration_ms: 0,
   })
   mount_menu(props)
   await tick()
@@ -1450,7 +1434,6 @@ test.each([
         actions,
         recent_actions_key: storage_key,
         max_recent,
-        fade_duration_ms: 0,
       })
     })
     await tick()
@@ -1491,7 +1474,6 @@ test.each([
       open: false,
       recent_actions_key: storage_key,
       max_recent,
-      fade_duration_ms: 0,
     })
     await tick()
 

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -1,5 +1,5 @@
 import { CommandMenu, PageSearch } from '$lib'
-import { flushSync, mount, tick } from 'svelte'
+import { type ComponentProps, flushSync, mount, tick } from 'svelte'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vite-plus/test'
 import { doc_query } from './index'
 
@@ -10,6 +10,11 @@ const mock_actions = [
 ]
 
 const menu_input = () => doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
+
+// Passes props straight through rather than merging in defaults: several tests mount a
+// $state proxy and then mutate it, which spreading into a fresh object would sever.
+const mount_menu = (props: ComponentProps<typeof CommandMenu>) =>
+  mount(CommandMenu, { target: document.body, props })
 
 async function type_search(text: string): Promise<HTMLInputElement> {
   const input = menu_input()
@@ -68,7 +73,7 @@ test.each([
       actions: mock_actions,
       fade_duration_ms: 0,
     })
-    mount(CommandMenu, { target: document.body, props })
+    mount_menu(props)
 
     const event = new KeyboardEvent(`keydown`, {
       key: key_to_press,
@@ -129,7 +134,7 @@ test.each([
       fade_duration_ms: 0,
       dialog_props,
     })
-    mount(CommandMenu, { target: document.body, props })
+    mount_menu(props)
 
     const event = new KeyboardEvent(`keydown`, {
       key: key_to_press,
@@ -157,7 +162,7 @@ test.each([`Escape`, `x`])(
       fade_duration_ms: 0,
       onkeydown,
     })
-    mount(CommandMenu, { target: document.body, props })
+    mount_menu(props)
     await tick()
 
     const event = new KeyboardEvent(`keydown`, {
@@ -203,15 +208,12 @@ test.each([
   `dialog cancel with close_keys=$close_keys prevents default: $default_prevented`,
   async ({ close_keys, closedby, default_prevented, effective_closedby }) => {
     const oncancel = vi.fn()
-    mount(CommandMenu, {
-      target: document.body,
-      props: {
-        open: true,
-        close_keys,
-        actions: mock_actions,
-        dialog_props: { oncancel, closedby },
-        fade_duration_ms: 0,
-      },
+    mount_menu({
+      open: true,
+      close_keys,
+      actions: mock_actions,
+      dialog_props: { oncancel, closedby },
+      fade_duration_ms: 0,
     })
     await tick()
 
@@ -227,16 +229,13 @@ test.each([
 
 test(`opens a labeled native light-dismiss dialog`, async () => {
   const show_modal = vi.spyOn(HTMLDialogElement.prototype, `showModal`)
-  mount(CommandMenu, {
-    target: document.body,
-    props: {
-      actions: mock_actions,
-      aria_label: `Run command`,
-      open: true,
-      backdrop_dim: false,
-      backdrop_blur: true,
-      fade_duration_ms: 0,
-    },
+  mount_menu({
+    actions: mock_actions,
+    aria_label: `Run command`,
+    open: true,
+    backdrop_dim: false,
+    backdrop_blur: true,
+    fade_duration_ms: 0,
   })
   await tick()
 
@@ -263,7 +262,7 @@ test(`handles action selection and execution`, async () => {
     fade_duration_ms: 0,
     onadd,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   const input_el = menu_input()
@@ -293,7 +292,7 @@ test(`ignores user-created options without action handlers`, async () => {
     allowUserOptions: true,
     fade_duration_ms: 0,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   await type_search(`custom command`)
@@ -320,7 +319,7 @@ test.each([0, 50])(
         fade_duration_ms,
         dialog_props: { onclose },
       })
-      mount(CommandMenu, { target: document.body, props })
+      mount_menu(props)
       await tick()
 
       const dialog = doc_query<HTMLDialogElement>(`dialog`)
@@ -351,7 +350,7 @@ test(`an onclose callback can reopen without another close event`, async () => {
       }),
     },
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   props.open = false
@@ -365,7 +364,7 @@ test(`an onclose callback can reopen without another close event`, async () => {
 
 test(`a stale native close cannot close a reopened menu`, async () => {
   const props = $state({ open: true, actions: mock_actions, fade_duration_ms: 0 })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
   const old_dialog = doc_query<HTMLDialogElement>(`dialog`)
 
@@ -398,7 +397,7 @@ test(`applies custom styles and props correctly`, async () => {
     liOptionStyle: custom_li_style,
   })
 
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   const select_wrapper = doc_query(`dialog div.multiselect`)
@@ -427,7 +426,7 @@ test(`native dialog close resets state and forwards dialog_props.onclose`, async
     fade_duration_ms: 0,
     dialog_props: { class: `custom-dialog`, onclose: on_close },
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   const dialog = doc_query<HTMLDialogElement>(`dialog`)
@@ -447,17 +446,14 @@ test(`native dialog close resets state and forwards dialog_props.onclose`, async
 })
 
 test(`rejects an empty static action list`, () => {
-  expect(() =>
-    mount(CommandMenu, {
-      target: document.body,
-      props: { open: true, actions: [], fade_duration_ms: 0 },
-    }),
-  ).toThrow(`MultiSelect: received no options`)
+  expect(() => mount_menu({ open: true, actions: [], fade_duration_ms: 0 })).toThrow(
+    `MultiSelect: received no options`,
+  )
 })
 
 test(`remains open when trigger keys are pressed while already open`, async () => {
   const props = $state({ open: true, actions: mock_actions, fade_duration_ms: 0 })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
 
   expect(props.open).toBe(true)
 
@@ -470,10 +466,7 @@ test(`remains open when trigger keys are pressed while already open`, async () =
 })
 
 test(`lets command menu dropdown overflow dialog box`, async () => {
-  mount(CommandMenu, {
-    target: document.body,
-    props: { open: true, actions: mock_actions, fade_duration_ms: 0 },
-  })
+  mount_menu({ open: true, actions: mock_actions, fade_duration_ms: 0 })
   await tick()
 
   const dialog = doc_query<HTMLDialogElement>(`dialog`)
@@ -515,10 +508,7 @@ test.each([
     { label: `delete file`, action: vi.fn() },
     { label: `update config`, action: vi.fn() },
   ]
-  mount(CommandMenu, {
-    target: document.body,
-    props: { open: true, actions, fuzzy, fade_duration_ms: 0 },
-  })
+  mount_menu({ open: true, actions, fuzzy, fade_duration_ms: 0 })
 
   await type_search(search)
 
@@ -538,7 +528,7 @@ test(`handles bindable props correctly`, async () => {
     input: null,
     fade_duration_ms: 0,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
 
   expect(props.dialog).toBeNull()
   expect(props.input).toBeNull()
@@ -565,7 +555,7 @@ test(`selects the first enabled action and preserves pointer selection across gr
     activeIndex: null as number | null,
     fade_duration_ms: 0,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   expect(doc_query(`li.active`).textContent).toContain(`Alpha`)
@@ -605,7 +595,7 @@ test(`auto-active considers only visible enabled actions`, async () => {
     maxOptions: 1,
     fade_duration_ms: 0,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   expect(props.activeIndex).toBeNull()
@@ -639,7 +629,7 @@ test(`preserves duplicate action identity across independent key changes`, async
     activeIndex: 1,
     fade_duration_ms: 0,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   expect(props.activeIndex).toBe(1)
@@ -683,7 +673,7 @@ test(`does not retain an ambiguous index when duplicate actions are rebuilt`, as
     activeIndex: 1,
     fade_duration_ms: 0,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   props.actions = make_actions()
@@ -704,7 +694,7 @@ test(`preserves the active action by its unique ID amid rebuilt duplicates`, asy
     activeIndex: 1,
     fade_duration_ms: 0,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
   const active_option = doc_query<HTMLLIElement>(`li.active`)
 
@@ -739,7 +729,7 @@ test(`groupSelectAll selects a whole action group without executing actions or c
     onselectAll: on_select_all,
     fade_duration_ms: 0,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   doc_query<HTMLButtonElement>(`dialog li.group-header button.group-select-all`).click()
@@ -781,10 +771,7 @@ test(`renders and searches action descriptions, metadata, badges, and keywords`,
     },
     { label: `quit`, action: vi.fn() },
   ]
-  mount(CommandMenu, {
-    target: document.body,
-    props: { open: true, actions, fade_duration_ms: 0 },
-  })
+  mount_menu({ open: true, actions, fade_duration_ms: 0 })
   await tick()
 
   expect(doc_query(`.cmd-description`).textContent).toBe(`Write buffer to disk`)
@@ -1206,13 +1193,10 @@ test.each([
   [`ctrl++`, [`Ctrl`, `+`]], // '+' is both the separator and the key
   [`ctrl+tab`, [`Ctrl`, `Tab`]], // segment without a symbol is title-cased
 ])(`renders shortcut %s as %j`, async (shortcut, expected_parts) => {
-  mount(CommandMenu, {
-    target: document.body,
-    props: {
-      open: true,
-      fade_duration_ms: 0,
-      actions: [{ label: `zoom in`, action: vi.fn(), shortcut }],
-    },
+  mount_menu({
+    open: true,
+    fade_duration_ms: 0,
+    actions: [{ label: `zoom in`, action: vi.fn(), shortcut }],
   })
   await tick()
 
@@ -1220,10 +1204,7 @@ test.each([
 })
 
 test(`plain actions without shortcut/description use default option rendering`, async () => {
-  mount(CommandMenu, {
-    target: document.body,
-    props: { open: true, actions: mock_actions, fade_duration_ms: 0 },
-  })
+  mount_menu({ open: true, actions: mock_actions, fade_duration_ms: 0 })
   await tick()
   expect(document.querySelector(`.cmd-action`)).toBeNull()
 })
@@ -1233,47 +1214,39 @@ test.each([
     desc: `fires when closed`,
     open: false,
     global_shortcuts: true,
-    action_disabled: false,
     calls: 1,
   },
   {
     desc: `disabled via prop`,
     open: false,
     global_shortcuts: false,
-    action_disabled: false,
     calls: 0,
   },
   {
     desc: `inactive while open`,
     open: true,
     global_shortcuts: true,
-    action_disabled: false,
     calls: 0,
   },
   {
     desc: `ignores wrong modifiers`,
     open: false,
     global_shortcuts: true,
-    action_disabled: false,
     calls: 0,
     shift: false,
   },
 ])(
   `global action shortcuts: $desc`,
-  async ({ open, global_shortcuts, calls, shift = true, action_disabled }) => {
+  async ({ open, global_shortcuts, calls, shift = true }) => {
     const spy = vi.fn()
     const actions = [
       {
         label: `save`,
         action: spy,
         shortcut: `ctrl+shift+s`,
-        disabled: action_disabled,
       },
     ]
-    mount(CommandMenu, {
-      target: document.body,
-      props: { actions, open, global_shortcuts, fade_duration_ms: 0 },
-    })
+    mount_menu({ actions, open, global_shortcuts, fade_duration_ms: 0 })
     await tick()
 
     globalThis.dispatchEvent(
@@ -1293,12 +1266,9 @@ test.each([
 
 test(`global shortcuts ignore events consumed by editable controls`, () => {
   const action = vi.fn()
-  mount(CommandMenu, {
-    target: document.body,
-    props: {
-      actions: [{ label: `save`, action, shortcut: `ctrl+shift+s` }],
-      fade_duration_ms: 0,
-    },
+  mount_menu({
+    actions: [{ label: `save`, action, shortcut: `ctrl+shift+s` }],
+    fade_duration_ms: 0,
   })
   const textarea = document.createElement(`textarea`)
   textarea.addEventListener(`keydown`, (event) => event.preventDefault())
@@ -1324,9 +1294,9 @@ test.each([`n`, `shift+n`])(
   `global shortcut %s fires only outside editable targets`,
   (shortcut) => {
     const action = vi.fn()
-    mount(CommandMenu, {
-      target: document.body,
-      props: { actions: [{ label: `new note`, action, shortcut }], fade_duration_ms: 0 },
+    mount_menu({
+      actions: [{ label: `new note`, action, shortcut }],
+      fade_duration_ms: 0,
     })
     const press = (tag: string) => {
       const target = document.createElement(tag)
@@ -1351,19 +1321,16 @@ test.each([`n`, `shift+n`])(
 
 test(`global shortcuts skip disabled duplicate bindings`, async () => {
   const [disabled_action, enabled_action] = [vi.fn(), vi.fn()]
-  mount(CommandMenu, {
-    target: document.body,
-    props: {
-      actions: [
-        {
-          label: `disabled save`,
-          action: disabled_action,
-          shortcut: `ctrl+shift+s`,
-          disabled: true,
-        },
-        { label: `save`, action: enabled_action, shortcut: `ctrl+shift+s` },
-      ],
-    },
+  mount_menu({
+    actions: [
+      {
+        label: `disabled save`,
+        action: disabled_action,
+        shortcut: `ctrl+shift+s`,
+        disabled: true,
+      },
+      { label: `save`, action: enabled_action, shortcut: `ctrl+shift+s` },
+    ],
   })
 
   press_ctrl_shift(`s`)
@@ -1386,7 +1353,7 @@ test(`recent_actions_key ranks, persists, and reloads recently triggered actions
     recent_actions_key: storage_key,
     fade_duration_ms: 0,
   })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   // no recents yet: original order
@@ -1424,7 +1391,7 @@ test(`recent_actions_key uses action ids for duplicate labels`, async () => {
     { label: `save`, description: `No id`, action: vi.fn() },
   ]
   const props = $state({ open: true, actions, recent_actions_key: storage_key })
-  mount(CommandMenu, { target: document.body, props })
+  mount_menu(props)
   await tick()
 
   expect(doc_query(`li[role='option'] .cmd-description`).textContent).toBe(`Mixed`)
@@ -1478,15 +1445,12 @@ test.each([
     }))
     // flushSync so render errors from bad storage data fail this test, not the suite
     flushSync(() => {
-      mount(CommandMenu, {
-        target: document.body,
-        props: {
-          open: true,
-          actions,
-          recent_actions_key: storage_key,
-          max_recent,
-          fade_duration_ms: 0,
-        },
+      mount_menu({
+        open: true,
+        actions,
+        recent_actions_key: storage_key,
+        max_recent,
+        fade_duration_ms: 0,
       })
     })
     await tick()
@@ -1522,15 +1486,12 @@ test.each([
   `global shortcut recents persistence: $desc`,
   async ({ actions, max_recent, keys, expected }) => {
     const storage_key = `test-cmd-recents-${expected.join(`-`)}`
-    mount(CommandMenu, {
-      target: document.body,
-      props: {
-        actions,
-        open: false,
-        recent_actions_key: storage_key,
-        max_recent,
-        fade_duration_ms: 0,
-      },
+    mount_menu({
+      actions,
+      open: false,
+      recent_actions_key: storage_key,
+      max_recent,
+      fade_duration_ms: 0,
     })
     await tick()
 

--- a/tests/vitest/DraggablePane.test.ts
+++ b/tests/vitest/DraggablePane.test.ts
@@ -6,6 +6,10 @@ import { afterEach, describe, expect, test, vi } from 'vite-plus/test'
 import { doc_query, escape_key, mock_rect, pointer_event, stub_prop } from './index'
 import TestPaneExternalToggles from './TestPaneExternalToggles.svelte'
 
+// Every drag/resize test works against the same 450x300 pane; only the origin varies.
+const mock_pane_rect = (pane: HTMLElement, left = 0, top = 0) =>
+  mock_rect(pane, { left, top, width: 450, height: 300 })
+
 describe(`DraggablePane`, () => {
   // click_outside registers document listeners that outlive innerHTML = '', and
   // stubbed globals must not leak into the next case
@@ -275,7 +279,7 @@ describe(`DraggablePane`, () => {
     mock_viewport()
     const { toggle, pane } = await setup({ position: `fixed` })
     mock_rect(toggle, { ...rect, width: 20, height: 20 })
-    mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+    mock_pane_rect(pane)
 
     toggle.click()
     await tick()
@@ -293,7 +297,7 @@ describe(`DraggablePane`, () => {
     const { toggle, pane } = await setup()
     cleanups.push(stub_prop(toggle, `offsetParent`, ancestor))
     mock_rect(toggle, { left: 700, top: 300, width: 20, height: 20 })
-    mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+    mock_pane_rect(pane)
 
     toggle.click()
     await tick()
@@ -312,7 +316,7 @@ describe(`DraggablePane`, () => {
     const { toggle, pane } = await setup()
     cleanups.push(stub_prop(toggle, `offsetParent`, null))
     mock_rect(toggle, { left: 700, top: 300, width: 20, height: 20 })
-    mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+    mock_pane_rect(pane)
 
     toggle.click()
     await tick()
@@ -328,7 +332,7 @@ describe(`DraggablePane`, () => {
     const { toggle, pane } = await setup()
     cleanups.push(stub_prop(toggle, `offsetParent`, ancestor))
     mock_rect(toggle, { left: 500, top: 100, width: 20, height: 20 })
-    mock_rect(pane, { left: 75, top: 125, width: 450, height: 300 })
+    mock_pane_rect(pane, 75, 125)
 
     toggle.click()
     await tick()
@@ -424,7 +428,7 @@ describe(`DraggablePane`, () => {
     `resize=%s dragging the %s strip sets the pane size`,
     async (resize, edge, [end_x, end_y], expected) => {
       const { pane } = await open_pane({ resize })
-      mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+      mock_pane_rect(pane)
 
       drag(strip_of(pane, edge), [445, 295], [end_x, end_y])
       await tick()
@@ -437,7 +441,7 @@ describe(`DraggablePane`, () => {
   test(`a narrow viewport preserves width until a horizontal resize changes it`, async () => {
     mock_viewport(400, 500)
     const { pane } = await open_pane({ resize: `both` })
-    mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+    mock_pane_rect(pane)
 
     strip_of(pane, `right`).dispatchEvent(pointer_event(`pointerdown`, 445, 150))
     await tick()
@@ -457,7 +461,7 @@ describe(`DraggablePane`, () => {
   test(`the default max width caps natural size but not a manual viewport-safe resize`, async () => {
     mock_viewport(700, 500)
     const { pane } = await open_pane({ resize: `both` })
-    mock_rect(pane, { left: 100, top: 50, width: 450, height: 300 })
+    mock_pane_rect(pane, 100, 50)
     expect(pane.style.maxWidth).toBe(`450px`)
 
     drag(corner_of(pane), [550, 350], [900, 900])
@@ -479,7 +483,7 @@ describe(`DraggablePane`, () => {
 
   test(`an explicit max_width remains authoritative after resizing`, async () => {
     const { pane } = await open_pane({ resize: `width`, max_width: `600px` })
-    mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+    mock_pane_rect(pane)
     const right_strip = strip_of(pane, `right`)
 
     drag(right_strip, [450, 150], [700, 150])
@@ -493,7 +497,7 @@ describe(`DraggablePane`, () => {
   // The visible grip is pointer-transparent decoration over the attachment's corner handle.
   test(`double-clicking the corner resets a manual resize`, async () => {
     const { pane } = await open_pane({ resize: `both` })
-    mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+    mock_pane_rect(pane)
 
     drag(strip_of(pane, `right`), [445, 295], [545, 150])
     await tick()
@@ -510,7 +514,7 @@ describe(`DraggablePane`, () => {
 
   test(`a resize opts the pane out of repositioning and reveals the controls`, async () => {
     const { pane } = await open_pane({ resize: `both` })
-    mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+    mock_pane_rect(pane)
     expect(document.querySelector(`.reset-button`)).toBeNull()
 
     strip_of(pane, `right`).dispatchEvent(pointer_event(`pointerdown`, 445, 150))
@@ -526,7 +530,7 @@ describe(`DraggablePane`, () => {
   test(`a resize released outside the pane does not dismiss it`, async () => {
     const on_close = vi.fn()
     const { pane } = await open_pane({ resize: `both`, on_close })
-    mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+    mock_pane_rect(pane)
 
     // press the grab strip, drag past the pane, release over the page
     drag(strip_of(pane, `right`), [445, 150], [900, 150])
@@ -559,7 +563,7 @@ describe(`DraggablePane`, () => {
     mock_viewport()
     const { toggle, pane } = await setup({ position: `fixed` })
     mock_rect(toggle, { left: 600, top: 20, width: 20, height: 20 })
-    mock_rect(pane, { left: 0, top: 0, width: 450, height: 300 })
+    mock_pane_rect(pane)
 
     toggle.click()
     await tick()

--- a/tests/vitest/DraggablePane.test.ts
+++ b/tests/vitest/DraggablePane.test.ts
@@ -290,12 +290,15 @@ describe(`DraggablePane`, () => {
     expect(pane.style.getPropertyValue(`--pane-viewport-clamp`)).toBe(clamp)
   })
 
-  test(`absolute positioning measures against the offsetParent`, async () => {
+  // Stubbed on the pane, not the toggle: the pane's own containing block is what its
+  // left/top resolve against, and the two only coincide while nothing repositions the
+  // toggle out of it.
+  test(`absolute positioning measures against the pane's offsetParent`, async () => {
     const ancestor = document.createElement(`div`)
     document.body.append(ancestor)
     mock_rect(ancestor, { left: 100, top: 50, width: 800, height: 600 })
     const { toggle, pane } = await setup()
-    cleanups.push(stub_prop(toggle, `offsetParent`, ancestor))
+    cleanups.push(stub_prop(pane, `offsetParent`, ancestor))
     mock_rect(toggle, { left: 700, top: 300, width: 20, height: 20 })
     mock_pane_rect(pane)
 

--- a/tests/vitest/MultiSelect.async.svelte.test.ts
+++ b/tests/vitest/MultiSelect.async.svelte.test.ts
@@ -20,11 +20,8 @@ afterEach(() => {
 const mock_console_error = () =>
   vi.spyOn(console, `error`).mockImplementation(() => undefined)
 
-// disabled=true and the base error case are covered by the allowEmpty/disabled/allowUserOptions matrix in MultiSelect.svelte.test.ts
-test(`empty options are valid while loading`, () => {
-  expect(() => mount_multiselect({ options: [], loading: true })).not.toThrow()
-})
-
+// Empty options while loading, disabled, or allowing user options, and the base error
+// case, all live in the `accepts empty options in %s mode` matrix in MultiSelect.svelte.test.ts
 // deferred loadOptions fetch: tests decide exactly when each request settles
 type LoadResult = { options: string[]; hasMore: boolean }
 

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -2441,13 +2441,13 @@ test.each([[true], [-1], [3.5], [`foo`], [{}]])(
   },
 )
 
-test.each<[OptionStyle, string | null, string]>([
-  // Invalid key cases
-  [`color: red;`, `invalid`, ``],
-  // Valid key cases
+// A key outside 'selected' | 'option' used to appear here as two more rows, but the body
+// queries one list per key and so asserted nothing for them — same mount as the `option`
+// row, no expectation reached.
+test.each<[OptionStyle, `selected` | `option`, string]>([
+  // String style cases
   [`color: red;`, `selected`, `color: red;`],
   [`color: red;`, `option`, `color: red;`],
-  [`color: red;`, null, `color: red;`],
   // Object style cases
   [{ selected: `color: red;`, option: `color: blue;` }, `selected`, `color: red;`],
   [{ selected: `color: red;`, option: `color: blue;` }, `option`, `color: blue;`],
@@ -2473,13 +2473,8 @@ test.each<[OptionStyle, string | null, string]>([
     }
     mount_multiselect({ options, selected: key === `selected` ? options : [] })
 
-    if (key === `selected`) {
-      const selected_li = doc_query(`ul.selected > li`)
-      expect(selected_li.style.cssText).toBe(expected_css)
-    } else if (key === `option`) {
-      const option_li = doc_query(`ul.options > li`)
-      expect(option_li.style.cssText).toBe(expected_css)
-    }
+    const li = doc_query(key === `selected` ? `ul.selected > li` : `ul.options > li`)
+    expect(li.style.cssText).toBe(expected_css)
   },
 )
 
@@ -3101,33 +3096,30 @@ describe(`selectAllOption feature`, () => {
   })
 })
 
-// Test that value prop can initialize selected options for both single (maxSelect=1) and multi-select (maxSelect=null)
-// Covers string, number, and object options, with single values for maxSelect=1 and arrays for maxSelect=null
-describe.each([[1], [null]])(`initial value prop with maxSelect=%s`, (max_select) => {
-  test.each([
-    [`Red`, [`Red`, `Green`, `Blue`], `Red`],
-    [1, [1, 2, 3], `1`],
-    [{ label: `Red` }, [{ label: `Red` }, { label: `Green` }], `Red`],
-    [[`Red`, `Green`], [`Red`, `Green`, `Blue`], `Red Green`],
-    [[1, 2], [1, 2, 3], `1 2`],
-    [
-      [{ label: `Red` }, { label: `Green` }],
-      [{ label: `Red` }, { label: `Green` }, { label: `Blue` }],
-      `Red Green`,
-    ],
-  ])(`works when value=%s`, (value, options, expected_text) => {
-    const is_single_value = !Array.isArray(value)
-    const is_single_select = max_select === 1
-
-    // Skip invalid combinations: single value with multi-select, array value with single select
-    if (is_single_value !== is_single_select) return
-
+// value initializes selected for single (maxSelect=1) and multi-select (maxSelect=null)
+// alike, over string, number and object options. Each row carries its own maxSelect: a
+// shared describe.each over both crossed with every value shape spent half its runs
+// returning at a validity guard, reporting six passing tests that asserted nothing.
+test.each<[1 | null, Option | Option[], Option[], string]>([
+  [1, `Red`, [`Red`, `Green`, `Blue`], `Red`],
+  [1, 1, [1, 2, 3], `1`],
+  [1, { label: `Red` }, [{ label: `Red` }, { label: `Green` }], `Red`],
+  [null, [`Red`, `Green`], [`Red`, `Green`, `Blue`], `Red Green`],
+  [null, [1, 2], [1, 2, 3], `1 2`],
+  [
+    null,
+    [{ label: `Red` }, { label: `Green` }],
+    [{ label: `Red` }, { label: `Green` }, { label: `Blue` }],
+    `Red Green`,
+  ],
+])(
+  `maxSelect=%s initializes selected from value=%j`,
+  (max_select, value, options, expected_text) => {
     mount_multiselect({ options, value, maxSelect: max_select })
 
-    const selected_ul = doc_query(`ul.selected`)
-    expect(selected_ul.textContent?.trim()).toBe(expected_text)
-  })
-})
+    expect(doc_query(`ul.selected`).textContent?.trim()).toBe(expected_text)
+  },
+)
 
 test(`createOptionMsg shows immediately with static options`, async () => {
   mount_multiselect({

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -713,22 +713,9 @@ describe(`Nav`, () => {
       expect(on_close).toHaveBeenCalledTimes(1)
     })
 
-    test.each([
-      [`clicking link`, () => click(doc_query(`a`))],
-      [`pressing Escape`, escape],
-    ])(`onclose called when %s closes menu`, async (_desc, close_action) => {
-      const on_close = vi.fn()
-      set_window_width(500)
-
-      mount_nav({ routes: [`/home`], onclose: on_close, breakpoint: 767 })
-      await tick()
-      await click(doc_query(`.burger`))
-      await tick()
-      await close_action()
-      await tick()
-      expect(on_close).toHaveBeenCalledTimes(1)
-      expect(doc_query(`.burger`).getAttribute(`aria-expanded`)).toBe(`false`)
-    })
+    // No per-cause onclose test: the callback fires from one $effect watching is_open go
+    // true->false, which the burger case above covers, and `closes on Escape or link
+    // click` already pins those two causes reaching that transition.
   })
 
   describe(`breakpoint prop`, () => {
@@ -1170,10 +1157,12 @@ describe(`Nav`, () => {
       expect(is_visible(dropdown_menu)).toBe(true)
     })
 
-    test(`schedule_hide early-returns on touch devices so dropdown survives mouseleave`, async () => {
+    // A touchscreen laptop reports touch support at desktop width, where the pointer is
+    // still a mouse: hover opens the dropdown, so hover has to be able to close it again.
+    // Suppressing the hide on touch support alone stranded it open until a click outside.
+    test(`a hover-opened dropdown still closes on a touch-capable desktop`, async () => {
       vi.useFakeTimers()
       vi.stubGlobal(`ontouchstart`, () => {})
-      // desktop width: hover-open is only blocked when touch AND mobile
       const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown_ms: 0 })
       await tick()
 
@@ -1182,7 +1171,25 @@ describe(`Nav`, () => {
       expect(is_visible(dropdown_menu)).toBe(true)
 
       mouse_leave(dropdown)
-      // with cooldown=0 a scheduled hide would fire immediately - the touch guard skips it
+      await vi.advanceTimersByTimeAsync(500)
+      expect(is_visible(dropdown_menu)).toBe(false)
+      vi.useRealTimers()
+    })
+
+    // What the touch guard was really protecting: a tap pins the dropdown, and the
+    // synthetic mouseleave that follows it must not undo the tap.
+    test(`a tap-pinned dropdown survives the mouseleave that follows the tap`, async () => {
+      vi.useFakeTimers()
+      vi.stubGlobal(`ontouchstart`, () => {})
+      const { dropdown, dropdown_menu, toggle } = mount_dropdown({
+        dropdown_cooldown_ms: 0,
+      })
+      await tick()
+
+      await click(toggle)
+      expect(is_visible(dropdown_menu)).toBe(true)
+
+      mouse_leave(dropdown)
       await vi.advanceTimersByTimeAsync(500)
       expect(is_visible(dropdown_menu)).toBe(true)
       vi.useRealTimers()

--- a/tests/vitest/attachments/click-outside.test.ts
+++ b/tests/vitest/attachments/click-outside.test.ts
@@ -229,7 +229,9 @@ describe(`click_outside`, () => {
   it(`locates a scroller's gutter past its border, not at its rect edge`, () => {
     const { callback } = attach_outside()
     const scroller = create_element()
-    mock_rect(scroller, { left: 100, top: 50 })
+    // Border box wide enough to hold border + scrollport + a 15px gutter on each axis, so
+    // every press below lands inside it the way a real hit test would deliver them.
+    mock_rect(scroller, { left: 100, top: 50, width: 225, height: 125 })
     cleanups.push(
       stub_prop(scroller, `clientLeft`, 10), // a 10px border, then...
       stub_prop(scroller, `clientTop`, 10),

--- a/tests/vitest/attachments/click-outside.test.ts
+++ b/tests/vitest/attachments/click-outside.test.ts
@@ -1,6 +1,6 @@
 import { click_outside } from '$lib/attachments'
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
-import { create_element, escape_key, stub_prop } from '../index'
+import { create_element, escape_key, mock_rect, stub_prop } from '../index'
 
 describe(`click_outside`, () => {
   const dispatch_press = (
@@ -220,6 +220,33 @@ describe(`click_outside`, () => {
     expect(callback).not.toHaveBeenCalled()
 
     press(400, 300) // control: same target inside the client box does dismiss
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  // The rect is the border box but clientWidth/Height are the padding box, so the gutter
+  // starts a border in from where the rect alone suggests. Getting that wrong swallows
+  // presses on the last border-width of content in any bordered scroller.
+  it(`locates a scroller's gutter past its border, not at its rect edge`, () => {
+    const { callback } = attach_outside()
+    const scroller = create_element()
+    mock_rect(scroller, { left: 100, top: 50 })
+    cleanups.push(
+      stub_prop(scroller, `clientLeft`, 10), // a 10px border, then...
+      stub_prop(scroller, `clientTop`, 10),
+      stub_prop(scroller, `clientWidth`, 200), // ...200px of scrollport, so the vertical
+      stub_prop(scroller, `clientHeight`, 100), // gutter opens at x 310 and the horizontal at y 160
+      stub_prop(scroller, `scrollWidth`, 400), // overflowing on both axes puts both there
+      stub_prop(scroller, `scrollHeight`, 400),
+    )
+    const press = (clientX: number, clientY: number) =>
+      dispatch_press(scroller, [], `pointerdown`, { clientX, clientY })
+
+    press(315, 100) // vertical gutter
+    press(150, 165) // horizontal gutter
+    expect(callback).not.toHaveBeenCalled()
+
+    // Inside both gutters but outside the border-box-only reading of them
+    press(305, 155)
     expect(callback).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/vitest/code-editor-edit-ops.test.ts
+++ b/tests/vitest/code-editor-edit-ops.test.ts
@@ -64,6 +64,14 @@ test.each<[string, BlockCommand, string, string, string]>([
   ],
   [`uncomment`, toggle_line_comment, `[# one\n  #two]`, `#`, `[one\n  two]`],
   [`mixed comment`, toggle_line_comment, `[// one\ntwo]`, `//`, `[// // one\n// two]`],
+  // An indent of whitespace outside [ \t] used to slice into the token, leaving `/ one`
+  [
+    `uncomment past an exotic indent`,
+    toggle_line_comment,
+    `[ // one\n// two]`,
+    `//`,
+    `[ one\ntwo]`,
+  ],
 ])(`block command: %s`, (_label, command, before, unit, expected) => {
   expect(run(command, before, unit)).toBe(expected)
 })

--- a/tests/vitest/masonry.test.ts
+++ b/tests/vitest/masonry.test.ts
@@ -39,12 +39,6 @@ const as_columns = () =>
 const resize_observers = new Map<Element, ResizeObserverCallback>()
 // number for a uniform height, or a function to give each item its own measured height
 let mock_height: number | ((el: Element) => number) = 100
-// Fire every registered ResizeObserver callback, as if all items had just been measured
-const measure_all_items = () => {
-  for (const item of item_els()) {
-    resize_observers.get(item)?.([mock_resize_entry(item)], mock_observer)
-  }
-}
 const measured_height = (el: Element): number =>
   typeof mock_height === `number` ? mock_height : mock_height(el)
 
@@ -55,12 +49,6 @@ const mock_resize_entry = (target: Element): ResizeObserverEntry => ({
   contentBoxSize: [],
   devicePixelContentBoxSize: [],
 })
-
-const mock_observer: ResizeObserver = {
-  observe: () => {},
-  unobserve: () => {},
-  disconnect: () => {},
-}
 
 globalThis.ResizeObserver = class ResizeObserver implements ResizeObserver {
   private readonly callback: ResizeObserverCallback
@@ -557,6 +545,19 @@ describe(`Masonry virtualization`, () => {
     expect(count_5).toBeGreaterThan(count_1)
   })
 
+  // overscan=0 removes the slack that hid an exclusive end one row short, so the item
+  // straddling the viewport's bottom edge went unrendered and left a blank strip.
+  test(`overscan=0 still renders the item at the viewport's bottom edge`, () => {
+    mount_virtualized(50, {
+      getEstimatedHeight: () => 100,
+      overscan: 0,
+      gap: 0,
+      calcCols: () => 1,
+    })
+    // 100px items in a 300px viewport: rows 0, 1 and 2 all sit on screen
+    expect([...item_els()].map((el) => el.textContent?.trim())).toEqual([`0`, `1`, `2`])
+  })
+
   test.each([
     [`balanced`, 2],
     [`row-first`, 3],
@@ -721,43 +722,6 @@ describe(`Masonry virtual scroll stability`, () => {
     const expected_measured = (item_count - rendered) * (mock_height + gap)
     expect(padding).toBeLessThan(expected_measured * 0.8)
     expect(padding).toBeGreaterThan(expected_estimated * 0.5)
-  })
-
-  test.each([
-    { estimated: 100, measured: 80 },
-    { estimated: 200, measured: 150 },
-  ])(
-    `padding stable after measurements (est=$estimated, meas=$measured)`,
-    async ({ estimated, measured }) => {
-      mock_height = measured
-      mount_virtualized(50, {
-        calcCols: () => 1,
-        getEstimatedHeight: () => estimated,
-        height: 200,
-        gap: 10,
-      })
-
-      const col = col_els()[0]
-      const initial_style = col?.getAttribute(`style`)
-
-      measure_all_items()
-
-      expect(col?.getAttribute(`style`)).toBe(initial_style)
-    },
-  )
-
-  test(`column distribution stable after measurements`, async () => {
-    mount_virtualized(100, {
-      calcCols: () => 3,
-      getEstimatedHeight: () => 100,
-      height: 300,
-    })
-
-    const before = get_col_dist()
-
-    measure_all_items()
-
-    expect(get_col_dist()).toEqual(before)
   })
 
   test(`10k items render only a virtualized window`, async () => {

--- a/tests/vitest/toast.svelte.test.ts
+++ b/tests/vitest/toast.svelte.test.ts
@@ -126,12 +126,7 @@ describe(`toast queue reducer`, () => {
         [`p0`, `p1`, `p2`],
       ],
       [
-        `skips past actions to the newest plain notice`,
-        [false, true, true, false],
-        [`p3`],
-        [`p0`, `p1`, `p2`],
-      ],
-      [
+        // the genuine skip-past-actions case: findLastIndex has to walk back to p0
         `drops the only actionless toast, wherever it sits`,
         [false, true, true, true],
         [`p0`],

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -46,11 +46,8 @@ const set_window_width = (width: number) => {
 
 // Element.prototype is the only place to intercept this: happy-dom has no layout, so the
 // component's own scrollIntoView call is all there is to observe.
-const spy_scroll_into_view = () => {
-  const scroll_into_view_mock = vi.fn<Element[`scrollIntoView`]>()
-  vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(scroll_into_view_mock)
-  return scroll_into_view_mock
-}
+const spy_scroll_into_view = () =>
+  vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(() => {})
 
 const scroll = async () => {
   globalThis.dispatchEvent(new Event(`scroll`))
@@ -262,7 +259,7 @@ describe(`Toc`, () => {
   test(`replaceState uses the raw id while the link href is URL-encoded`, async () => {
     set_body(`<h2 id="sec:1">Section</h2>`)
     const replace_state_mock = vi.spyOn(history, `replaceState`)
-    vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(() => {})
+    spy_scroll_into_view()
 
     mount_toc()
     await tick()
@@ -713,7 +710,7 @@ describe(`Toc`, () => {
     set_headings(2)
     set_window_width(1200)
     mock_active_heading(`heading-1`)
-    vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(() => {})
+    spy_scroll_into_view()
     const replace_mock = vi.spyOn(history, `replaceState`)
 
     mount_toc()

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -44,6 +44,14 @@ const set_window_width = (width: number) => {
   globalThis.dispatchEvent(new Event(`resize`))
 }
 
+// Element.prototype is the only place to intercept this: happy-dom has no layout, so the
+// component's own scrollIntoView call is all there is to observe.
+const spy_scroll_into_view = () => {
+  const scroll_into_view_mock = vi.fn<Element[`scrollIntoView`]>()
+  vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(scroll_into_view_mock)
+  return scroll_into_view_mock
+}
+
 const scroll = async () => {
   globalThis.dispatchEvent(new Event(`scroll`))
   await tick()
@@ -392,10 +400,7 @@ describe(`Toc`, () => {
       set_body(`<h2 id="first">First</h2><h2 id="second">Second</h2>`)
       mock_active_heading(`first`)
       const replace_state_mock = vi.spyOn(history, `replaceState`)
-      const scroll_into_view_mock = vi.fn<Element[`scrollIntoView`]>()
-      vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(
-        scroll_into_view_mock,
-      )
+      const scroll_into_view_mock = spy_scroll_into_view()
 
       mount_toc({
         tocItem: createRawSnippet<[HTMLHeadingElement]>((heading) => ({
@@ -446,10 +451,7 @@ describe(`Toc`, () => {
   test(`modified clicks on ToC links keep native browser behavior`, async () => {
     set_body(`<h2 id="intro">Intro</h2>`)
     const replace_state_mock = vi.spyOn(history, `replaceState`)
-    const scroll_into_view_mock = vi.fn<Element[`scrollIntoView`]>()
-    vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(
-      scroll_into_view_mock,
-    )
+    const scroll_into_view_mock = spy_scroll_into_view()
 
     mount_toc()
     await tick()
@@ -768,10 +770,7 @@ describe(`Toc`, () => {
     async (_, key, scrollBehavior, expected_behavior) => {
       set_headings(2)
 
-      const scroll_into_view_mock = vi.fn<Element[`scrollIntoView`]>()
-      vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(
-        scroll_into_view_mock,
-      )
+      const scroll_into_view_mock = spy_scroll_into_view()
       const replace_state_mock = vi.spyOn(history, `replaceState`)
 
       // breakpoint above the happy-dom window width forces mobile mode, where open=true is
@@ -835,10 +834,7 @@ describe(`Toc`, () => {
 
   test(`mutation observer tracks headings added and removed after mount`, async () => {
     set_body(`<div id="content"><h2 id="initial">Initial Heading</h2></div>`)
-    const scroll_into_view_mock = vi.fn<Element[`scrollIntoView`]>()
-    vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(
-      scroll_into_view_mock,
-    )
+    const scroll_into_view_mock = spy_scroll_into_view()
 
     mount_toc()
     await tick()

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -740,10 +740,6 @@ describe(`fuzzy_match_indices`, () => {
 })
 
 describe(`is_editable_event_target`, () => {
-  afterEach(() => {
-    document.body.innerHTML = ``
-  })
-
   test.each([
     [`<input />`, `input`, true],
     [`<textarea></textarea>`, `textarea`, true],
@@ -846,9 +842,6 @@ describe(`step_focus`, () => {
   beforeEach(() => {
     document.body.innerHTML = `<button>0</button><button>1</button><button>2</button>`
     items = [...document.querySelectorAll(`button`)]
-  })
-  afterEach(() => {
-    document.body.innerHTML = ``
   })
 
   const press = (key: string, options?: { horizontal?: boolean }) => {


### PR DESCRIPTION
Started from a report that the tooltip arrow's tip wasn't quite centered on the side of the tooltip. The cause generalized into a class of bug worth sweeping for: geometry read in one box model and written in another. `getBoundingClientRect` and `offsetHeight` report the **border box**, while absolute insets, `clientWidth/Height`, `offsetTop` and `scrollTop` all live in the **padding box**.

### Box-model coordinate-space bugs

- **`tooltip.ts`** — the arrow's cross-axis center was measured from the border box but written as an absolute inset, which resolves against the padding box, so every tip sat one border-width off center. Measured 0.99px off with the default 1px border, 3.98px with a 4px one.
- **`tooltip.ts`** — the main-axis inset used the *painted* border width, which is zeroed for a transparent color, where the *layout* width is what shifts the padding box. Under `4px solid transparent` the tip cleared the surface by 2px instead of 6.
- **`DraggablePane.svelte`** — the pane anchored to its positioned ancestor's border-box rect but writes `left`/`top`, which resolve against that ancestor's padding box. `.demo-box` already carries a 1px border, so **the shipped demo has always been a pixel off its toggle**; a 10px border put it 10px off.
- **`click-outside.ts`** — the scrollbar gutter was located at `rect.left + clientWidth`, mixing a border-box origin with a padding-box width. On any bordered scroller the last border-width of content read as gutter, silently suppressing dismissal.
- **`Toc.svelte`** — `offsetHeight` (border box) stood in for the scrollport height when centering the active item, where `clientHeight` is the box `scrollTop` and `offsetTop` count in.

### Further defects found while sweeping

- **`tooltip.ts`** — the listener is `pointerover`, which fires again on every crossing between the trigger's own children, and `request_open` cleared the pending timer before scheduling a fresh full delay. A trigger built from several elements could never reach its deadline while the pointer moved across it. Measured: 160ms into a 100ms delay, still hidden.
- **`draggable.ts`** — the origin came from a rect or `offsetLeft` (border edge) but `left`/`top` place the margin edge, so a node with margins jumped by them on `pointerdown` before any movement, and the bounds clamp was then measured from the wrong place.
- **`toast-queue.svelte.ts`** — `rebalance_queue` paused the whole pending list, reading a caller's wall-clock `expires_at_ms` as if the queue had derived it and adopting the distance to it as the visible budget. A 5000ms budget paired with a 60s deadline became a 60s budget, inverting the documented "budget wins" rule. Only a toast coming off screen has a clock to bank, which the demotion already does itself.
- **`Nav.svelte`** — hover-open was gated on `is_touch_device && is_mobile` but the hide on `is_touch_device` alone, so on a touchscreen laptop the dropdown opened on hover and never closed. Taps were never at risk: they pin the dropdown and `schedule_hide` already returns early on `is_pinned`.
- **`Masonry.svelte`** — the exclusive render-window `end` omitted the row straddling the viewport bottom, which `start` compensates for with its own `-1` margin. Hidden by the default overscan of 5; with `overscan={0}` the last on-screen row went unrendered.
- **`edit-ops.ts`** — `toggle_line_comment` tested commented-ness with `trimStart()` (all Unicode whitespace) but sliced using an indent width counting only `[ \t]`. A line indented with a non-breaking space uncommented `" // foo"` to `"/ foo"`, leaving half the token behind.

Every fix carries a regression test confirmed to fail against the pre-fix code.

### Test cleanup

15 test instances removed with **byte-identical coverage** (10218/10510 statements, 5137/5615 branches before and after). Most could not fail:

- six `MultiSelect` value-prop cases returned at a validity guard before asserting anything
- two option-style rows whose key matched neither assertion branch
- three `Masonry` tests calling a `measure_all_items()` that is a no-op under `virtualize` — which the suite itself proves at its `virtualization skips ResizeObservers` test
- a duplicate toast overflow row (`findLastIndex` returns the same index for both patterns), a dead `action_disabled` column, and two `afterEach` hooks duplicating `setup.ts`'s global `beforeEach`

New `mount_menu`, `spy_scroll_into_view` and `mock_pane_rect` helpers fold 44 call sites.

### Judgment calls

- One flagged deletion was **rejected**: `applies DOM attributes to input node` was reported as covered elsewhere, but `input.form-control` appears only in that test and nothing else asserts `input.id`.
- The Nav change overrides a previously passing test that asserted the stuck-open dropdown as correct; it's replaced with two tests covering the hover and tap-pinned paths separately.
