### PR TITLE
Open Nav dropdowns on click only and rebuild the mobile submenu

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -109,8 +109,8 @@ body > div {
   }
   aside.toc.mobile {
     /* the aside is position: fixed, so it is already out of flow and takes no grid track.
-       It used to be collapsed to 0x0 here, which also collapsed the panel it now lays out. */
-    min-width: 0;
+       It used to be collapsed to 0x0 here, which also collapsed the panel it now lays out.
+       Toc floors its own mobile min-width now, so only the margin is still ours to reset. */
     margin: 0;
   }
   main {

--- a/src/app.css
+++ b/src/app.css
@@ -45,6 +45,10 @@ body {
   background: var(--bg);
   color: var(--text);
   line-height: 1.6;
+  /* prose here is full of bare identifiers (`duplicateOptionMsg/noMatchingOptionsMsg`) that
+     offer no break opportunity and used to spill off a phone. break-word only splits a word
+     that cannot fit a line on its own, so it leaves intrinsic sizing alone. */
+  overflow-wrap: break-word;
   min-height: 100vh;
   box-sizing: border-box;
   display: flex;
@@ -144,6 +148,10 @@ code {
   border-radius: 3pt;
   background: var(--surface);
   font-size: 1.1em;
+  /* an identifier like `flash_clicked_headings_for_ms` has no break opportunity, so inline
+     code used to set the min-content width of its line and scroll a phone sideways.
+     `pre` is unaffected: white-space: pre offers no soft wrap opportunities either way. */
+  overflow-wrap: anywhere;
 }
 pre {
   position: relative;

--- a/src/app.css
+++ b/src/app.css
@@ -104,14 +104,17 @@ body > div {
     color: inherit; /* Toc uses :where(); else global `a` paints every item accent */
   }
   aside.toc.mobile {
-    width: 0;
-    height: 0;
+    /* the aside is position: fixed, so it is already out of flow and takes no grid track.
+       It used to be collapsed to 0x0 here, which also collapsed the panel it now lays out. */
     min-width: 0;
     margin: 0;
-    overflow: visible; /* fixed FAB must not occupy a grid track */
   }
   main {
     margin: 0;
+    /* grid items floor at min-content, so one wide code block or table stretched `main` past
+       the viewport and scrolled the whole page sideways on a phone. Code scrolls inside its
+       own `pre code` instead. */
+    min-width: 0;
   }
 }
 main {

--- a/src/lib/ActionButton.svelte
+++ b/src/lib/ActionButton.svelte
@@ -6,9 +6,8 @@
   import { merge_defaults, ACTION_BUTTON_LABELS, type ActionButtonLabels } from './labels'
   import type { ActionButtonSnippetProps, ActionState } from './types'
 
-  // drives the hidden width sizer, so every state reserves its own width up front
-  // Derived from the labels record so a new state cannot be added without the hidden
-  // width sizer below growing to match it
+  // Drives the hidden width sizer so every state reserves its width up front; derived from
+  // the labels record so a new state can't be added without the sizer growing to match.
   const ACTION_STATES = Object.keys(ACTION_BUTTON_LABELS) as ActionState[]
 
   let {

--- a/src/lib/ActionMenu.svelte
+++ b/src/lib/ActionMenu.svelte
@@ -45,8 +45,8 @@
   type Props = Omit<HTMLAttributes<HTMLMenuElement>, `children`> & {
     actions: (CmdAction | CmdSection)[]
     disabled?: boolean
-    // Native light-dismiss is the default. Supplying press dismissal, escape: false,
-    // enabled: false, or extra inside regions switches to the custom dismissal path.
+    // Native light-dismiss by default; press dismissal, escape/enabled false, or extra
+    // inside regions switch to the custom dismissal path.
     dismiss?: DismissConfig
     item?: Snippet<[{ action: CmdAction; section?: CmdSection; checked?: boolean }]>
     on_select?: (action: CmdAction, section?: CmdSection) => void
@@ -105,9 +105,8 @@
   // section; its required `action` callback is what one entry has and the other lacks.
   const is_section = (entry: CmdAction | CmdSection): entry is CmdSection =>
     !(`action` in entry)
-  // Tag by source field so id `Copy`, label `Copy`, and section `Copy` stay distinct.
-  // Index is appended only when that tag repeats in the same each — unique ids stay
-  // stable across reorder.
+  // Tag by source field so id `Copy`, label `Copy` and section `Copy` stay distinct; the
+  // index is appended only on repeats, so unique ids stay stable across reorder.
   const tag = (entry: CmdAction | CmdSection): string =>
     is_section(entry)
       ? JSON.stringify([`section`, entry.title])
@@ -121,8 +120,8 @@
     )
   }
   const entry_keys = $derived(keys_of(actions))
-  // An empty section is a heading over nothing, so it is dropped once anything else has
-  // something to show. A menu of nothing but empty sections stays externally controllable.
+  // Empty sections are headings over nothing, dropped once anything else has content; a menu
+  // of only empty sections stays externally controllable.
   const all_empty = $derived(
     actions.every((entry) => is_section(entry) && !entry.actions.length),
   )
@@ -163,8 +162,8 @@
     event.preventDefault() // replace the browser's own menu
     const point = { x: event.clientX, y: event.clientY }
     clearTimeout(context_open_timeout)
-    // Chromium fires contextmenu before pointerup. Opening an auto popover immediately
-    // would let that pointerup light-dismiss the menu from the gesture that opened it.
+    // Chromium fires contextmenu before pointerup, which would light-dismiss an auto popover
+    // opened synchronously from the same gesture.
     context_open_timeout = setTimeout(() => {
       if (!disabled && !all_empty) at = point
     }, 0)
@@ -306,8 +305,8 @@
     z-index: var(--action-menu-z-index, 20);
     margin: 0;
     padding: var(--action-menu-padding, 3pt);
-    /* Rows inherit the page's line-height otherwise, which on a 16px/1.6 body makes every
-       item 33px tall before its own padding. Menu rows want to be tighter than prose. */
+    /* else rows inherit the page line-height: on a 16px/1.6 body each item is 33px tall
+       before its own padding */
     line-height: var(--action-menu-line-height, 1.35);
     list-style: none;
     min-width: var(--action-menu-min-width, 10rem);
@@ -350,9 +349,8 @@
       font-weight: 600;
     }
     kbd {
-      /* A bare `monospace` family makes browsers resolve `em` against their monospace
-         default (13px, not 16px), so a relative size renders a fifth smaller than asked for
-         and symbol keys like ⌘ ⇧ ⌥ shrink past legibility. Inherit the menu's font instead. */
+      /* a bare `monospace` family resolves `em` against the browser's monospace default
+         (13px, not 16px), shrinking symbol keys like ⌘ ⇧ ⌥ past legibility */
       font-family: inherit;
       font-size: 0.9em;
       opacity: 0.85;

--- a/src/lib/ButtonGroup.svelte
+++ b/src/lib/ButtonGroup.svelte
@@ -51,18 +51,16 @@
     // the sort arrow sits outside the radiogroup; style/attrs go here, not on the host
     sort_button_props?: Omit<HTMLButtonAttributes, `aria-label` | `disabled` | `type`>
     option?: Snippet<[{ option: ButtonGroupOption<Value>; selected: boolean }]>
-    // sibling of the button rather than content of it, so an option can carry a
-    // trailing link or badge without nesting interactive content inside a button.
-    // Caveat in single-select mode: the group is a radiogroup, which per ARIA owns only
-    // radios, so anything focusable here is both an extra tab stop between the radios
-    // and an aria-required-children violation. Prefer non-focusable content, or accept
-    // the tradeoff knowingly — the sort arrow sits outside the group for this reason.
+    // Sibling of the button, not content of it, so an option can carry a trailing link or
+    // badge without nesting interactive content in a button. Caveat in single-select mode:
+    // a radiogroup owns only radios per ARIA, so anything focusable here is an extra tab stop
+    // and an aria-required-children violation (hence the sort arrow sitting outside).
     option_suffix?: Snippet<[{ option: ButtonGroupOption<Value>; selected: boolean }]>
-    // Content comes from each option's own `tooltip`; the rest is yours, which is
-    // what lets a consumer opt into allow_html for rich tooltips
+    // Content comes from each option's own `tooltip`; the rest is yours, so a consumer can
+    // opt into allow_html for rich tooltips
     tooltip_options?: Omit<TooltipOptions, `content` | `render`>
-    // a div cannot legally sit inside phrasing content, so a group rendered in a
-    // heading or a paragraph needs to be a span
+    // a div can't sit inside phrasing content, so a group in a heading or paragraph needs
+    // to be a span
     as?: string
   }
   // Literal arms keep on_change narrow; `multiple: boolean` covers `multiple={flag}`
@@ -99,8 +97,7 @@
   const option_list = $derived(
     (Array.isArray(options) ? options : Object.entries(options)).map(to_option<Value>),
   )
-  // buttons the keyboard can reach, in render order: the roving stop below falls back
-  // to the first of them
+  // keyboard-reachable buttons in render order; the roving stop falls back to the first
   const enabled_options = $derived(
     disabled ? [] : option_list.filter((opt) => !opt.disabled),
   )
@@ -108,8 +105,8 @@
     Array.isArray(selected) ? selected : selected == null ? [] : [selected],
   )
 
-  // Roving tabindex: one stop for the whole radio group, on the checked option. A
-  // selection pointing at no rendered option would otherwise leave nothing tabbable.
+  // Roving tabindex: one stop on the checked option. Falls back so a selection pointing at
+  // no rendered option still leaves something tabbable.
   const roving_value = $derived.by(() => {
     if (multiple) return null
     const checked_option = enabled_options.find((opt) => opt.value === selected_values[0])
@@ -123,21 +120,20 @@
         ? selected_values.filter((val) => val !== value)
         : [...selected_values, value]
       : value
-    // The discriminated union is right for consumers, but TS cannot correlate it with
-    // the `multiple` local, so the call is widened back to what this branch just set
+    // TS can't correlate the consumer-facing discriminated union with the `multiple` local,
+    // so widen the call back to what this branch just set
     ;(on_change as ((selected: Value | Value[]) => void) | undefined)?.(selected)
   }
 
   function handle_keydown(event: KeyboardEvent) {
     if (!(event.currentTarget instanceof HTMLElement)) return
-    // `[data-value]` excludes anything an option_suffix renders: a bare `button` query
-    // also collects those, which desyncs focus from the option it is meant to select
+    // `[data-value]` excludes option_suffix buttons, which would desync focus from the
+    // option it is meant to select
     const selector = `button[data-value]:not(:disabled)`
     const buttons = [...event.currentTarget.querySelectorAll<HTMLButtonElement>(selector)]
     const next_value = step_focus(event, buttons, { horizontal: true })?.dataset.value
-    // A radio group carries its selection with focus; independent toggles do not. Read
-    // the value off the button rather than indexing a parallel array, so DOM order and
-    // the option list cannot drift apart again.
+    // A radio group carries its selection with focus; independent toggles don't. Value is
+    // read off the button so DOM order and the option list can't drift apart.
     if (!multiple && next_value !== undefined) select(next_value as Value)
   }
 </script>
@@ -227,9 +223,9 @@
       justify-content: var(--btn-group-justify-content, flex-start);
       gap: inherit;
     }
-    /* the pill: the `option_suffix` wrapper where there is one, the button itself
-       everywhere else. Box and state colors live here so slotted content renders inside
-       the pill, while padding stays on the button so its edges still toggle. */
+    /* the pill: the `option_suffix` wrapper if present, else the button. Box and state colors
+       live here so slotted content sits inside the pill; padding stays on the button so its
+       edges still toggle. */
     .option,
     button:not(.option > button) {
       display: inline-flex;
@@ -240,9 +236,8 @@
       border-radius: var(--btn-group-btn-radius, 3pt);
       /* `all 0s` is the browser default, so the knob is inert until a consumer sets it */
       transition: var(--btn-group-btn-transition, all 0s);
-      /* checked is excluded here rather than relying on source order: :hover plus this
-         :not() outweighs the checked selector below, so hovering a selected option would
-         otherwise replace its darker shading with the lighter hover one */
+      /* checked excluded here, not by source order: :hover plus this :not() outranks the
+         checked rule below, so hovering a selected option would lighten it */
       &:hover:not(
           :disabled,
           [aria-checked='true'],
@@ -273,18 +268,16 @@
       align-items: center;
       gap: var(--btn-group-btn-gap, 0.4em);
       padding: var(--btn-group-btn-padding, 2pt 6pt);
-      /* longhands rather than the `font` shorthand, which would also set weight and
-         style: this selector outranks a consumer's own `button {}` rule, so the
-         shorthand silently overrode their global button typography */
+      /* longhands, not the `font` shorthand: this selector outranks a consumer's own
+         `button {}` rule, so the shorthand silently reset their weight and style */
       font-family: var(--btn-group-btn-font-family, inherit);
       font-size: var(--btn-group-btn-font-size, inherit);
       cursor: var(--btn-group-btn-cursor, pointer);
     }
-    /* after `button`'s padding shorthand so padding-right is not reset; inside a pill
-       the button drops its own box rather than nesting a second one in it. Dropping the
-       border rather than making it transparent keeps the pill the size of an unwrapped
-       one and lets the button fill it, so clicks on its edges still toggle. Right padding
-       shrinks by default so a trailing suffix (link, badge) sits in that former gap. */
+    /* after `button`'s padding shorthand so padding-right survives. Inside a pill the button
+       drops its box; dropping the border (rather than making it transparent) keeps the pill
+       the size of an unwrapped one and lets the button fill it, so edge clicks still toggle.
+       Right padding shrinks so a trailing suffix sits in that former gap. */
     .option > button {
       background: none;
       color: inherit;

--- a/src/lib/CodeExample.svelte
+++ b/src/lib/CodeExample.svelte
@@ -126,6 +126,10 @@
     flex-direction: column;
     margin: var(--code-example-margin, 1em auto);
     position: relative;
+    /* Deliberately not `contain: layout`, tempting though it is for examples that render
+       viewport-fixed chrome: it also makes this a stacking context, which traps a
+       portalled/absolute dropdown inside the example box. Such demos pass breakpoint={0}
+       (or position: static) instead so they never render fixed chrome in the first place. */
     /* a wide example scrolls inside its own pre/preview instead of widening the page */
     min-width: 0;
   }

--- a/src/lib/CodeExample.svelte
+++ b/src/lib/CodeExample.svelte
@@ -29,11 +29,11 @@
     src?: string // code fence content, dedented by the remark plugin
     meta?: {
       // code fence metadata
-      collapsible?: boolean // whether to show a button to expand/collapse the code
-      code_above?: boolean // whether to show the code above the example (default: true when collapsible, false otherwise)
-      id?: string // id of the <div> wrapping the code and example (e.g. to write very specific testing selectors)
+      collapsible?: boolean // show an expand/collapse button
+      code_above?: boolean // code above the example (default: `collapsible`)
+      id?: string // id of the wrapping <div>, e.g. for precise test selectors
       repl?: string // Svelte REPL URL
-      github?: string | boolean // GitHub URL or true to link to the file serving the current page
+      github?: string | boolean // GitHub URL, or true to link the current page's file
       repo?: string // GitHub repo URL
       Wrapper?: string // Svelte component to wrap the example
       example?: boolean
@@ -45,8 +45,8 @@
     title?: Snippet<[]>
     example?: Snippet<[]>
     code?: Snippet<[]>
-    // one bag is shared by every external link, so an `href` on it could only ever
-    // point the repl, github and repo icons at the same URL
+    // one bag shared by every external link, so an `href` here would point all three icons
+    // at the same URL
     link_props?: Omit<HTMLAnchorAttributes, `href`>
     button_props?: Omit<HTMLButtonAttributes, `type`>
     labels?: Partial<CodeExampleLabels>
@@ -126,10 +126,9 @@
     flex-direction: column;
     margin: var(--code-example-margin, 1em auto);
     position: relative;
-    /* Deliberately not `contain: layout`, tempting though it is for examples that render
-       viewport-fixed chrome: it also makes this a stacking context, which traps a
-       portalled/absolute dropdown inside the example box. Such demos pass breakpoint={0}
-       (or position: static) instead so they never render fixed chrome in the first place. */
+    /* Deliberately not `contain: layout`: it makes this a stacking context, trapping
+       portalled/absolute dropdowns in the example box. Demos with viewport-fixed chrome
+       pass breakpoint={0} (or position: static) instead. */
     /* a wide example scrolls inside its own pre/preview instead of widening the page */
     min-width: 0;
   }

--- a/src/lib/CommandMenu.svelte
+++ b/src/lib/CommandMenu.svelte
@@ -74,8 +74,8 @@
     dialog_props?: HTMLAttributes<HTMLDialogElement>
     // run action.shortcut hotkeys globally while the menu is closed (default: true)
     global_shortcuts?: boolean
-    // localStorage key to persist recently triggered actions. When set, recent
-    // actions rank first in the dropdown (most recent on top). null = disabled
+    // localStorage key persisting recently triggered actions, which then rank first
+    // (most recent on top); null disables
     recent_actions_key?: string | null
     max_recent?: number // cap on persisted recent actions (default: 20)
   } = $props()
@@ -138,8 +138,7 @@
   const sorted_actions = $derived.by(() => {
     if (!recent_actions || !action_ids_are_unique || recent_action_ids.length === 0)
       return actions
-    // drop stale persisted ids (actions removed/renamed since) so they don't
-    // occupy low ranks and push real recents below non-recent actions
+    // drop stale persisted ids, which would occupy low ranks and push real recents down
     const rank = new SvelteMap<string, number>()
     for (const action_id of recent_action_ids) {
       if (action_id_counts.has(action_id)) rank.set(action_id, rank.size)
@@ -202,8 +201,8 @@
   const custom_backdrop_dismiss = $derived(
     !escape_closes && dialog_props?.closedby === undefined,
   )
-  // Bare action shortcuts stay inert while the menu is up: there the keyboard
-  // belongs to the search input. An action without a shortcut has no keys to match.
+  // Bare action shortcuts stay inert while the menu is up: the keyboard belongs to the
+  // search input then.
   const key_bindings = $derived<Hotkey[]>([
     ...toggle_bindings,
     ...actions.map((action) => ({

--- a/src/lib/ConfirmDialog.svelte
+++ b/src/lib/ConfirmDialog.svelte
@@ -112,9 +112,8 @@
     {:else}
       {@render request.body.snippet()}
     {/if}
-    <!-- Rebuilds the controls between questions. Keyed on choice id alone, Svelte reused
-    the same DOM nodes when consecutive requests offer the same ids, so the second half
-    of a double-click landed on the button that now answers the NEXT question. -->
+    <!-- Rebuilds the controls between questions: keyed on choice id alone, Svelte reused the
+    nodes, so a double-click's second half answered the NEXT question -->
     {#key request}
       {#if request.kind === `choice`}
         <div class="actions">

--- a/src/lib/CopyButton.svelte
+++ b/src/lib/CopyButton.svelte
@@ -100,9 +100,8 @@
     }
 
     apply_copy_buttons()
-    // Coalesce to one scan per frame: this walks every code block in the document and
-    // re-reads its `textContent`, while the observer fires on every render flush anywhere
-    // in the app, so an animating demo would otherwise rescan the document per flush.
+    // One scan per frame: this re-reads every code block's `textContent`, while the observer
+    // fires on every render flush, so an animating demo would rescan the document per flush.
     let frame = 0
     const observer = new MutationObserver(() => {
       cancelAnimationFrame(frame)

--- a/src/lib/DraggablePane.svelte
+++ b/src/lib/DraggablePane.svelte
@@ -13,8 +13,8 @@
   import { chain_handlers } from './utils'
 
   type CloseVia = `toggle` | `button` | `pointer` | `escape`
-  // Handed to both snippets so they can react to the pane's own chrome — a plot pausing
-  // its animation while the pane is being dragged over it, say.
+  // Handed to both snippets so they can react to pane chrome, e.g. a plot pausing its
+  // animation while the pane is dragged over it.
   type PaneState = {
     open: boolean
     show_controls: boolean
@@ -59,14 +59,13 @@
     // Gap between the toggle button's bottom-right corner and the pane's
     offset?: { x?: number; y?: number }
     max_width?: string
-    // `aria-label` is deliberately absent from the Omit: several panes on a page need
-    // distinct names. The rest describe the dialog itself and stay component-owned.
+    // `aria-label` deliberately not omitted: several panes on a page need distinct names
     pane_props?: Omit<HTMLAttributes<HTMLDivElement>, `aria-modal` | `role`>
     // Only Escape and the close button dismiss — ignore outside presses
     persistent?: boolean
     dismiss_on?: `press` | `release`
     // Outside controls that drive `open`; the pane's own toggle is always included. Elements
-    // only — click_outside's selector form needs its `scope` guard, which this does not expose
+    // only — click_outside's selector form needs a `scope` guard this doesn't expose
     inside?: (Element | null | undefined)[]
     resize?: `both` | `width` | `height` | `none`
     // `fixed` escapes overflow-clipping ancestors; height capped to space below top edge
@@ -82,18 +81,17 @@
 
   const msg = $derived(merge_defaults(DRAGGABLE_PANE_LABELS, labels))
   const viewport_margin_px = 8
-  // How much of the pane stays on screen when the toggle sits near the bottom edge.
-  // Without it a low toggle parks the pane in the last few pixels of the viewport.
+  // without it, a toggle near the bottom parks the pane in the last few px of the viewport
   const min_reachable_height_px = 180
-  // Doubles as `resizable`'s handle_size and as the padding reserved for it, so the
-  // grab zone never overlaps content or the content area's own scrollbar
+  // doubles as `resizable`'s handle_size and the padding reserving it, so the grab zone
+  // never overlaps content or its scrollbar
   const resize_gutter_px = 8
   const default_pane_width_px = 450
   const fallback_position = { left: 50, top: 50 }
   let resized_max_width = $state<string | null>(null)
   let resize_start_width = 0
-  // An explicit consumer cap stays authoritative. The bundled default cap only shapes the
-  // natural width; after a manual resize, the attachment's viewport bound takes over.
+  // An explicit consumer cap stays authoritative; the default only shapes the natural width,
+  // and after a manual resize the attachment's viewport bound takes over.
   const viewport_max_width = `calc(100vw - ${2 * viewport_margin_px}px)`
   const pane_max_width = $derived(
     max_width ?? resized_max_width ?? `${default_pane_width_px}px`,
@@ -128,15 +126,13 @@
   const clamp_to_viewport = (value: number, upper: number) =>
     Math.max(viewport_margin_px, Math.min(value, upper))
 
-  // Where the pane sits when it has not been dragged: under the toggle, right edges
-  // aligned. Fixed panes additionally stay inside the viewport.
+  // Undragged: under the toggle, right edges aligned; fixed panes also stay in the viewport
   const anchor_position = (): { left: number; top: number } => {
     if (!toggle_btn) return fallback_position
     const toggle_rect = toggle_btn.getBoundingClientRect()
     const pane_width = pane?.getBoundingClientRect().width || default_pane_width_px
     const [offset_x, offset_y] = [offset.x ?? 5, offset.y ?? 5]
-    // The anchor in viewport coordinates; each strategy below only restates it in the
-    // space its own left/top are read in.
+    // the anchor in viewport coordinates; each strategy below restates it in its own space
     const left = toggle_rect.right - pane_width + offset_x
     const top = toggle_rect.bottom + offset_y
 
@@ -153,18 +149,15 @@
       }
     }
 
-    // The pane's containing block, not the toggle's: they are siblings and normally share
-    // one, but toggle_props can position the toggle independently, and it is the pane's
-    // own left/top being computed here. Always laid out at this point — every caller
-    // either holds an open pane or is a control inside it.
+    // The pane's containing block, not the toggle's: the siblings usually share one, but
+    // toggle_props can position the toggle independently.
     const ancestor = pane?.offsetParent
     // No positioned ancestor means the pane is placed against the document
     if (!ancestor) {
       return { left: left + globalThis.scrollX, top: top + globalThis.scrollY }
     }
-    // An absolute child's insets resolve against the ancestor's padding box, whereas its
-    // rect is the border box, so the border comes off too. clientLeft/clientTop are that
-    // border, already in used-value terms.
+    // An absolute child's insets resolve against the ancestor's padding box while its rect is
+    // the border box, so subtract that border (clientLeft/clientTop).
     const ancestor_rect = ancestor.getBoundingClientRect()
     return {
       left: left - ancestor_rect.left - ancestor.clientLeft,
@@ -172,14 +165,12 @@
     }
   }
 
-  // Move the pane back under the toggle and drop manual size overrides. A fixed pane
-  // must not extend past the bottom viewport edge, so --pane-viewport-clamp (min()'d
-  // with --pane-max-height in CSS) is rewritten on every move, or a reset after a drag
-  // plus a window resize would keep a stale cap. No minimum needed: anchor_position
-  // already clamps the top so min_reachable_height_px of space remains below it.
+  // Move the pane back under the toggle and drop manual size overrides. --pane-viewport-clamp
+  // (min()'d with --pane-max-height in CSS) keeps a fixed pane above the bottom edge and is
+  // rewritten on every move, else a reset after a drag plus window resize keeps a stale cap.
   const position_pane = () => {
     if (!pane) return
-    // Clear the manual size first so anchor_position() measures the natural width
+    // clear the manual size first so anchor_position() measures the natural width
     pane.style.width = ``
     pane.style.height = ``
     const { left, top } = anchor_position()
@@ -207,22 +198,21 @@
 
   let resize_timeout: ReturnType<typeof setTimeout> | undefined
   onDestroy(() => clearTimeout(resize_timeout))
-  // Debounced, and reanchor re-checks on the trailing edge: the pane may have been
-  // dragged or closed during the wait, either of which cancels the reposition
+  // debounced; reanchor re-checks because the pane may be dragged or closed during the wait
   const handle_viewport_resize = () => {
     clearTimeout(resize_timeout)
     resize_timeout = setTimeout(reanchor, 50)
   }
 
-  // Resolve at gesture time: the pane may have been dragged or reanchored since attach.
-  // Bounding-client coordinates make the same calculation work for fixed and absolute panes.
+  // Resolved at gesture time: the pane may have moved since attach. Bounding-client
+  // coordinates work for both fixed and absolute panes.
   const resize_width_limit = (pane_node: HTMLElement) => {
     const { left, width } = pane_node.getBoundingClientRect()
     const room =
       globalThis.innerWidth - Math.max(viewport_margin_px, left) - viewport_margin_px
     const explicit_limit = Number(max_width?.trim().match(/^.*(?=px$)/u)?.[0])
-    // Keep the viewport cap at least as wide as the pane so starting a resize does not yank
-    // an overflowing pane narrower; an explicit pixel cap remains authoritative.
+    // cap at least the pane's width so starting a resize doesn't yank an overflowing pane
+    // narrower; an explicit pixel cap stays authoritative
     return Math.min(
       Math.max(room, width),
       explicit_limit >= 0 ? explicit_limit : Infinity,
@@ -250,8 +240,8 @@
   {/if}
 </button>
 
-<!-- toc-exclude keeps pane headings out of a page's Toc: this is floating chrome. The
-aria-label sits before the spread, so a page with several panes renames them via pane_props -->
+<!-- toc-exclude keeps pane headings out of a page's Toc. aria-label sits before the spread so
+several panes can be renamed via pane_props -->
 <div
   bind:this={pane}
   aria-label="Draggable pane"
@@ -282,9 +272,8 @@ aria-label sits before the spread, so a page with several panes renames them via
     edges: resize_edges,
     min_width: 200,
     min_height: 100,
-    // Width only. Height is already bounded by the CSS `max-height` (--pane-max-height
-    // min'd with --pane-viewport-clamp); adding a second JS cap on top of it only fought
-    // the user's drag.
+    // Width only: height is already bounded by CSS max-height (--pane-max-height min'd with
+    // --pane-viewport-clamp), and a second JS cap only fought the user's drag.
     max_width: resize_width_limit,
     handle_size: resize_gutter_px,
     labels: { handle: msg.resize_handle },
@@ -367,14 +356,12 @@ aria-label sits before the spread, so a page with several panes renames them via
   div.draggable-pane {
     /* position comes from style:position, default absolute so it scrolls with the page */
     box-sizing: border-box;
-    /* one in-flow child; minmax(0, 1fr) lets it scroll instead of overflowing once
-       the pane has a definite height from a resize or the viewport clamp */
+    /* one in-flow child; minmax(0, 1fr) lets it scroll once the pane has a definite height */
     grid-template-rows: minmax(0, 1fr);
     text-align: left;
     width: var(--pane-width, 28em);
     min-height: var(--pane-min-height, auto);
-    /* --pane-viewport-clamp (set for position="fixed") keeps a pane whose toggle sits
-       low on screen above the bottom viewport edge */
+    /* --pane-viewport-clamp (position="fixed") keeps a low pane above the bottom edge */
     max-height: min(var(--pane-max-height, 80vh), var(--pane-viewport-clamp, 200vh));
     overflow: visible; /* the control tab protrudes past the pane's right border */
     background: var(--pane-bg, var(--page-bg, light-dark(white, black)));
@@ -398,10 +385,8 @@ aria-label sits before the spread, so a page with several panes renames them via
       padding: var(--pane-padding, 1ex);
       display: grid;
       gap: var(--pane-gap, 4pt);
-      /* Rows size to their content and sit at the top. Without this, `normal` stretches the
-         auto rows to fill a pane taller than its content — which only shows up once content
-         gets short, e.g. a settings pane filtered down to one row, where it inflates that
-         row (and any input in it) to hundreds of pixels. */
+      /* rows size to content and sit at the top; `normal` stretches auto rows to fill a pane
+         taller than its content, inflating e.g. a lone filtered row to hundreds of pixels */
       align-content: var(--pane-align-content, start);
       box-sizing: border-box;
       min-height: 0; /* or the row refuses to shrink below its content */

--- a/src/lib/FileDetails.svelte
+++ b/src/lib/FileDetails.svelte
@@ -43,14 +43,14 @@
   // Use reactive state for node refs to avoid binding_property_non_reactive warning
   let detail_elements = $state<(HTMLDetailsElement | null)[]>([])
 
-  // DOM `open` isn't reactive, so track it in $state synced from the toggle event
-  // and toggle_all, plus the $effect below (toggle doesn't fire for pre-opened details)
+  // DOM `open` isn't reactive, so mirror it in $state from toggle events, toggle_all and the
+  // $effect below (toggle doesn't fire for pre-opened details)
   let has_open_details = $state(false)
   const sync_has_open_details = () => {
     has_open_details = detail_elements.some((node) => node?.open)
   }
 
-  // Trim stale refs when files shrink and sync detail_elements back to files.node for external access
+  // trim stale refs when files shrink, and sync detail_elements back to files.node
   $effect(() => {
     if (detail_elements.length > files.length) {
       detail_elements.splice(files.length)

--- a/src/lib/FindBar.svelte
+++ b/src/lib/FindBar.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { Search } from './icons'
-  // Find-in-page bar over root: Enter/Shift+Enter step; Escape closes. Style matches
-  // with ::highlight(find-match), which cannot be component-scoped. For custom chrome,
-  // use create_find_state.
+  // Find-in-page bar over root: Enter/Shift+Enter step, Escape closes. Matches use
+  // ::highlight(find-match), which can't be scoped; for custom chrome use create_find_state.
   import { tick } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { tooltip } from './attachments/index'

--- a/src/lib/Icon.svelte
+++ b/src/lib/Icon.svelte
@@ -3,9 +3,8 @@
   import type { IconData } from './icons/types'
 
   // SVGAttributes, not HTMLAttributes, which rejects the `width`/`height` an <svg> takes.
-  // Either a glyph (`<Icon icon={Info} />`) or an ad-hoc `path`, never both and never
-  // neither — a bare <Icon /> is a type error. Pass the glyph value, not a name, so the
-  // bundler keeps only the icons this call site reaches.
+  // Exactly one of a glyph or an ad-hoc `path` — a bare <Icon /> is a type error. Pass the
+  // glyph value, not a name, so the bundler keeps only the icons this call site reaches.
   let {
     icon,
     path,

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -8,7 +8,8 @@
   type ItemId = string | number
   type ItemRecord = { id: ItemId; idx: number; item: Item }
 
-  // Non-primitive items need an id property (name it via idKey) to key the each block.
+  // With the default getId, non-primitive items need an id property (name it via idKey) to
+  // key the each block; a custom getId can derive the key from anything.
   // See https://svelte.dev/docs/svelte/each#Keyed-each-blocks.
   let {
     animate = true,
@@ -173,8 +174,10 @@
   const shortest_col = (heights: number[]): number =>
     heights.indexOf(Math.min(...heights))
 
-  // New items go to the shortest column, existing ones keep theirs. Mutating
-  // stable_assignments inside a $derived is safe: it's a non-reactive cache, not a dependency.
+  // At a steady column count new items go to the shortest column and existing ones keep
+  // theirs; a change drops every assignment (more columns) or reseats the ones now out of
+  // range (fewer). Mutating stable_assignments inside a $derived is safe: it's a
+  // non-reactive cache, not a dependency.
   function balanced_stable_to_cols(num_cols: number): ItemRecord[][] {
     if (num_cols > prev_stable_num_cols) stable_assignments.clear()
     prev_stable_num_cols = num_cols
@@ -253,7 +256,7 @@
 
   let items_to_cols = $derived.by(() => {
     // balanced-stable never falls back: stable assignments + estimates for new items keep
-    // existing items from jumping columns
+    // existing items from jumping columns as long as the column count holds
     if (effective_order === `balanced-stable`) return balanced_stable_to_cols(n_cols)
 
     // Other height-aware modes need every item measured; check the mode first so only they

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -8,7 +8,8 @@
   type ItemId = string | number
   type ItemRecord = { id: ItemId; idx: number; item: Item }
 
-  // On non-primitive types, we need a property to tell masonry items apart. The name of this attribute can be customized with idKey which defaults to 'id'. See https://svelte.dev/docs/svelte/each#Keyed-each-blocks.
+  // Non-primitive items need an id property (name it via idKey) to key the each block.
+  // See https://svelte.dev/docs/svelte/each#Keyed-each-blocks.
   let {
     animate = true,
     order = `balanced-stable`,
@@ -68,12 +69,11 @@
   // Needed over a random uuid so the id survives hydration.
   const unique_id = $props.id()
 
-  // Height tracking for column balancing and virtualization
-  // Use plain Map (not reactive) to avoid triggering re-renders on every measurement
-  // Only measured_count is reactive to trigger column balancing when needed
+  // Plain (non-reactive) Map so measurements don't re-render; only the two counters below
+  // are reactive, to drive column balancing
   const item_heights_cache = new Map<ItemId, number>()
-  let measured_count = $state(0) // trigger reactivity for column balancing
-  let measured_sum = $state(0) // running sum for average calculation
+  let measured_count = $state(0)
+  let measured_sum = $state(0)
   let avg_measured_height = $derived(
     measured_count > 0 ? measured_sum / measured_count : null,
   )
@@ -83,7 +83,7 @@
   let prev_stable_num_cols = 0
   const item_records = new Map<ItemId, ItemRecord>()
 
-  // Clean up stale heights and stable assignments when items change (prevents memory leak)
+  // Drop heights/assignments of removed items (prevents memory leak)
   $effect(() => {
     const current_ids = new Set(items.map(getId))
     let removed_sum = 0
@@ -116,16 +116,13 @@
 
   // Reads from non-reactive cache, so won't trigger re-renders
   const get_height = (item: Item): number => {
-    // `||` (not `??`) is intentional: a 0 height is meaningless for balancing,
-    // so it falls through to the estimate/average/default chain.
+    // `||` not `??`: a 0 height is meaningless, so fall through to the estimate chain
     const cached = item_heights_cache.get(getId(item))
     return cached || getEstimatedHeight?.(item) || avg_measured_height || 150
   }
 
-  // Measure item heights via ResizeObserver.
-  // Always attach observers for non-virtualizing cases, even for modes that don't
-  // need measurement initially, because the user may switch modes at runtime.
-  // Skip entirely during virtualization - only estimated heights are used there.
+  // Attached even for modes that don't need measurement, since order can change at runtime.
+  // Skipped while virtualizing, which uses estimates only.
   const measure_height = (item_id: ItemId) => (node: HTMLElement) => {
     if (virtualize) return
     const observer = new ResizeObserver(() => {
@@ -134,7 +131,7 @@
       if (new_height > 0 && old_height !== new_height) {
         measured_sum += new_height - old_height
         item_heights_cache.set(item_id, new_height)
-        // Keep measured_count in sync with cache so measurement checks stay accurate
+        // in sync with the cache so `measured_count >= items.length` checks stay accurate
         measured_count = item_heights_cache.size
       }
     })
@@ -142,11 +139,10 @@
     return () => observer.disconnect()
   }
 
-  // Effective order: virtualization forces row-first
   let effective_order = $derived(virtualize ? `row-first` : order)
 
-  // Place each item in the column given by its index alone. Deliberately never calls
-  // get_height, so index-based modes take no dependency on height state.
+  // Index-only placement. Deliberately never calls get_height, so these modes take no
+  // dependency on height state.
   function distribute_by_idx(
     num_cols: number,
     pick_col: (idx: number) => number,
@@ -158,8 +154,7 @@
     return cols
   }
 
-  // Place every item into a column chosen by pick_col, which receives the running
-  // per-column heights (item height + gap) accumulated so far.
+  // pick_col receives the per-column heights (item height + gap) accumulated so far
   function distribute(
     num_cols: number,
     pick_col: (heights: number[], item: Item) => number,
@@ -178,10 +173,8 @@
   const shortest_col = (heights: number[]): number =>
     heights.indexOf(Math.min(...heights))
 
-  // Stable balancing: new items go to shortest column, existing items keep their column
-  // NOTE: This function intentionally mutates stable_assignments during $derived computation.
-  // This is safe because the Map is a non-reactive cache for persistence across renders,
-  // not a reactive dependency. The derived recomputes based on items/nCols/order changes.
+  // New items go to the shortest column, existing ones keep theirs. Mutating
+  // stable_assignments inside a $derived is safe: it's a non-reactive cache, not a dependency.
   function balanced_stable_to_cols(num_cols: number): ItemRecord[][] {
     if (num_cols > prev_stable_num_cols) stable_assignments.clear()
     prev_stable_num_cols = num_cols
@@ -190,7 +183,6 @@
       const id = getId(item)
       const col_idx = stable_assignments.get(id)
       if (col_idx !== undefined && col_idx < num_cols) return col_idx
-      // New or out-of-range item - assign to shortest
       const new_col = shortest_col(heights)
       stable_assignments.set(id, new_col)
       return new_col
@@ -204,7 +196,6 @@
     let col_idx = 0
 
     return distribute(num_cols, (heights) => {
-      // Move to next column once the current one exceeded its target height
       if (heights[col_idx] >= target_per_col && col_idx < num_cols - 1) col_idx++
       return col_idx
     })
@@ -217,9 +208,8 @@
       )
     }
   })
-  // CSS container queries hide excess SSR columns before hydration
-  // When masonryWidth is 0 (SSR), prefer explicit initialCols before using the
-  // historical 1920px viewport fallback.
+  // masonryWidth is 0 during SSR: prefer initialCols over the historical 1920px fallback.
+  // CSS container queries hide the excess SSR columns before hydration.
   let n_cols = $derived.by(() => {
     if (
       initialCols !== undefined &&
@@ -229,11 +219,11 @@
         `Masonry: initialCols must be a positive integer when provided, received ${initialCols}.`,
       )
     }
-    // distribute() builds one array per column, so fewer than one leaves nowhere to put
-    // an item. Zero is fine with no items, which is what the default calcCols returns.
+    // distribute() builds one array per column, so <1 leaves nowhere to put an item (0 is
+    // fine when empty, which is what the default calcCols returns).
     const checked = (cols: number) => {
-      // a fractional count is just as broken: Array.from truncates the column array while
-      // `idx % n_cols` in row-first keeps producing the untruncated index
+      // fractional is equally broken: Array.from truncates the column array while row-first's
+      // `idx % n_cols` keeps producing the untruncated index
       if (items.length > 0 && (!Number.isInteger(cols) || cols < 1)) {
         throw new Error(
           `Masonry: calcCols must return a positive integer, received ${cols}.`,
@@ -261,14 +251,13 @@
     }).join(`\n`),
   )
 
-  // Distribute items based on order mode
   let items_to_cols = $derived.by(() => {
-    // balanced-stable should NEVER fall back - it uses stable assignments + estimates for new items
-    // This prevents existing items from jumping columns when new items are added
+    // balanced-stable never falls back: stable assignments + estimates for new items keep
+    // existing items from jumping columns
     if (effective_order === `balanced-stable`) return balanced_stable_to_cols(n_cols)
 
-    // The other height-aware modes need every item measured before they can balance.
-    // Check the mode first so only those modes take a dependency on measured_count.
+    // Other height-aware modes need every item measured; check the mode first so only they
+    // depend on measured_count.
     if (effective_order === `balanced` && measured_count >= items.length) {
       return distribute(n_cols, shortest_col)
     }
@@ -276,7 +265,7 @@
       return column_balanced_to_cols(n_cols)
     }
     if (effective_order === `column-sequential`) {
-      // Purely sequential column-first: first N items in col 1, next N in col 2, etc.
+      // sequential column-first: first N items in col 1, next N in col 2, etc.
       const items_per_col = Math.ceil(items.length / n_cols)
       return distribute_by_idx(n_cols, (idx) =>
         Math.min(Math.floor(idx / items_per_col), n_cols - 1),
@@ -286,8 +275,6 @@
     return distribute_by_idx(n_cols, (idx) => idx % n_cols)
   })
 
-  // Virtualization logic
-  // Warn if virtualize=true but no height provided (only once)
   let warned_missing_height = false
   $effect.pre(() => {
     if (virtualize && height === undefined && !warned_missing_height) {
@@ -309,8 +296,7 @@
     return low_idx
   }
 
-  // Scroll state with requestAnimationFrame throttling
-  // Declared early because prefix_heights depends on it for virtualization
+  // declared before prefix_heights, which depends on it
   let scroll_top = $state(0)
   let ticking = false
 
@@ -323,28 +309,25 @@
     })
   }
 
-  // Prefix height arrays per column: prefix_heights[col][i] = cumulative height of items 0..i
-  // When virtualizing: use ONLY estimates, never measured heights, so they can't drift
-  // When not virtualizing: use measured heights (accurate balancing)
+  // prefix_heights[col][idx] = cumulative height of items 0..idx. Virtualizing uses ONLY
+  // estimates, never measured heights, so the scroll window can't drift.
   let prefix_heights = $derived(
     items_to_cols.map((column_items) => {
       let sum = 0
       return column_items.map(({ item }) => {
-        // `||` for the same reason as get_height: a 0 estimate is meaningless, and `??`
-        // here would collapse the scroll window to gaps alone
+        // `||` as in get_height: `??` would collapse the scroll window to gaps alone
         sum += (virtualize ? getEstimatedHeight?.(item) || 150 : get_height(item)) + gap
         return sum
       })
     }),
   )
 
-  // Container height for virtualization viewport
-  // For numeric height, use directly; for string (CSS units like "80vh"), use measured clientHeight
+  // viewport height: numbers used directly, CSS strings like `80vh` need the measured value
   let container_height = $derived(
     typeof height === `number` ? height : masonryHeight || 400,
   )
 
-  // Same height as a CSS value for the scroll container; strings like `80vh` pass through
+  // same height as a CSS value; strings like `80vh` pass through
   let css_height = $derived(
     typeof height === `number` ? `${height}px` : (height ?? `400px`),
   )
@@ -353,21 +336,19 @@
     virtualize ? `overflow-y: auto; height: ${css_height};` : ``,
   )
 
-  // Only enable virtualization once we have a valid container height measurement
-  // This prevents flicker when using CSS units like "80vh" that need DOM measurement
+  // wait for a real container height, else CSS units like `80vh` flicker
   let can_virtualize = $derived(
     virtualize && (typeof height === `number` || masonryHeight > 0),
   )
 
-  // Per-column render window: the on-screen slice plus the padding standing in for the
-  // items culled above and below it. Recomputes on scroll, so it deliberately reads
-  // prefix_heights rather than recomputing those O(n) prefix sums.
+  // Per-column render window: on-screen slice plus padding for the culled items. Recomputes
+  // on scroll, so it reads prefix_heights rather than redoing those O(n) prefix sums.
   let col_windows = $derived(
     prefix_heights.map((ph) => {
       if (!can_virtualize) return { start: 0, end: ph.length, pad_top: 0, pad_bottom: 0 }
       const start = Math.max(0, binary_search_ge(ph, scroll_top) - 1 - overscan)
-      // The item found at the viewport's bottom edge straddles it, so it is on screen and
-      // the exclusive end has to clear it — mirroring the row of margin `start` takes.
+      // the item straddling the bottom edge is on screen, so the exclusive end must clear it
+      // (mirrors the row of margin `start` takes)
       const end = Math.min(
         ph.length,
         binary_search_ge(ph, scroll_top + container_height) + 1 + overscan,
@@ -381,11 +362,11 @@
     }),
   )
 
-  // Auto-disable animations when actively virtualizing (FLIP doesn't work well)
+  // FLIP animations don't work well with virtualization
   let effective_animate = $derived(animate && !can_virtualize)
 </script>
 
-<!-- Dynamic container query styles in <head> hide excess SSR columns -->
+<!-- container queries in <head> hide excess SSR columns -->
 <svelte:head>
   <svelte:element this={`style`}>{container_query_css}</svelte:element>
 </svelte:head>
@@ -444,8 +425,7 @@
 </div>
 
 <style>
-  /* layout properties live inline (see issue #48) so CSS resets can't override them.
-  Only what can't be expressed inline belongs here. */
+  /* layout properties live inline (see issue #48) so CSS resets can't override them */
   div.masonry {
     container-type: inline-size;
     container-name: masonry;

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -171,7 +171,7 @@
     collapseAllGroups = $bindable(),
     expandAllGroups = $bindable(),
     shortcuts = {},
-    // Selection history for undo/redo (enabled by default, set to false or 0 to disable)
+    // undo/redo history; false or 0 disables it
     history = true,
     undo = $bindable(),
     redo = $bindable(),
@@ -185,8 +185,7 @@
 
   // every string this component renders on its own, overridable key by key for i18n
   const msg = $derived(merge_defaults(MULTI_SELECT_LABELS, labels))
-  // `get_label` returns string | number; everything that compares, announces or renders a
-  // label as text wants the string form, so coerce once here rather than at each call site
+  // `get_label` returns string | number; coerce once here rather than at each call site
   const label_of = (option_item: Option): string => `${utils.get_label(option_item)}`
 
   const invalid_config = (message: string): never => {
@@ -274,20 +273,19 @@
   const base_id = $derived(id ?? `sms-${unique_id}`)
   const listbox_id = $derived(`${base_id}-listbox`)
   const input_display = $derived(selected_display === `input`)
-  const multi_select = $derived(maxSelect === null || maxSelect > 1) // can hold 2+ selections
+  const multi_select = $derived(maxSelect === null || maxSelect > 1)
 
-  // Shared fuzzy/substring text matching (used by the default filterFunc and group-name matching)
+  // used by the default filterFunc and by group-name matching
   const text_matches = (search: string, target: string): boolean =>
     fuzzy
       ? utils.fuzzy_match(search, target)
       : target.toLowerCase().includes(search.toLowerCase())
 
-  // Platform detection for keyboard shortcuts (Mac uses Cmd, others use Ctrl)
+  // Mac uses Cmd for shortcuts, everything else Ctrl
   const is_mac =
     typeof navigator !== `undefined` && /Mac|iPhone|iPad|iPod/u.test(navigator.userAgent)
   const mod_key = is_mac ? `meta` : `ctrl`
 
-  // Default shortcuts
   const default_shortcuts: KeyboardShortcuts = {
     select_all: null,
     clear_all: `${mod_key}+backspace`,
@@ -298,7 +296,7 @@
   }
   const effective_shortcuts = $derived({ ...default_shortcuts, ...shortcuts })
 
-  // Extract loadOptions config into single derived object (supports both simple function and config object)
+  // normalizes the function-or-config-object prop into one shape
   const load_options_config = $derived.by(() => {
     if (!loadOptions) return null
     const load_config: LoadOptionsConfig<Option> =
@@ -312,9 +310,8 @@
   })
 
   // === Selection and value sync ===
-  // Sync selected ↔ value bidirectionally. Use untrack to prevent each effect from
-  // reacting to changes in the "destination" value, and utils.values_equal to prevent
-  // infinite loops with reactive wrappers that clone arrays. See issue #309.
+  // sync selected ↔ value. untrack keeps each effect off its own destination; values_equal
+  // avoids infinite loops with reactive wrappers that clone arrays. See issue #309.
   $effect.pre(() => {
     const new_value = maxSelect === 1 ? (selected[0] ?? null) : selected
     const old_value = untrack(() => value)
@@ -330,14 +327,12 @@
     if (!utils.values_equal(old_selected, new_selected)) selected = new_selected
   })
 
-  let should_wiggle = $state(false) // controls wiggle animation when user tries to exceed maxSelect
-  let should_ignore_hover = $state(false) // ignore mouseover during keyboard navigation to prevent scroll-triggered hover
-  let highlighted_idx: number | null = $state(null) // index of highlighted selected item for arrow key navigation
-  // rangeSelect anchor bookkeeping. A plain (non-$state) var since it's only read inside
-  // event handlers, never in the template or a derived. Note the anchor can't be matched
-  // by reference: matchingOptions is $bindable, so its elements are re-proxied and never
-  // === the caller's objects. That's why is_same_option compares key + label. idx is the
-  // last known position, a hint for relocating the option after the list shifts.
+  let should_wiggle = $state(false) // wiggle when the user tries to exceed maxSelect
+  let should_ignore_hover = $state(false) // suppress scroll-triggered hover during key nav
+  let highlighted_idx: number | null = $state(null) // chip index for arrow-key navigation
+  // rangeSelect anchor. Plain (non-$state) since only event handlers read it. The anchor
+  // can't be matched by reference — matchingOptions is $bindable, so its elements are
+  // re-proxied — hence is_same_option comparing key + label; idx is a relocation hint.
   let range_anchor: { option: Option; idx: number | null } | null = null
 
   // maxVisibleChips: chips beyond the limit collapse into a "+N more" toggle.
@@ -359,9 +354,8 @@
     }
   })
 
-  // Carries an id, not just text: assigning the same string twice leaves the live
-  // region's content unchanged, so a repeated identical message (two equal-sized range
-  // selections in a row, say) would never be announced. The id keys the rendered node.
+  // carries an id, not just text: re-assigning the same string leaves the live region's
+  // content unchanged, so a repeated identical message would never be announced
   let last_announcement = $state<{ text: string; id: number } | null>(null)
   let announcement_count = 0
   const announce = (text: string) => {
@@ -375,7 +369,6 @@
     return () => clearTimeout(timer)
   })
 
-  // History tracking for undo/redo
   const max_history = $derived(
     history === true
       ? 50
@@ -387,23 +380,22 @@
   let history_index = $state(-1) // -1 = no history yet
   let prev_selected: Option[] | null = null // null = uninitialized, sync on first run
 
-  // Track changes to selected via $effect (catches internal + external changes)
+  // catches internal and external changes to `selected`
   $effect(() => {
-    // Disabled unless max_history > 0 (handles false, 0, negative, non-finite inputs)
+    // `!(x > 0)` also covers false, negative and non-finite history props
     if (!(max_history > 0)) {
-      // Clear history when disabled so re-enabling starts fresh
+      // clear so re-enabling starts fresh
       history_stack = []
       history_index = -1
-      // Don't read `selected` here to avoid creating unnecessary reactive dependency
+      // don't read `selected` here, it would add a needless dependency
       prev_selected = null
       return
     }
-    // Initialize prev_selected on first run to avoid phantom undo from [] → initial selection
+    // first run syncs the tracker, else [] → initial selection reads as an undoable step
     if (prev_selected === null) {
       prev_selected = [...selected]
       return
     }
-    // Ignore duplicate reactive updates.
     if (utils.values_equal(selected, prev_selected)) return
 
     const next_stack = history_stack.slice(0, history_index + 1)
@@ -414,7 +406,6 @@
     prev_selected = [...selected]
   })
 
-  // keep the bindable canUndo/canRedo props in sync
   $effect(() => {
     canUndo = max_history > 0 && !disabled && history_index > 0
     canRedo = max_history > 0 && !disabled && history_index < history_stack.length - 1
@@ -440,11 +431,11 @@
   undo = () => move_history(-1, onundo)
   redo = () => move_history(1, onredo)
 
-  // Debounced onsearch event - fires 150ms after search text stops changing
+  // onsearch fires 150ms after the search text stops changing
   let search_initialized = false
   $effect(() => {
     const current_search = searchText
-    // Skip initial mount - only fire on actual user input
+    // skip mount, only fire on real user input
     if (!search_initialized) {
       search_initialized = true
       return
@@ -452,13 +443,12 @@
     if (!onsearch) return // cleanup handles any pending timer
 
     const timer = setTimeout(() => {
-      // Optional chaining in case onsearch is removed while timer is pending
+      // optional chaining: onsearch may be removed while the timer is pending
       onsearch?.({ searchText: current_search, matchingOptions })
     }, 150)
     return () => clearTimeout(timer)
   })
 
-  // Internal state for loadOptions feature
   let loaded_options = $state<Option[]>([])
   let [load_options_has_more, is_loading_options] = $state([true, false])
   let load_options_last_search: string | null = $state(null) // null = nothing dispatched yet
@@ -470,7 +460,7 @@
 
   // === Derived collections and indexing ===
   let has_search_text = $derived(searchText.trim().length > 0)
-  // Cache selected labels to avoid repeated .map() calls (keys are mapped once into the Set below)
+  // cached to avoid repeated .map() calls
   let selected_labels = $derived(selected.map((opt) => utils.get_label(opt)))
   let input_committed_label = $derived(
     input_display && selected[0] !== undefined ? label_of(selected[0]) : null,
@@ -479,16 +469,15 @@
     input_display && searchText === input_committed_label,
   )
   let show_all_input_options = $state(false)
-  // whitespace-only input maps to `` (it previously filtered out every option while
-  // also suppressing the no-match message = blank dropdown); non-blank input stays
-  // raw so filterFunc/loadOptions/highlighting receive exactly what the user typed
+  // whitespace-only input maps to `` (it used to filter out every option while also
+  // suppressing the no-match message, leaving a blank dropdown); non-blank input stays raw
+  // so filterFunc/loadOptions/highlighting receive exactly what the user typed
   let effective_filter_text = $derived(
     input_text_is_committed || show_all_input_options || !has_search_text
       ? ``
       : searchText,
   )
 
-  // Check if option matches search text (label or optionally group name)
   const matches_search = (opt: Option, search: string): boolean =>
     filterFunc(opt, search) ||
     (searchMatchesGroups &&
@@ -496,9 +485,8 @@
       utils.has_group(opt) &&
       text_matches(search, opt.group))
 
-  // `options` and `loadOptions` compose instead of competing: local options are filtered
-  // client-side and lead the list, so they render with no debounce and no request while
-  // remote batches append behind them (e.g. PageSearch matching routes as you type).
+  // `options` and `loadOptions` compose: local options are filtered client-side and lead
+  // the list (no debounce, no request) while remote batches append behind them
   let effective_options = $derived.by(() => {
     const local_options = options
     if (!load_options_config) return local_options
@@ -508,15 +496,15 @@
     return [...local_matches, ...loaded_options]
   })
   let form_value = $derived.by(() => {
-    // input mode intentionally submits the visible text, committed or draft
-    // (free-text combobox contract, pinned by tests)
+    // input mode deliberately submits the visible text, committed or draft: the free-text
+    // combobox contract, pinned by tests
     if (input_display) return has_search_text ? searchText : null
     return selected.length >= Number(required) ? form_serialize(selected) : null
   })
   let prev_input_committed_label: string | null = null
-  // Keep searchText in sync with committed selections, including external value changes.
-  // onbeforeinput calls clear_input_committed_selection(), which clears input_committed_label
-  // before browser text mutation so this pre-effect only resets stale committed text.
+  // keeps searchText in sync with committed selections, external value changes included.
+  // onbeforeinput clears input_committed_label ahead of the browser's text mutation, so
+  // this pre-effect only ever resets stale committed text.
   $effect.pre(() => {
     if (input_committed_label !== null && searchText !== input_committed_label) {
       searchText = input_committed_label
@@ -538,12 +526,11 @@
           load_options_has_more &&
           (load_options_last_search ?? ``) !== effective_filter_text)),
   )
-  // Sets for O(1) lookups (used in template, has_user_message, group_header_state, batch
-  // operations). Plain (non-reactive) collections suffice for all these deriveds:
-  // they're rebuilt wholesale on change, never mutated in place.
+  // plain Sets for O(1) lookups: these deriveds are rebuilt wholesale, never mutated in
+  // place, so reactive collections would buy nothing
   let selected_keys_set = $derived(new Set(selected.map((opt) => key(opt))))
-  // Selected labels normalized to strings (numeric labels like 123 match "123"),
-  // lowercased when duplicates='case-insensitive' — for duplicate detection
+  // duplicate detection: labels as strings (so 123 matches "123"), lowercased when
+  // duplicates='case-insensitive'
   const lower_dupes = $derived(duplicates === `case-insensitive`)
   const norm_label = (label: unknown) =>
     lower_dupes ? `${label}`.toLowerCase() : `${label}`
@@ -556,14 +543,13 @@
   const is_disabled = (opt: Option): boolean =>
     Boolean(utils.is_object(opt) && opt.disabled)
 
-  // Identity check for bulk/range operations. Compares label too since a custom `key`
-  // may deliberately collapse distinct options (e.g. duplicates sharing one key).
+  // identity check for bulk/range ops. Compares label too, since a custom `key` may
+  // deliberately collapse distinct options onto one key.
   const is_same_option = (opt_a: Option | null | undefined, opt_b: Option): boolean =>
     opt_a != null &&
     key(opt_a) === key(opt_b) &&
     utils.get_label(opt_a) === utils.get_label(opt_b)
 
-  // Check if option index is within the maxOptions visibility limit
   const is_option_visible = (idx: number) => idx >= 0 && idx < visible_navigable_count
 
   // non-disabled options, limited to those rendered under maxOptions unless
@@ -634,10 +620,8 @@
     new Map(navigable_options.map((opt, idx) => [opt, idx])),
   )
 
-  // Number of options rendered in the dropdown: maxOptions hides options
-  // beyond the limit, so keyboard navigation must not activate them (otherwise
-  // aria-activedescendant would point at a non-existent DOM id and Enter could
-  // select an option the user can't see)
+  // keyboard nav must stop at maxOptions: past it aria-activedescendant would point at a
+  // non-existent DOM id and Enter could select an option the user can't see
   let visible_navigable_count = $derived(
     Math.min(navigable_options.length, maxOptions ?? Infinity),
   )
@@ -663,9 +647,8 @@
   const has_grouped_options = $derived(
     grouped_options.some(({ group }) => group !== null),
   )
-  // Virtualization supports flat and grouped lists (headers become rows of the same
-  // itemHeight). The validation below rejects sticky grouped headers because a header
-  // scrolled out of the render window cannot stay pinned.
+  // flat and grouped lists both virtualize (headers are rows of the same itemHeight), but
+  // validation rejects sticky grouped headers: one scrolled out of the window can't stay pinned
   const is_virtual_list_enabled = $derived(Boolean(virtual_config))
   let options_scroll_top = $state(0)
   let options_client_height = $state(0)
@@ -673,8 +656,8 @@
   const virtual_viewport = $derived(
     options_client_height > 0 ? options_client_height : 400,
   )
-  // Rows eligible for rendering: group headers interleaved with their options
-  // (maxOptions hides options past the limit, collapsed groups keep only their header)
+  // renderable rows: headers interleaved with their options (maxOptions truncates,
+  // collapsed groups keep only their header)
   type RenderRow =
     | {
         kind: `option`
@@ -684,9 +667,8 @@
         group: string | null
       }
     | { kind: `header`; group_idx: number; render_key: unknown }
-  // stable symbols as header render keys: can't collide with user option keys.
-  // Cache is bounded by distinct group names seen over the component's life, so
-  // symbols stay stable when filtering temporarily removes a group.
+  // symbols as header render keys: they can't collide with user option keys, and caching
+  // them per group name keeps them stable when filtering temporarily drops a group
   const header_key_cache = new Map<string, symbol>()
   const header_key = (group: string): symbol => {
     const header_symbol = header_key_cache.get(group) ?? Symbol(`sms-header-${group}`)
@@ -716,8 +698,8 @@
     })
     return rows
   })
-  // row index of each navigable option (keyboard auto-scroll needs row offsets,
-  // which diverge from flat option indices once header rows are interleaved)
+  // row index per navigable option: keyboard auto-scroll needs row offsets, which diverge
+  // from flat option indices once header rows are interleaved
   const option_row_indices = $derived.by(() => {
     const indices: number[] = []
     render_rows.forEach((row, row_idx) => {
@@ -745,21 +727,18 @@
       ? render_rows.slice(render_window.start, render_window.end)
       : render_rows,
   )
-  // Measure the dropdown viewport when it opens so the window matches the real
-  // scroll area (clientHeight is 0 before open and in happy-dom/SSR)
+  // measure on open so the window matches the real scroll area (clientHeight is 0 before
+  // open and in happy-dom/SSR)
   $effect(() => {
     if (!is_virtual_list_enabled || !open || !options_list_el) return
     const list_el = options_list_el
     tick().then(() => (options_client_height = list_el.clientHeight))
   })
 
-  // Render keys for the dropdown's keyed {#each}: identical to key(opt) for unique
-  // options (keeps DOM nodes stable when the list is filtered) but disambiguates
-  // repeated keys (e.g. options=['a', 'a'] or case-variant labels sharing a value)
-  // so Svelte can't crash with each_key_duplicate on unsanitized options arrays.
-  // Repeat occurrences get stable cached symbols: outside the user key namespace
-  // (a string suffix could collide with a real key like 'a-dup-1') and stable
-  // across re-derivations so keyed DOM nodes aren't recreated.
+  // keys for the dropdown's keyed {#each}: key(opt) for unique options, so filtering keeps
+  // DOM nodes stable, but repeats (options=['a', 'a']) would crash Svelte with
+  // each_key_duplicate. Repeats get cached symbols — outside the user key namespace (a
+  // string suffix could collide with a real 'a-dup-1') and stable across re-derivations.
   const dup_key_cache = new Map<unknown, symbol[]>()
   // One counter per pass, so a key repeated across groups is still disambiguated
   const render_key_assigner = () => {
@@ -782,15 +761,14 @@
       group_items.map(next_render_key),
     )
   })
-  // The chips need the same treatment: two selected entries can share a key (duplicate
-  // `preselected` options, or `selected={['a', 'a']}`) and Svelte throws each_key_duplicate.
-  // Symbols also beat keying by index, which would defeat move detection on reorder.
+  // chips need the same: two selected entries can share a key (`selected={['a', 'a']}`).
+  // Symbols beat keying by index, which would defeat move detection on reorder.
   let chip_render_keys = $derived.by(() => {
     const next_render_key = render_key_assigner()
     return visible_chips.map(next_render_key)
   })
 
-  // Pre-computed group header state (avoids repeated calculations in template)
+  // precomputed to keep the template from recalculating per header
   type GroupHeaderState = {
     all_selected: boolean
     selected_count: number
@@ -813,7 +791,7 @@
   })
 
   // === Grouping ===
-  // Update collapsedGroups state: 'add' adds groups, 'delete' removes groups, 'set' replaces all
+  // 'set' replaces the whole set; 'add'/'delete' are the SvelteSet methods of that name
   function update_collapsed_groups(
     action: `add` | `delete` | `set`,
     groups: string | Iterable<string>,
@@ -833,7 +811,7 @@
     ongroupToggle?.({ group: group_name, collapsed: !was_collapsed })
   }
 
-  // Collapse/expand all groups (exposed via bindable props)
+  // exposed via bindable props
   collapseAllGroups = () => {
     const groups = grouped_options.flatMap(({ group }) => (group === null ? [] : [group]))
     if (groups.length === 0) return
@@ -855,13 +833,11 @@
     }
   }
 
-  // Get names of collapsed groups that have matching options
   const get_collapsed_with_matches = () =>
     grouped_options.flatMap(({ group, collapsed }) => (group && collapsed ? [group] : []))
 
-  // Auto-expand collapsed groups when search matches their options. Only reacts
-  // to search-text changes (via prev_expand_search + untrack) so a group the
-  // user manually collapses mid-search isn't instantly re-expanded.
+  // auto-expand groups whose options match. Reacts only to search-text changes, else a
+  // group the user collapses mid-search is instantly re-expanded.
   let prev_expand_search = ``
   $effect(() => {
     const search = has_search_text ? searchText : ``
@@ -872,7 +848,6 @@
     }
   })
 
-  // Normalize placeholder prop (supports string or { text, persistent } object)
   const placeholder_text = $derived(
     typeof placeholder === `string` ? placeholder : (placeholder?.text ?? null),
   )
@@ -880,7 +855,7 @@
     typeof placeholder === `object` && placeholder?.persistent === true,
   )
 
-  // Sort selected per the sortSelected prop (used by add() and apply_bulk_add())
+  // used by add() and apply_bulk_add()
   function sort_selected(items: Option[]): Option[] {
     if (sortSelected === true) {
       return items.toSorted((opt_1, opt_2) =>
@@ -894,7 +869,6 @@
   // Revalidate reactive props and remote option groups after mount.
   $effect(() => validate_config(has_grouped_options))
 
-  // Resolve createOptionMsg to a string (supports string, function, or null)
   const resolved_create_msg = $derived.by(() => {
     if (createOptionMsg === null || createOptionMsg === undefined) return null
     if (typeof createOptionMsg === `function`) {
@@ -912,8 +886,8 @@
   // active state of the user-message <li> (dupe / create / no-match)
   let is_user_message_active = $state(false)
 
-  // effective_options is pre-filtered when loading remotely (local options by
-  // matches_search, remote batches by the server), so only filter the static list here
+  // when loading remotely effective_options is already filtered (locals by matches_search,
+  // batches by the server), so only the static list needs filtering here
   const search_matches = (opt: Option): boolean =>
     Boolean(loadOptions) || matches_search(opt, effective_filter_text)
 
@@ -1010,8 +984,7 @@
     previous_filter_text = effective_filter_text
   })
 
-  // Whether the options <ul> is in the DOM at all — aria-controls must not
-  // reference a non-existent id (mirrors the template's render condition)
+  // mirrors the template's render condition: aria-controls must not name a missing id
   const listbox_rendered = $derived(
     Boolean(
       (has_search_text && noMatchingOptionsMsg) ||
@@ -1022,8 +995,7 @@
 
   // Selected chips are plain list items, so left/right chip highlighting stays visual.
   const user_message_id = $derived(`${base_id}-user-msg`)
-  // A group header is presentational, so its options reference it by id to pick the group
-  // name up as their description
+  // the header is presentational, so its options cite this id as their description
   const group_header_id = (group_name: string) =>
     `${base_id}-group-${encodeURIComponent(group_name)}`
   const active_option_id = $derived(
@@ -1036,12 +1008,12 @@
 
   // false once removing would drop selected below minSelect
   const can_remove = $derived(minSelect === null || selected.length > minSelect)
-  // maxSelect = 1 replaces the current option instead of blocking, so it never counts
-  // as at-capacity (used by add() and paste; re-evaluated after async oncreate resolves)
+  // maxSelect=1 replaces rather than blocks, so it never counts as at-capacity. Called
+  // again after an async oncreate resolves.
   const at_max_capacity = () =>
     maxSelect !== null && maxSelect !== 1 && selected.length >= maxSelect
 
-  // Merge per-option style (string or {option, selected} object) with the li*Style prop
+  // merges a per-option style with the matching li*Style prop
   const merge_styles = (
     opt: Option,
     style_key: `selected` | `option`,
@@ -1061,16 +1033,15 @@
       title,
       selectedTitle,
       disabledTitle,
-      // `active` deliberately lives outside this object: it is the only field that tracks
-      // `activeIndex`, and since a fresh object is never `===` the previous one, bundling
-      // it here re-rendered every option row on each arrow key rather than just two.
+      // `active` deliberately stays out of this object: it's the only field tracking
+      // `activeIndex`, and bundling it re-rendered every row on each arrow key
       selected: is_option_selected(option_item, label),
       style: merge_styles(option_item, `option`, liOptionStyle),
     }
   }
 
   // === Selection mutations ===
-  // toggle an option between selected and unselected states (for keepSelectedInDropdown mode)
+  // keepSelectedInDropdown mode
   function toggle_option(option_to_toggle: Option, event: Event) {
     const is_currently_selected = selected_keys_set.has(key(option_to_toggle))
 
@@ -1092,8 +1063,8 @@
     return add_valid_option(option_to_add, event, from_paste)
   }
 
-  // from_paste: when true, skip option reconstruction so parse_paste() objects
-  // are preserved as-is (extra fields like value/group/metadata aren't stripped)
+  // from_paste skips option reconstruction so parse_paste() objects keep extra fields
+  // (value/group/metadata) instead of being stripped
   async function add_valid_option(
     option_to_add: Option,
     event: Event,
@@ -1107,8 +1078,8 @@
       option_to_add = Number(option_to_add) as Option
     }
 
-    // dupe check by key (not reference — Svelte proxies break identity); the label check
-    // additionally applies to user-typed options, or to all when duplicates='case-insensitive'
+    // dupe check by key, not reference: Svelte proxies break identity. The label check adds
+    // user-typed options, or all of them when duplicates='case-insensitive'.
     const option_key = key(option_to_add)
     const is_from_options = effective_options.some((opt) => key(opt) === option_key)
     const is_user_option =
@@ -1122,7 +1093,7 @@
       (check_label && is_label_selected(label_of(option_to_add)))
     const is_duplicate = is_dupe()
     const max_reached = at_max_capacity()
-    // Fire events for blocked add attempts (redundant null check narrows maxSelect for TS)
+    // events for blocked adds (the redundant null check narrows maxSelect for TS)
     if (max_reached && maxSelect !== null) {
       should_wiggle = true
       onmaxreached?.({ selected, maxSelect, attemptedOption: option_to_add })
@@ -1147,14 +1118,14 @@
         }
       }
       // Fire oncreate — return false to reject, return Option to transform
-      if (creating_option) return // ignore create attempts while an async oncreate is pending
+      if (creating_option) return // an async oncreate is already pending
       type CreateResult = false | Option | undefined
       let oncreate_result: CreateResult
       let was_async = false
       try {
         const raw_result = oncreate?.({ option: option_to_add })
-        // await thenables (not just native Promises) so results from non-native
-        // promise implementations aren't added as option objects
+        // await thenables, not just native Promises, else a non-native promise gets added
+        // as an option object
         if (typeof (raw_result as PromiseLike<unknown>)?.then === `function`) {
           was_async = true
           creating_option = true
@@ -1165,8 +1136,8 @@
           }
         } else oncreate_result = raw_result as CreateResult
       } catch (error) {
-        // sync throws are caught too: add_valid_option() is async, so an uncaught throw would
-        // surface as an unhandled rejection in non-awaiting event handlers
+        // sync throws too: this function is async, so an uncaught throw would surface as an
+        // unhandled rejection in non-awaiting event handlers
         const failure = was_async ? `promise rejected` : `threw`
         console.error(`MultiSelect: oncreate ${failure}:`, error)
         return
@@ -1188,7 +1159,6 @@
     }
     if (input_display) searchText = label_of(option_to_add)
     else if (resetFilterOnAdd) searchText = ``
-    // for maxSelect = 1 we always replace current option with new one
     selected = next_selected
 
     clear_validity()
@@ -1208,9 +1178,8 @@
     let option_removed = selected[idx]
 
     if (option_removed === undefined && allowUserOptions) {
-      // if option with label could not be found but allowUserOptions is truthy,
-      // assume it was created by user and create corresponding option object
-      // on the fly for use as event payload
+      // not found but allowUserOptions is on, so assume the user created it and rebuild an
+      // option object for the event payload
       const is_object_option = typeof effective_options[0] === `object`
       option_removed = (
         is_object_option ? { label: option_to_drop } : option_to_drop
@@ -1242,7 +1211,7 @@
     if (open) return
     open = true
     if (focus_input && !(event instanceof FocusEvent)) {
-      // avoid double-focusing input when event that opened dropdown was already input FocusEvent
+      // skipped for FocusEvents, which already focused the input
       input?.focus()
     }
     onopen?.({ event })
@@ -1250,13 +1219,11 @@
 
   let suppress_next_focus_open = false
 
-  // The remove button that ran the removal is unmounted by it, so focus would land on
-  // <body>. Hand it back to the input, but only when it was genuinely lost.
+  // the removal unmounts the button that ran it, dropping focus to <body>. Hand focus back
+  // to the input, but only once Svelte has flushed and only if it was genuinely lost.
   const with_focus_rescue = (handler: (event: Event) => void) => (event: Event) => {
     const button = event.currentTarget
     handler(event)
-    // The button survives until Svelte flushes the removal, so focus only drops after
-    // this tick. Rescue it then, and only if it was genuinely lost.
     void tick().then(() => {
       if (button instanceof HTMLElement && button.isConnected) return
       const active = document.activeElement
@@ -1351,13 +1318,12 @@
   const has_user_message = $derived(user_message !== null)
 
   // === Keyboard and pointer handlers ===
-  // Handle arrow key navigation through options (uses navigable_options to skip collapsed groups)
+  // navigable_options skips collapsed groups
   async function handle_arrow_navigation(direction: 1 | -1, event?: KeyboardEvent) {
     should_ignore_hover = true
     if (rangeSelect) {
-      // Anchors on the pre-move position, so an unmodified navigation drops the anchor
-      // and the next Shift+Arrow extends from where the cursor now is, not from a range
-      // the user has since navigated away from.
+      // anchors on the pre-move position, so an unmodified navigation drops the anchor and
+      // the next Shift+Arrow extends from the cursor, not a range navigated away from
       if (!event?.shiftKey) range_anchor = null
       else if (range_anchor === null && activeOption) {
         range_anchor = { option: activeOption, idx: activeIndex }
@@ -1374,10 +1340,9 @@
       is_user_message_active = !is_user_message_active
       return
     }
-    if (activeIndex === null && navigable_options.length === 0) return // nothing to navigate
+    if (activeIndex === null && navigable_options.length === 0) return
 
-    // Navigate rendered, enabled options with wrap-around. The user-message row
-    // remains navigable when present.
+    // wraps around the rendered, enabled options, plus the user-message row when present
     const total = visible_navigable_count + (has_user_message ? 1 : 0)
     const start_idx = activeIndex ?? (direction === 1 ? -1 : 0)
     activeIndex = null
@@ -1405,9 +1370,8 @@
         activeIndex !== null &&
         !is_user_message_active
       ) {
-        // In virtual mode the active li may not be rendered: scroll by row offset
-        // instead of scrollIntoView. Clamp scroll so the active row lies within
-        // [row_bottom - viewport, row_top] (no-op when already in view).
+        // the active li may not be rendered in virtual mode, so scroll by row offset rather
+        // than scrollIntoView, clamped to [row_bottom - viewport, row_top]
         const { item_height } = virtual_window
         const row_top = (option_row_indices[activeIndex] ?? activeIndex) * item_height
         const next_scroll_top = Math.min(
@@ -1423,7 +1387,7 @@
         options_list_el?.querySelector(`li.active`)?.scrollIntoView({ block: `nearest` })
     }
 
-    // Fire onactivate for keyboard navigation only (not mouse hover)
+    // keyboard navigation only, not mouse hover
     onactivate?.({ option: activeOption, index: activeIndex })
     if (event?.shiftKey && rangeSelect && activeOption)
       handle_option_interact(activeOption, event, activeIndex)
@@ -1444,12 +1408,10 @@
     return true
   }
 
-  // keydown on the search input; option/header rows handle their own keys via
-  // if_enter_or_space
+  // keydown on the search input; option/header rows use if_enter_or_space instead
   async function handle_keydown(event: KeyboardEvent) {
-    if (disabled) return // Block all keyboard handling when disabled
-    // Ignore keys while an IME composition is in progress: Enter confirms the
-    // composition (not the active option) and arrow keys navigate the IME
+    if (disabled) return
+    // during an IME composition Enter confirms the composition and arrows move the
     // candidate window, so acting on them would hijack CJK text input
     if (event.isComposing) return
     const chip_navigation_enabled = !input_display && selected.length > 0 && !searchText
@@ -1474,7 +1436,6 @@
     )
       return
 
-    // Clear selected-item highlight for any key except arrow/backspace navigation
     if (
       highlighted_idx !== null &&
       ![`ArrowLeft`, `ArrowRight`, `Backspace`].includes(event.key)
@@ -1482,8 +1443,7 @@
       highlighted_idx = null
 
     if (event.key === `Escape` || event.key === `Tab`) {
-      // a closed dropdown has nothing to dismiss, so the key belongs to the enclosing
-      // dialog/pane
+      // a closed dropdown has nothing to dismiss, so the key belongs to the enclosing pane
       if (open) event.stopPropagation()
       close_and_clear(event)
     } else if (event.key === `Enter`) {
@@ -1495,11 +1455,9 @@
         if (is_disabled(activeOption)) return
         handle_option_interact(activeOption, event, activeIndex)
       } else if (allowUserOptions && has_search_text && !load_options_pending) {
-        // user entered text but no options match, so if allowUserOptions is truthy, we create new option
         add(searchText as Option, event)
       } else {
-        // no active option and no search text means the options dropdown is closed
-        // in which case enter means open it
+        // no active option and no search text: the dropdown is closed, so Enter opens it
         open_dropdown(event)
       }
     } else if (event.key === `ArrowLeft` && chip_navigation_enabled) {
@@ -1526,9 +1484,9 @@
             selected.length === 0 ? null : Math.min(prev_highlighted, selected.length - 1)
         }
       }
-    }  // make first matching option active on any keypress while open (if no special case matched)
+    }  // any other keypress while open activates the first matching option
     else if (open && navigable_options.length > 0 && activeIndex === null) {
-      // Don't stop propagation or prevent default here, allow normal character input
+      // no stopPropagation/preventDefault here, normal character input must go through
       const first_enabled_idx = rendered_options.findIndex(
         (candidate) => !is_disabled(candidate),
       )
@@ -1546,7 +1504,7 @@
     if (removed_options.length === 0) return
 
     selected = selected.slice(0, keep_count)
-    searchText = `` // always clear on remove all (resetFilterOnAdd only applies to add operations)
+    searchText = `` // always clear: resetFilterOnAdd only governs adds
     announce(msg.options_removed(removed_options.length))
     onremoveAll?.({ options: removed_options })
     onchange?.({ options: selected, type: `removeAll` })
@@ -1570,7 +1528,7 @@
     return added
   }
 
-  // Batch-add options to selection (used by select_all and group select).
+  // used by select_all and group select
   function batch_add_options(
     options_to_add: Option[],
     event: Event,
@@ -1613,7 +1571,6 @@
     })
   }
 
-  // Batch-add options for top-level "Select all" (selectAllScope picks the candidates)
   function select_all(event: Event) {
     event.stopPropagation()
     batch_add_options(select_all_candidates, event, selectAllScope)
@@ -1623,9 +1580,8 @@
     max_reached: boolean,
     all_selectable_selected: boolean,
   ) {
-    // `selectAllDisabledTitle` is consulted first, including when the matching scope is
-    // unavailable: returning that message ahead of the prop meant `null` could not suppress
-    // the title and neither a string nor a function could replace it.
+    // the prop wins even when the matching scope is unavailable: returning that message
+    // first meant `null` couldn't suppress the title and nothing could replace it
     if (selectAllDisabledTitle === null) return ``
     // `max_reached` already implies a non-null maxSelect; the check re-narrows it for the label
     const default_title = matching_scope_unavailable
@@ -1633,7 +1589,7 @@
       : max_reached && maxSelect !== null && !all_selectable_selected
         ? msg.max_select_reached(maxSelect)
         : msg.all_options_selected
-    // the callback gets the state behind `default_title` too, so it can tell the three
+    // the callback also gets the state behind `default_title`, so it can tell the three
     // disabled reasons apart or wrap the default instead of rebuilding it
     return typeof selectAllDisabledTitle === `function`
       ? selectAllDisabledTitle({
@@ -1647,8 +1603,7 @@
       : (selectAllDisabledTitle ?? default_title)
   }
 
-  // Toggle group selection: works even when group is collapsed
-  // If all selectable options are selected, deselect them; otherwise select all
+  // works even when the group is collapsed
   function toggle_group_selection(
     selectable: Option[],
     all_selected: boolean,
@@ -1656,8 +1611,7 @@
   ) {
     event.stopPropagation()
     if (all_selected) {
-      // Deselect options in this group, but never drop below minSelect
-      // (consistent with remove_all and per-chip removal)
+      // never drop below minSelect, matching remove_all and per-chip removal
       const keys_to_remove = new Set(selectable.map((opt) => key(opt)))
       const max_removals =
         minSelect === null ? Infinity : Math.max(0, selected.length - minSelect)
@@ -1690,8 +1644,7 @@
       }
     }
 
-  // Returns true only when a range was actually selected; false tells the caller to
-  // fall back to an ordinary add.
+  // true only when a range was actually selected; false tells the caller to do a plain add
   function select_range(
     target: Option,
     event: Event,
@@ -1699,9 +1652,9 @@
   ): boolean {
     if (!multi_select) return false
     const visible_options = range_navigable_options
-    // hint indexes the dropdown rows, an order-preserving subsequence of visible_options,
-    // so the real position is at or after it — searching forward from there keeps
-    // indistinguishable rows on the clicked occurrence. Scan back only if it overshot.
+    // the hint indexes the dropdown rows, an order-preserving subsequence, so the real
+    // position is at or after it; searching forward keeps indistinguishable rows on the
+    // clicked occurrence. Scan back only if the hint overshot.
     const index_of = (option_to_find: Option, hint?: number | null): number => {
       const from = Math.min(hint ?? 0, visible_options.length)
       const match = (idx: number) => is_same_option(visible_options[idx], option_to_find)
@@ -1709,9 +1662,8 @@
       for (let idx = from - 1; idx >= 0; idx--) if (match(idx)) return idx
       return -1
     }
-    // A row the user can't see (past maxOptions) or that has left the list can't be a
-    // range endpoint. Report it unhandled so the caller still performs an ordinary add
-    // rather than swallowing the interaction.
+    // a row past maxOptions or gone from the list can't be a range endpoint; report it
+    // unhandled so the caller still does a plain add rather than swallowing the click
     if (!rendered_options.some((item) => is_same_option(item, target))) return false
     const target_idx = index_of(target, target_idx_hint)
     if (target_idx === -1) return false
@@ -1735,7 +1687,7 @@
     return true
   }
 
-  // Shared click/keyboard/range entry point for selecting an option
+  // shared click/keyboard/range entry point for selecting an option
   const handle_option_interact = (
     opt: Option,
     event: MouseEvent | KeyboardEvent,
@@ -1746,36 +1698,33 @@
     const extends_range =
       event.shiftKey &&
       (!(`key` in event) || event.key === `ArrowUp` || event.key === `ArrowDown`)
-    // select_range reports false when there's no usable anchor, so no need to check here
+    // select_range reports false when there's no usable anchor
     if (rangeSelect && extends_range && select_range(opt, event, option_idx)) return
     const selected_before = selected.length
     if (keepSelectedInDropdown && !input_display) toggle_option(opt, event)
     else void add(opt, event)
     if (!rangeSelect) return
-    // Anchor only on an add that landed. A rejected one (maxSelect reached, duplicate
-    // refused) or a toggle-off leaves no sensible anchor, so drop it rather than let a
-    // later Shift+click extend from a stale position. maxSelect===1 replaces without
-    // growing selected, but multi_select is false there so ranges never run.
+    // anchor only on an add that landed: a rejected add or a toggle-off leaves no sensible
+    // anchor, and a later Shift+click would extend from a stale position. maxSelect===1
+    // replaces without growing `selected`, but multi_select is false there anyway.
     range_anchor =
       selected.length > selected_before ? { option: opt, idx: option_idx ?? null } : null
   }
 
   // === Drag, input, and paste handlers ===
   let drag_idx: number | null = $state(null)
-  // chip index captured on dragstart: the authoritative drag source. Drops whose
-  // text/plain doesn't match a drag started on THIS instance are foreign (dragged
-  // page text/links, chips from another MultiSelect) and must not reorder.
+  // chip index captured on dragstart, the authoritative drag source: a drop whose
+  // text/plain doesn't match a drag started on THIS instance is foreign (page text, a chip
+  // from another MultiSelect) and must not reorder
   let drag_start_idx: number | null = null
-  // event handlers enable dragging to reorder selected options
   const on_chip_drop = (target_idx: number) => (event: DragEvent) => {
     if (!event.dataTransfer) return
     event.dataTransfer.dropEffect = `move`
     // parseInt yields NaN for empty/foreign drag data; Number('') → 0 would move item 0
     // oxlint-disable-next-line unicorn/prefer-number-coercion
     const start_idx = parseInt(event.dataTransfer.getData(`text/plain`), 10)
-    // Reject foreign drops: NaN/mismatched data never equals the index captured on
-    // dragstart (which also rules out NaN and negatives). The length check guards
-    // against `selected` shrinking mid-drag — splicing out of range corrupts it.
+    // NaN/mismatched data never equals the index captured on dragstart, so foreign drops
+    // fall out here; the length check guards `selected` shrinking mid-drag
     if (start_idx !== drag_start_idx || start_idx >= selected.length) return
     drag_start_idx = null
     const previous = [...selected]
@@ -1823,9 +1772,8 @@
     onchange?.({ option: option_removed, type: `remove` })
   }
 
-  // Clear committed selection BEFORE the value change so the
-  // input_committed_label → searchText sync effect can't clobber the user's
-  // draft on the same tick (ordering matters in real browsers).
+  // clears before the value change so the input_committed_label → searchText sync effect
+  // can't clobber the user's draft on the same tick (ordering matters in real browsers)
   const handle_input_beforeinput = () => {
     show_all_input_options = false
     if (input_committed_label !== null) clear_input_committed_selection()
@@ -1834,8 +1782,8 @@
   const handle_input_input = (event: Event) => {
     show_all_input_options = false
     if (!open) open_dropdown(event, false, false)
-    // Fallback for input events fired without beforeinput (e.g. some
-    // programmatic value setters); bind:value has already synced searchText.
+    // fallback for input events fired without beforeinput (some programmatic value
+    // setters); bind:value has already synced searchText
     if (input_committed_label !== null && searchText !== input_committed_label) {
       clear_input_committed_selection()
     }
@@ -1852,7 +1800,7 @@
     if (closeDropdownOnSelect === `retain-focus`) event.preventDefault()
   }
 
-  // Override input's focus method to ensure dropdown opens on programmatic focus
+  // patch input.focus() so programmatic focus also opens the dropdown
   // https://github.com/janosh/svelte-widgets/issues/289
   $effect(() => {
     if (!input) return
@@ -1872,16 +1820,16 @@
   })
 
   const handle_input_blur: FocusEventHandler<HTMLInputElement> = (event) => {
-    // For portalled dropdowns, don't close on blur since clicks on portalled elements
-    // will cause blur but we want to allow the click to register first
-    // (otherwise mobile touch event is unable to select options https://github.com/janosh/svelte-widgets/issues/335)
+    // a portalled dropdown must not close on blur: its own clicks blur the input, and
+    // closing first breaks option selection on touch
+    // https://github.com/janosh/svelte-widgets/issues/335
     if (
       !portal_params?.active &&
       (!(event.relatedTarget instanceof Node) || !outerDiv?.contains(event.relatedTarget))
     )
       close_dropdown(event)
 
-    onblur?.(event) // Call original handler (if any passed as component prop)
+    onblur?.(event)
   }
 
   async function handle_paste(event: ClipboardEvent) {
@@ -1895,10 +1843,9 @@
     const rejected: Option[] = []
     const overflow: Option[] = []
     for (const [idx, parsed_option] of parsed.entries()) {
-      // A splitter as ordinary as `text.split(',')` yields an empty entry for a trailing
-      // separator. `add` throws on those, and the throw would reject this async function:
-      // the loop stops, every later entry is silently dropped and `onparsed_paste` never
-      // fires. Count them as rejected and carry on.
+      // `text.split(',')` yields an empty entry for a trailing separator, and `add` throws
+      // on those: the rejection would stop the loop, drop every later entry and skip
+      // `onparsed_paste`. Count them as rejected and carry on.
       if (!is_non_empty_option(parsed_option)) {
         rejected.push(parsed_option)
         continue
@@ -1911,9 +1858,8 @@
       }
       const before = selected.length
       const before_first = maxSelect === 1 ? selected[0] : undefined
-      // add() only suspends when an async oncreate is pending (creating_option set
-      // synchronously) — awaiting only then keeps the sync paste path synchronous
-      // so onparsed_paste still fires in the same task as the paste event
+      // add() only suspends on a pending async oncreate (creating_option is set
+      // synchronously), so awaiting just then keeps onparsed_paste in the paste's own task
       const add_result = add(parsed_option, event, true)
       if (creating_option) await add_result
       if (selected.length > before || (maxSelect === 1 && selected[0] !== before_first)) {
@@ -1931,27 +1877,26 @@
   // reset form validation when required prop changes
   // https://github.com/janosh/svelte-widgets/issues/285
   $effect.pre(() => {
-    void required // register as dependency so validity resets when it changes
+    void required // register as dependency
     form_input?.setCustomValidity(``)
   })
 
   // === Async loadOptions ===
-  // Retire the in-flight fetch: bump the id so its result is discarded, abort it so
-  // consumers forwarding `signal` can bail, and drop the now-meaningless loading flag.
+  // retire the in-flight fetch: bump the id to discard its result, abort so consumers
+  // forwarding `signal` can bail, drop the now-meaningless loading flag
   function cancel_in_flight_load() {
     load_request_id++
     load_abort_controller?.abort()
     is_loading_options = false
   }
 
-  // Captures search at call time to avoid race conditions. reset=true bypasses the
-  // loading mutex so search changes can start a new fetch even while a previous one is
-  // in-flight; the request_id discards stale results and the old request is aborted.
+  // captures `search` at call time. reset=true bypasses the loading mutex so a new search
+  // can start mid-flight; request_id discards the stale result and the old fetch is aborted.
   async function load_dynamic_options(reset: boolean) {
     if (
       !load_options_config ||
-      // paginating from nothing repeats the first page, and would hand out offset 0 on
-      // a non-reset load, which the documented cursor pattern reads as "reset"
+      // paginating from nothing repeats the first page and hands out offset 0, which the
+      // documented cursor pattern reads as "reset"
       (!reset && (is_loading_options || !load_options_has_more || !loaded_options.length))
     )
       return
@@ -1979,9 +1924,8 @@
       loaded_options = reset ? result.options : [...loaded_options, ...result.options]
       load_options_has_more = result.hasMore
     } catch (error) {
-      // A consumer forwarding `signal` rejects with AbortError once we cancel, which is
-      // self-inflicted. One that ignores `signal` still reports genuine failures while
-      // superseded, so only swallow errors that are actually aborts.
+      // a consumer forwarding `signal` rejects with a self-inflicted AbortError on cancel,
+      // but one ignoring `signal` still reports real failures — so swallow aborts only
       if (abort_controller.signal.aborted && (error as Error)?.name === `AbortError`) {
         return
       }
@@ -1989,18 +1933,15 @@
       // a superseded request must not clobber the live request's state
       if (request_id === load_request_id) load_options_has_more = false
     } finally {
-      // Only clear loading if this is still the active request — a newer
-      // reset call may have started while this one was in-flight
+      // only the active request may clear loading; a newer reset may have started meanwhile
       if (request_id === load_request_id) {
         is_loading_options = false
         if (load_abort_controller === abort_controller) load_abort_controller = null
       }
     }
-    // Auto-fill: if the loaded batch doesn't overflow the dropdown, the scrollbar
-    // won't appear and onscroll can never fire. Keep loading until scrollable or done.
-    // An empty batch means the next request would be identical, so stop instead of
-    // spinning to MAX_AUTO_FILL_ROUNDS against a server that reports hasMore anyway.
-    // This also keeps offset=0 meaning "reset": non-reset loads always have options.
+    // auto-fill: a batch that doesn't overflow the dropdown yields no scrollbar, so onscroll
+    // can never fire — keep loading until scrollable or done. An empty batch stops it, since
+    // the next request would be identical (and it keeps offset=0 meaning "reset").
     if (
       request_id !== load_request_id ||
       batch_length === 0 ||
@@ -2056,25 +1997,23 @@
     if (!open) return
 
     const search = effective_filter_text
-    // First load = nothing dispatched yet for this open: no completed search AND none in
-    // flight. Read loading via untrack so its synchronous set inside load_dynamic_options
-    // can't re-trigger this effect — otherwise keystrokes during the still-awaiting first
-    // fetch would fire repeated immediate loads instead of taking the debounce path.
+    // first load = nothing dispatched yet for this open (none completed, none in flight).
+    // untrack the loading flag, else its synchronous set re-triggers this effect and
+    // keystrokes during the first fetch fire immediate loads instead of debouncing.
     const is_first_load =
       load_options_last_search === null && !untrack(() => is_loading_options)
     if (is_first_load) {
       if (config.should_fetch_on_open) void load_dynamic_options(true)
       else if (search) schedule_load()
     } else if (search !== load_options_last_search) {
-      // Subsequent loads: abort the superseded fetch and clear stale results
-      // immediately, then debounce the new search
+      // abort the superseded fetch and clear stale results now, then debounce the new search
       cancel_in_flight_load()
       clear_loaded_batch()
       schedule_load()
     }
     return () => clearTimeout(debounce_timer)
   })
-  // Abort any in-flight fetch on unmount so callers passing `signal` to fetch can bail
+  // abort on unmount so callers forwarding `signal` can bail
   $effect(() => () => cancel_in_flight_load())
 
   function handle_options_scroll(event: Event) {
@@ -2155,8 +2094,8 @@
   tabindex="-1"
   {style}
 >
-  <!-- form control input invisible to the user, used for validation and form submission -->
-  <!-- value mirrors selected options in chip mode and visible text in input mode -->
+  <!-- hidden control for validation and form submission; its value mirrors the selected
+  options in chip mode and the visible text in input mode -->
   <input
     {name}
     required={Boolean(required)}
@@ -2224,8 +2163,8 @@
             onclick={(event) => {
               event.stopPropagation()
               is_chip_list_expanded = !is_chip_list_expanded
-              // clear a beyond-limit highlight, else the auto-expand effect would
-              // instantly undo this collapse (making "show less" a no-op)
+              // clear a beyond-limit highlight, else the auto-expand effect undoes this
+              // collapse instantly and "show less" is a no-op
               if (!is_chip_list_expanded) highlighted_idx = null
             }}
             onmouseup={(event) => event.stopPropagation()}
@@ -2370,9 +2309,8 @@
           {typeof selectAllOption === `string` ? selectAllOption : `Select all`}
         </li>
       {/if}
-      <!-- option <li> markup shared by the virtual and non-virtual render paths.
-        flat_idx is passed positionally so duplicate option values still get
-        unique DOM ids / aria-posinset / hover indices -->
+      <!-- option <li> shared by the virtual and non-virtual render paths. flat_idx comes in
+        positionally so duplicate option values still get unique ids/posinset/hover indices -->
       {#snippet option_li(option_item: Option, flat_idx: number, group: string | null)}
         {@const view = get_option_view(option_item, flat_idx)}
         {@const is_active = activeIndex === flat_idx}
@@ -2388,8 +2326,8 @@
           class={[liOptionClass, is_active && liActiveOptionClass]}
           onmouseover={() => {
             if (view.disabled || should_ignore_hover) return
-            // without this the effect that pins the user-message row snaps activeIndex
-            // straight back, so hover highlighting is dead while that row is active
+            // else the effect pinning the user-message row snaps activeIndex straight back
+            // and hover highlighting is dead while that row is active
             is_user_message_active = false
             activeIndex = flat_idx
           }}
@@ -2410,10 +2348,9 @@
           )}
         >
           {#if keepSelectedInDropdown === `checkboxes`}
-            <!-- Suppressing the native toggle leaves the box driven only by `view.selected`.
-                 The click still bubbles to the <li>, which runs the real toggle, so a rejected
-                 one (maxSelect/minSelect reached, disabled option) can no longer leave the box
-                 flipped while the selection never changed. -->
+            <!-- suppressing the native toggle leaves the box driven only by `view.selected`;
+                 the click still bubbles to the <li>, so a rejected toggle (maxSelect/minSelect
+                 reached, disabled option) can't leave the box flipped -->
             <input
               type="checkbox"
               class="option-checkbox"
@@ -2436,8 +2373,8 @@
           {/if}
         </li>
       {/snippet}
-      <!-- spacers keep scrollHeight equal to the full list height so the scrollbar
-        behaves as if all options were rendered -->
+      <!-- spacers keep scrollHeight at the full list height, so the scrollbar behaves as if
+        every option were rendered -->
       {#snippet virtual_spacer(height: number)}
         <li
           aria-hidden="true"
@@ -2462,12 +2399,10 @@
           }}
           {@const handle_group_select = (event: Event) =>
             toggle_group_selection(selectable, all_selected, event)}
-          <!-- A listbox may only own `option` (or `group`) elements, so the header row is
-            presentational and its options point back at it with `aria-describedby`, which
-            is what carries the group name to assistive tech now. `role="presentation"` is
-            dropped by conflict resolution if the element is focusable or carries a global
-            ARIA attribute, so this <li> must have neither: the collapse control is a real
-            nested <button> and the label lives in the text, not in `aria-label`. -->
+          <!-- a listbox may only own `option`/`group` children, so this row is presentational
+            and its options carry the group name via `aria-describedby`. `role="presentation"`
+            is dropped if the element is focusable or has a global ARIA attribute, so this
+            <li> must have neither — hence the nested <button> and no `aria-label`. -->
           <li
             class={[`group-header`, liGroupHeaderClass]}
             class:collapsible={collapsibleGroups}
@@ -2476,9 +2411,8 @@
             style={liGroupHeaderStyle}
             onclick={handle_toggle}
           >
-            <!-- The description each option points at. A hidden span rather than the
-              <li> itself, so screen readers get exactly the group name and not the count,
-              the select-all button and the chevron along with it. -->
+            <!-- a hidden span rather than the <li> itself, so screen readers get the group
+              name alone, not the count, select-all button and chevron with it -->
             <span id={group_header_id(group_name)} class="sr-only">
               {msg.group(group_name)}
             </span>
@@ -2604,8 +2538,8 @@
     border: 0;
   }
 
-  /* Use :where() for elements with user-overridable class props (outerDivClass, ulSelectedClass, liSelectedClass)
-     so user-provided classes take precedence. See: https://github.com/janosh/svelte-widgets/issues/380 */
+  /* :where() so user class props (outerDivClass, ulSelectedClass, liSelectedClass) win
+     https://github.com/janosh/svelte-widgets/issues/380 */
   :where(div.multiselect) {
     position: relative;
     align-items: center;
@@ -2618,18 +2552,15 @@
     width: var(--sms-width);
     max-width: var(--sms-max-width);
     padding: var(--sms-padding, 0 3pt);
-    /* pair the default text color with the light-dark() background so the widget
-       stays readable on dark pages that never declare color-scheme (light-dark()
-       falls back to light there). Set --sms-text-color: inherit to blend with the
-       page instead. */
+    /* pairs with the light-dark() background so the widget stays readable on dark pages
+       that never declare color-scheme. Set --sms-text-color: inherit to blend in instead. */
     color: var(--sms-text-color, light-dark(#222, #eee));
     font-size: var(--sms-font-size, inherit);
     min-height: var(--sms-min-height, 22pt);
     margin: var(--sms-margin);
   }
   :where(div.multiselect.open) {
-    /* increase z-index when open to ensure the dropdown of one <MultiSelect />
-    displays above that of another slightly below it on the page */
+    /* so an open dropdown covers the MultiSelect below it on the page */
     z-index: var(--sms-open-z-index, 4);
   }
   :where(div.multiselect:focus-within) {
@@ -2706,7 +2637,7 @@
     aspect-ratio: auto;
     padding: 0 2pt;
   }
-  /* "+N more" chip toggle rendered when maxVisibleChips collapses overflow */
+  /* "+N more" toggle, rendered when maxVisibleChips collapses overflow */
   :is(div.multiselect li.more-chip button.more-chips) {
     border-radius: 3pt;
     aspect-ratio: auto;
@@ -2745,14 +2676,14 @@
     min-width: 0;
   }
 
-  /* When options are selected, placeholder is hidden in which case we minimize input width to avoid adding unnecessary width to div.multiselect */
+  /* with the placeholder hidden the input must not pad out div.multiselect's width */
   :where(
     div.multiselect:not(.input-display) > ul.selected > input:not(:placeholder-shown)
   ) {
     min-width: 1px; /* Minimal width to remain interactive */
   }
 
-  /* don't wrap ::placeholder rules in :is() as it seems to be overpowered by browser defaults i.t.o. specificity */
+  /* not wrapped in :is(): browser defaults then outweigh it on specificity */
   div.multiselect > ul.selected > input::placeholder {
     padding-inline-start: 5pt;
     color: var(--sms-placeholder-color);
@@ -2769,19 +2700,17 @@
     pointer-events: none;
   }
 
-  /* Use :where() for ul.options elements with class props (ulOptionsClass, liOptionClass, liUserMsgClass) */
+  /* :where() so class props (ulOptionsClass, liOptionClass, liUserMsgClass) win */
   :where(ul.options) {
     list-style: none;
-    /* top, left, width, position are managed by portal when active */
-    /* but provide defaults for non-portaled or initial state */
-    position: absolute; /* Default, overridden by portal to fixed when open */
+    /* the portal manages top/left/width/position when active (fixed while open); these are
+       the defaults for the non-portalled and initial states */
+    position: absolute;
     top: 100%;
-    /* deliberately physical: with width 100% left/right anchoring is identical, and
-       a logical inset would resolve to `right` in RTL, conflicting with the portal's
-       physical `left` positioning (over-constrained fixed element) */
+    /* deliberately physical: at width 100% left/right anchoring is identical, and a logical
+       inset would resolve to `right` in RTL, over-constraining the portal's fixed `left` */
     left: 0;
     width: 100%;
-    /* Default z-index if not portaled/overridden by portal */
     z-index: var(--sms-options-z-index, 3);
     overflow: auto;
     transition:
@@ -2790,8 +2719,8 @@
       visibility 0.2s;
     box-sizing: border-box;
     background: var(--sms-options-bg, light-dark(#fcfcfc, #222226));
-    /* pair text with the light-dark() background: when portalled the dropdown is
-       moved to document.body and no longer inherits div.multiselect's color */
+    /* portalling moves the dropdown to document.body, where it no longer inherits
+       div.multiselect's color */
     color: var(--sms-text-color, light-dark(#222, #eee));
     max-height: var(--sms-options-max-height, 50vh);
     overscroll-behavior: var(--sms-options-overscroll, none);
@@ -2818,8 +2747,7 @@
     opacity: 0;
     transform: translateY(50px);
     pointer-events: none;
-    /* position: fixed prevents the hidden dropdown from contributing to
-       ancestor scrollHeight (unlike position: absolute which extends it) */
+    /* fixed keeps the hidden dropdown out of ancestor scrollHeight, which absolute extends */
     position: fixed;
   }
   :where(ul.options > li) {
@@ -2829,9 +2757,9 @@
     border-inline-start: 1px solid transparent;
   }
   :where(ul.options .user-msg) {
-    /* block needed so vertical padding applies to span */
+    /* block so vertical padding applies to the span */
     display: block;
-    /* vertical padding tracks ul.options > li so this row is no taller than an option */
+    /* tracks ul.options > li so this row is no taller than an option */
     padding: 2pt 2ex;
   }
   :where(ul.options > li.selected) {
@@ -2865,7 +2793,7 @@
     margin-inline-end: 6px;
     accent-color: var(--sms-active-color, cornflowerblue);
   }
-  /* Select all option styling - has liSelectAllClass prop */
+  /* :where() — has the liSelectAllClass prop */
   :where(ul.options > li.select-all) {
     border-bottom: var(
       --sms-select-all-border-bottom,
@@ -2893,7 +2821,7 @@
       )
     );
   }
-  /* Group header styling - has liGroupHeaderClass prop */
+  /* :where() — has the liGroupHeaderClass prop */
   :where(ul.options > li.group-header) {
     display: flex;
     align-items: center;
@@ -2940,7 +2868,6 @@
     font-weight: normal;
     margin-inline-start: 4pt;
   }
-  /* Sticky group headers when enabled */
   :where(ul.options > li.group-header.sticky) {
     position: sticky;
     top: 0;
@@ -2950,7 +2877,7 @@
       var(--sms-options-bg, light-dark(#fcfcfc, #222226))
     );
   }
-  /* Indent grouped options for visual hierarchy */
+  /* indent options so groups read as a hierarchy */
   :where(
     ul.options > li:not(.group-header):not(.select-all):not(.user-msg):not(.loading-more)
   ) {
@@ -2959,7 +2886,6 @@
       var(--sms-group-option-indent, 1.5ex)
     );
   }
-  /* group chevron collapse/expand animation */
   :is(ul.options > li.group-header) :global(svg) {
     transition: transform var(--sms-group-collapse-duration, 0.15s) ease-out;
   }

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -539,13 +539,23 @@
     border-end-end-radius: var(--nav-border-radius);
     outline-offset: -1px;
     opacity: 0.6;
-    transition: opacity 0.15s;
+    transition:
+      opacity 0.15s,
+      color 0.15s;
   }
   .dropdown > div:first-child > button :global(svg) {
     transition: transform 0.2s ease;
   }
+  /* the row tints its background on hover, but the caret is a separate target within it, so
+     it recolors on its own to say the arrow itself is what opens the section. currentColor
+     last: --nav-link-active-color has no default, and an unset one would make `color`
+     invalid at computed-value time and inherit rather than drop out. */
   .dropdown > div:first-child > button:hover {
     opacity: 1;
+    color: var(
+      --nav-dropdown-toggle-hover-color,
+      var(--nav-link-active-color, currentColor)
+    );
   }
   .dropdown > div:first-child > button.open {
     opacity: 1;
@@ -727,7 +737,9 @@
     border-radius: var(--nav-border-radius);
     opacity: 0.6;
   }
-  nav.mobile .dropdown > div:first-child > button.open {
+  /* :hover here too, or this selector's extra `nav.mobile` outranks the shared hover rule
+     and pins the caret back to 0.6 */
+  nav.mobile .dropdown > div:first-child > button:is(.open, :hover) {
     opacity: 1;
   }
   /* `display: none` can't transition, so collapse via a 0fr grid row + fade. `visibility`

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -746,6 +746,11 @@
      keeps the still-mounted links out of the tab order. */
   nav.mobile .dropdown > div:last-child {
     position: static;
+    /* the desktop panel floats free of the page, so it hugs its content and may be given a
+       floor wider than its trigger. Inline in the mobile column both push the menu past the
+       phone's edge, so drop each to the column's own width. */
+    width: auto;
+    min-width: 0;
     border: none;
     box-shadow: none;
     padding: 0;
@@ -788,6 +793,11 @@
     padding-top: 2pt;
   }
   nav.mobile .dropdown > div:last-child a {
+    /* the desktop rule's nowrap makes a long label set the panel's min-content width, so the
+       phone menu scrolled sideways to reach the tail. `anywhere` (not break-word) is what
+       lowers min-content, and top-level rows already wrap this way. */
+    white-space: normal;
+    overflow-wrap: anywhere;
     padding-block: 2pt;
     padding-inline: 6pt 8pt;
     /* matches the top-level rows; an inherited 1.6 made child rows taller than their parent */

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -15,14 +15,13 @@
 
   type NavLinkRouteObject = NavRouteObject & { href: string }
 
-  // Parameter passed to the item snippet
   interface ItemSnippetParams {
-    route: NavRouteObject // normalized route object
+    route: NavRouteObject
     href: string
     label: string
     is_active: boolean
     is_dropdown: boolean
-    render_default: Snippet // escape hatch to render default
+    render_default: Snippet
   }
 
   let {
@@ -49,8 +48,8 @@
     item?: Snippet<[ItemSnippetParams]>
     link?: Snippet<[{ href: string; label: string; isActive: boolean }]>
     menu_props?: Omit<HTMLAttributes<HTMLDivElement>, `id`>
-    // `href` and `aria-current` stay component-owned: one shared bag cannot carry a
-    // per-route destination, and overriding it would point every link at the same page
+    // `href`/`aria-current` stay component-owned: one shared bag would point every link
+    // at the same page
     link_props?: Omit<HTMLAnchorAttributes, `aria-current` | `href`>
     // mobile menu toggle; style/class land here rather than on the <nav> host
     burger_props?: Omit<HTMLButtonAttributes, `aria-controls` | `aria-expanded` | `type`>
@@ -73,9 +72,8 @@
   const msg = $derived(merge_defaults(NAV_LABELS, labels))
 
   let is_open = $state(false)
-  // Submenus open on click/tap only. Hover-opening them made every pass of the pointer
-  // across the nav pop a panel open over the page, and a touch device has no hover to
-  // begin with, so the two input modes behaved differently for no gain.
+  // click/tap only: hover-opening popped panels on every pointer pass and touch devices
+  // have no hover, so the two input modes diverged for no gain
   let open_dropdown = $state<string | null>(null)
   // Start from the real width on the client so hydration doesn't flash the desktop nav on phones
   let viewport_width = $state(globalThis.innerWidth ?? Infinity)
@@ -85,8 +83,7 @@
   const unique_id = $props.id()
   const panel_id = `nav-menu-${unique_id}`
 
-  // Track previous is_open state for callbacks. Deliberately not $state: it's
-  // written inside the $effect below, which would re-trigger the effect if reactive.
+  // deliberately not $state: written inside the $effect below, which would self-retrigger
   let prev_is_open = false
 
   $effect(() => {
@@ -105,11 +102,9 @@
     open_dropdown = null
   }
 
-  // Query the submenu links / toggle button of the dropdown for a given route href, scoped
-  // to this instance: `data-href` is the route href, so two Navs rendering the same route
-  // would otherwise match each other's dropdowns and steal each other's focus. The scope is
-  // an id string rather than a `bind:this` ref so it is already usable while children
-  // render, which is when `focus_trap`'s `restore` reads the toggle.
+  // scoped per instance, else two Navs rendering the same route match each other's
+  // dropdowns and steal focus. An id string, not `bind:this`, so it's usable while
+  // children render — when `focus_trap`'s `restore` reads the toggle.
   const dropdown_sel = (href: string) =>
     `[data-nav="${unique_id}"] .dropdown[data-href="${CSS.escape(href)}"]`
   const dropdown_links = (href: string) =>
@@ -143,8 +138,8 @@
     toggle_dropdown(href, true)
   }
 
-  // On the whole dropdown, so arrows keep working after focus has moved from the toggle
-  // onto a link and Escape hands focus back to the toggle from anywhere inside.
+  // on the whole dropdown so arrows keep working once focus leaves the toggle, and
+  // Escape returns focus to the toggle from anywhere inside
   function handle_dropdown_keydown(event: KeyboardEvent, href: string) {
     if (!is_dropdown_open(href)) return
     if (event.key === `Escape`) {
@@ -157,7 +152,7 @@
   function is_current(path: string | undefined) {
     if (!path) return
     if (path === `/`) return page?.url.pathname === `/` ? `page` : undefined
-    // Match exact path or path followed by / to avoid partial matches
+    // exact path or `path/` prefix, never a partial segment match
     const pathname = page?.url.pathname
     const exact_match = pathname === path
     const prefix_match = pathname?.startsWith(`${path}/`)
@@ -174,7 +169,7 @@
 
     if (remove_parent) text = text.split(`/`).findLast(Boolean) ?? text
     let label = text.replace(/^\//u, ``).replaceAll(`-`, ` `)
-    // Handle root path '/' which becomes empty after stripping
+    // '/' strips to the empty string
     if (!label && text === `/`) label = `Home`
     return { label, style: label ? `text-transform: capitalize` : `` }
   }
@@ -199,7 +194,6 @@
     }
     const content = route.tooltip ?? (route.href ? tooltips?.[route.href] : undefined)
     if (!content) return
-    // Support both string (content only) and object (full options) formats
     const tooltip_overrides = typeof content === `string` ? { content } : content
     return tooltip({ ...tooltip_options, ...tooltip_overrides })
   }
@@ -231,7 +225,6 @@
 
 <svelte:window {onkeydown} bind:innerWidth={viewport_width} />
 
-<!-- Default item rendering snippet for escape hatch -->
 {#snippet default_item_render(
   parsed_route: NavLinkRouteObject,
   formatted: { label: string; style: string },
@@ -272,9 +265,8 @@
   data-nav={unique_id}
   class:mobile={is_mobile}
   onclick={chain_handlers((event: MouseEvent) => {
-    // The `link` snippet renders the consumer's own markup, which carries none of the
-    // wiring `link_click_handler` adds to the default anchor. Without this, navigating
-    // from the burger menu left the overlay covering the page it had just moved to.
+    // the `link` snippet's markup misses `link_click_handler`'s wiring, so without this
+    // the burger overlay stayed up over the page it had just navigated to
     const target = event.target
     if (target instanceof Element && target.closest(`a[href]`)) close_menus()
   }, rest?.onclick)}
@@ -298,8 +290,7 @@
     <span aria-hidden="true"></span>
   </button>
 
-  <!-- Escape is also handled on window, but a consumer onkeydown that stops propagation
-  would prevent that, so close from the element too -->
+  <!-- also on window, but a consumer onkeydown that stops propagation would block that -->
   <div
     {...menu_props}
     id={panel_id}
@@ -315,11 +306,9 @@
       {@const is_right = parsed_route.align === `right`}
       {@const item_tooltip = get_tooltip(parsed_route)}
 
-      <!-- Separator-only item -->
       {#if parsed_route.separator && !parsed_route.href}
         <div class="separator" role="separator"></div>
       {:else if sub_routes}
-        <!-- Dropdown menu item -->
         {@const child_is_active = is_child_current(sub_routes)}
         {@const parent_page_exists = sub_routes.includes(parsed_route.href)}
         {@const filtered_sub_routes = sub_routes.filter(
@@ -379,13 +368,12 @@
             data-submenu
             tabindex="-1"
             {@attach focus_trap({
-              enabled: dropdown_open, // an open submenu owns the keyboard
+              enabled: dropdown_open,
               initial: false, // toggle_dropdown already picks the entry point
               restore: dropdown_toggle(parsed_route.href) ?? false,
             })}
           >
-            <!-- `display: contents` everywhere except the mobile layout, where this wrapper is
-            the single grid row whose 0fr -> 1fr animates the section open -->
+            <!-- `display: contents` except on mobile, where it's the grid row animating 0fr -> 1fr -->
             <div class="submenu-inner">
               {#each filtered_sub_routes as child_href (child_href)}
                 {@const child_formatted = format_label(child_href, true)}
@@ -412,14 +400,11 @@
             </div>
           </div>
         </div>
-        <!-- Separator after dropdown if specified -->
         {#if parsed_route.separator}
           <div class="separator" role="separator"></div>
         {/if}
       {:else}
-        <!-- Regular link item -->
         {#if item}
-          <!-- User-provided item snippet with render_default escape hatch -->
           {#snippet render_default_snippet()}
             {@render default_item_render(parsed_route, formatted, item_tooltip)}
           {/snippet}
@@ -440,7 +425,6 @@
             {@render default_item_render(parsed_route, formatted, item_tooltip)}
           </span>
         {/if}
-        <!-- Separator after item if specified -->
         {#if parsed_route.separator}
           <div class="separator" role="separator"></div>
         {/if}
@@ -492,13 +476,12 @@
   .menu > span > a[aria-current='page'] {
     color: var(--nav-link-active-color);
   }
-  /* Disabled items */
   .menu .disabled {
     opacity: var(--nav-disabled-opacity, 0.5);
     cursor: not-allowed;
     pointer-events: none;
   }
-  /* Right-aligned items - only first one gets margin-inline-start: auto */
+  /* only the first right-aligned item gets the auto margin */
   .menu > :is(.align-right, .dropdown.align-right) {
     margin-inline-start: auto;
   }
@@ -507,7 +490,6 @@
     + :is(.align-right, .dropdown.align-right) {
     margin-inline-start: 0;
   }
-  /* Separator */
   .menu > .separator {
     width: 1px;
     height: 1.2em;
@@ -515,7 +497,6 @@
     opacity: 0.3;
     margin: var(--nav-separator-margin, 0 0.25em);
   }
-  /* Dropdown styles */
   .dropdown {
     position: relative;
   }
@@ -583,9 +564,9 @@
     inset-inline-start: var(--nav-dropdown-left, 0);
     inset-inline-end: var(--nav-dropdown-right, auto);
     margin: var(--nav-dropdown-margin, 2pt) 0 0 0;
-    min-width: var(--nav-dropdown-min-width, 100%); /* at least as wide as parent */
+    min-width: var(--nav-dropdown-min-width, 100%);
     max-width: var(--nav-dropdown-max-width, none);
-    width: var(--nav-dropdown-width, max-content); /* grow wider if content needs it */
+    width: var(--nav-dropdown-width, max-content);
     background-color: var(--nav-dropdown-bg, var(--nav-surface-bg));
     border: 1px solid var(--nav-dropdown-border-color, var(--nav-surface-border));
     border-radius: var(--nav-border-radius, 6pt);
@@ -598,8 +579,8 @@
   .dropdown > div:last-child.visible {
     display: flex;
   }
-  /* the links are direct flex/grid items of the popover on desktop; only the mobile layout
-     below gives this wrapper a box of its own */
+  /* on desktop the links are direct items of the popover; only mobile gives this
+     wrapper a box of its own */
   .submenu-inner {
     display: contents;
   }
@@ -617,27 +598,22 @@
   .dropdown > div:last-child a[aria-current='page'] {
     color: var(--nav-link-active-color);
   }
-  /* Mobile burger button */
   .burger {
     display: none;
-    /* `absolute` scopes the burger to the nearest positioned ancestor instead of the viewport,
-       which is what an embedded demo wants: two Navs on one page otherwise pin two burgers to
-       the same corner and the top one wins every tap. Pair it with --nav-mobile-menu-position. */
+    /* set `absolute` (with --nav-mobile-menu-position) for embedded demos: two fixed Navs
+       pin two burgers to the same corner and the top one wins every tap */
     position: var(--nav-burger-position, fixed);
     top: 1rem;
     inset-inline-start: 1rem;
     flex-direction: column;
     justify-content: space-around;
-    /* 1.4rem bars in a 0.3rem-padded box, matching Toc's mobile toggle — the two are the only
-       pinned mobile chrome a page has, so they have to read as a set */
+    /* sized to match Toc's mobile toggle — the only other pinned mobile chrome */
     width: var(--nav-burger-size, 1.4rem);
     height: var(--nav-burger-size, 1.4rem);
     box-sizing: content-box;
     padding: var(--nav-burger-padding, 0.3rem);
-    /* The same opaque chip as Toc's toggle, for the same reason: pinned over scrolling page
-       content, a transparent button leaves the bars sitting on whatever text passes beneath.
-       Both toggles are anchored by their box edge — no negative margin pulling the padding
-       out — so the chip, not the glyph, is what lines up 1rem from the corner. */
+    /* opaque chip like Toc's toggle: pinned over scrolling content, a transparent button
+       leaves the bars on whatever text passes beneath */
     background: var(--nav-burger-bg, var(--nav-surface-bg));
     border: 1px solid var(--nav-burger-border-color, var(--nav-surface-border));
     border-radius: var(--nav-border-radius, 6pt);
@@ -655,10 +631,8 @@
       transform 0.2s linear;
     transform-origin: center;
   }
-  /* Both strokes must land on the box's centre line or the X reads as lopsided. Under
-     `space-around` with three equal bars, adjacent bar centres are exactly height/3 apart —
-     the outer bars are one step from the middle one, which is already centred. A hardcoded
-     offset (0.4rem against a 1.4rem box) left them ~1px shy of meeting. */
+  /* height/3 is the exact gap between adjacent bar centres under `space-around`, so both
+     strokes land on the centre line; a hardcoded 0.4rem left them ~1px shy of meeting */
   .burger[aria-expanded='true'] span:first-child {
     transform: translateY(calc(var(--nav-burger-size, 1.4rem) / 3)) rotate(45deg);
   }
@@ -668,18 +642,16 @@
   .burger[aria-expanded='true'] span:nth-child(3) {
     transform: translateY(calc(var(--nav-burger-size, 1.4rem) / -3)) rotate(-45deg);
   }
-  /* Mobile styles - using .mobile class set via JS based on breakpoint prop */
+  /* .mobile is set in JS from the breakpoint prop, not a media query */
   nav.mobile .burger {
     display: flex;
   }
   nav.mobile .menu {
     position: var(--nav-mobile-menu-position, fixed);
     top: 3rem;
-    /* Hug the content and hang off the burger's side rather than spanning the viewport: a
-       full-width bar of mostly empty space reads as a broken layout, and the menu is chrome
-       floating over the page, not a section of it. Capped so a long route label still can't
-       push it off-screen. Hosts wanting the full-width bar can set --nav-mobile-inset to a
-       single value like `0.5rem`. */
+    /* hug the content beside the burger rather than spanning the viewport: a full-width bar
+       of empty space reads as broken layout. Set --nav-mobile-inset to a single value like
+       `0.5rem` for the full-width bar. */
     inset-inline: var(--nav-mobile-inset, 0.5rem auto);
     width: max-content;
     max-width: calc(100dvw - 1rem);
@@ -693,8 +665,8 @@
       visibility 0.3s ease;
     z-index: var(--nav-mobile-z-index, 2);
     flex-direction: column;
-    /* one scrollable column: with several submenus expanded the menu outgrows a phone
-       screen, and wrapping would spill entries into a second column off the panel */
+    /* wrapping would spill entries into a second column off the panel once several
+       submenus are expanded */
     flex-wrap: nowrap;
     align-items: stretch;
     justify-content: start;
@@ -708,37 +680,30 @@
     opacity: 1;
     visibility: visible;
   }
-  /* `.menu > span` and `.dropdown > div:first-child` are the two elements that paint a row's
-     highlight. Padding must land on both or neither: padding `.dropdown` instead of its inner
-     wrapper grew the row around the pill rather than the pill itself, so plain links rendered
-     visibly wider and taller pills than dropdown rows. */
+  /* both selectors paint a row's highlight, so padding must land on both or neither —
+     padding `.dropdown` itself grew the row around the pill, not the pill */
   nav.mobile :is(.menu > span, .dropdown > div:first-child) {
     padding: 1pt 8pt;
   }
-  /* Fill the pill, matching the flex:1 that dropdown rows already give their link, so the
-     whole row is tappable rather than just the text. flex:1 only fills the content box, so
-     the negative margin pulls the link back out over the span's padding and its own padding
-     puts the text back where it was — otherwise the padding is a dead band inside the
-     painted pill. The padding stays on the span so a custom `item` snippet still gets it. */
+  /* make the whole pill tappable: flex:1 only fills the content box, so the negative margin
+     pulls the link out over the span's padding, which would otherwise be a dead band. The
+     padding stays on the span so a custom `item` snippet still gets it. */
   nav.mobile .menu > span > a {
     flex: 1;
     margin: -1pt -8pt;
     padding: 1pt 8pt;
   }
-  /* Same pull-out for dropdown rows, inline-start only — the chevron owns the other end. The
-     link keeps its own --nav-item-padding, which stacked on the row's padding and left every
-     expandable entry indented past its plain siblings. */
+  /* same pull-out, inline-start only (the chevron owns the other end): the link's own
+     --nav-item-padding stacked on the row's and indented every expandable entry */
   nav.mobile .dropdown > div:first-child > :is(a, span) {
     margin-inline-start: -8pt;
     padding-inline-start: 8pt;
   }
-  /* Mobile separator */
   nav.mobile .menu > .separator {
     width: 100%;
     height: 1px;
     margin: var(--nav-separator-margin, 0.25em 0);
   }
-  /* Mobile dropdown styles - show as expandable section */
   nav.mobile .dropdown {
     flex-direction: column;
     align-items: stretch;
@@ -753,10 +718,9 @@
     border-radius: var(--nav-border-radius);
   }
   nav.mobile .dropdown > div:first-child > button {
-    /* The caret is the only way to open a section, so it gets the biggest target the row can
-       give it: full row height via `stretch`, and negative margins pulling it out over the
-       row's own padding so the tap area runs to the painted edge instead of stopping short
-       of it. The padding puts back what the margins take, keeping the glyph where it was. */
+    /* the caret is the only way to open a section, so give it the largest tap target: full
+       row height, and negative margins running it out to the row's painted edge (the
+       padding puts back what they take, keeping the glyph in place) */
     align-self: stretch;
     margin: -1pt -8pt -1pt 0;
     padding: 1pt 8pt 1pt 14pt;
@@ -766,10 +730,8 @@
   nav.mobile .dropdown > div:first-child > button.open {
     opacity: 1;
   }
-  /* Expand the section rather than switching it on: `display: none` can't transition, so the
-     collapsed state is a zero-height grid row (0fr -> 1fr against the wrapper below) plus a
-     fade. `visibility` rides along because the links stay in the DOM while collapsed and
-     would otherwise keep collecting Tab focus behind a closed section. */
+  /* `display: none` can't transition, so collapse via a 0fr grid row + fade. `visibility`
+     keeps the still-mounted links out of the tab order. */
   nav.mobile .dropdown > div:last-child {
     position: static;
     border: none;
@@ -790,9 +752,8 @@
     opacity: 1;
     visibility: visible;
   }
-  /* The animated row. Its gap above the first link is padding that opens with it, not a
-     margin on the section: `min-height: 0` zeroes the row's content but not its padding, so
-     a static 2pt would sit under every collapsed submenu as a visible sliver. */
+  /* the animated row. Its top gap is padding that opens with it: `min-height: 0` zeroes the
+     row's content but not its padding, so a static 2pt would leave a sliver when collapsed. */
   nav.mobile .submenu-inner {
     display: flex;
     flex-direction: column;
@@ -800,13 +761,10 @@
     overflow: hidden;
     padding-top: 0;
     transition: padding-top var(--nav-submenu-duration, 0.25s) ease;
-    /* One rule down the whole section instead of one per link: the links abut, so their own
-       borders would nearly join, but the section's opening padding leaves a notch above the
-       first one and the line has to read as a single stroke tying the group to its parent.
-       A hairline sitting close under the parent label — it marks where the section belongs,
-       so it should not compete with the labels beside it. Its own colour rather than
-       --nav-surface-border, which is tuned for a 1px panel edge over the page background,
-       not for a rule over the panel's own fill. */
+    /* one rule down the whole section, not one per link: per-link borders leave a notch
+       under the section's opening padding instead of a single stroke. Its own colour, since
+       --nav-surface-border is tuned for a panel edge over the page, not a rule over the
+       panel's fill. */
     margin-inline-start: 10pt;
     border-inline-start: 1px solid
       var(
@@ -820,12 +778,10 @@
   nav.mobile .dropdown > div:last-child a {
     padding-block: 2pt;
     padding-inline: 6pt 8pt;
-    /* An inherited 1.6 made every child row taller than the parent it hangs under, which read
-       as a list of headings rather than a nested section. 1.3 is what the top-level rows use. */
+    /* matches the top-level rows; an inherited 1.6 made child rows taller than their parent */
     line-height: 1.3;
-    /* Pull the link's own border onto the wrapper's guide line, so the active row recolours a
-       segment of that line instead of drawing a second one beside it. Same width as the rule
-       it covers, or the two would not line up on both edges. */
+    /* pull the link's border onto the wrapper's guide line so the active row recolours a
+       segment of it rather than drawing a second line beside it (hence the equal width) */
     margin-inline-start: -1px;
     border-inline-start: 1px solid transparent;
     font-size: 0.9em;
@@ -833,7 +789,6 @@
   nav.mobile .dropdown > div:last-child a[aria-current='page'] {
     border-inline-start-color: var(--nav-link-active-color, currentColor);
   }
-  /* Mobile right-aligned items stack normally */
   nav.mobile .menu > :is(.align-right, .dropdown.align-right) {
     margin-inline-start: 0;
   }

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -39,7 +39,6 @@
     tooltips,
     tooltip_options,
     breakpoint = 767,
-    dropdown_cooldown_ms = 150,
     onnavigate,
     onopen,
     onclose,
@@ -62,7 +61,6 @@
     tooltips?: Record<string, string | Omit<TooltipOptions, `disabled`>>
     tooltip_options?: Omit<TooltipOptions, `content` | `render`>
     breakpoint?: number
-    dropdown_cooldown_ms?: number // delay before hiding dropdown after mouse leaves; ignored when pinned
     onnavigate?: (data: {
       href: string
       event: MouseEvent
@@ -75,13 +73,13 @@
   const msg = $derived(merge_defaults(NAV_LABELS, labels))
 
   let is_open = $state(false)
-  let hovered_dropdown = $state<string | null>(null)
-  let pinned_dropdown = $state<string | null>(null)
-  let is_touch_device = $state(false)
+  // Submenus open on click/tap only. Hover-opening them made every pass of the pointer
+  // across the nav pop a panel open over the page, and a touch device has no hover to
+  // begin with, so the two input modes behaved differently for no gain.
+  let open_dropdown = $state<string | null>(null)
   // Start from the real width on the client so hydration doesn't flash the desktop nav on phones
   let viewport_width = $state(globalThis.innerWidth ?? Infinity)
   let is_mobile = $derived(viewport_width <= breakpoint)
-  let hide_timeout: ReturnType<typeof setTimeout> | null = null
   let focus_timeout: ReturnType<typeof setTimeout> | undefined
   // `$props.id()` survives hydration; a random uuid would mismatch aria-controls
   const unique_id = $props.id()
@@ -90,11 +88,6 @@
   // Track previous is_open state for callbacks. Deliberately not $state: it's
   // written inside the $effect below, which would re-trigger the effect if reactive.
   let prev_is_open = false
-
-  // Detect touch support after mounting so SSR never touches navigator.
-  $effect(() => {
-    is_touch_device = `ontouchstart` in globalThis || navigator.maxTouchPoints > 0
-  })
 
   $effect(() => {
     if (is_open && !prev_is_open) {
@@ -105,16 +98,11 @@
     prev_is_open = is_open
   })
 
-  $effect(() => () => {
-    if (hide_timeout) clearTimeout(hide_timeout)
-    clearTimeout(focus_timeout)
-  })
+  $effect(() => () => clearTimeout(focus_timeout))
 
   function close_menus() {
-    if (hide_timeout) clearTimeout(hide_timeout)
     is_open = false
-    hovered_dropdown = null
-    pinned_dropdown = null
+    open_dropdown = null
   }
 
   // Query the submenu links / toggle button of the dropdown for a given route href, scoped
@@ -132,39 +120,19 @@
     )
 
   function toggle_dropdown(href: string, focus_first = false) {
-    const is_opening = pinned_dropdown !== href
-    pinned_dropdown = is_opening ? href : null
-    hovered_dropdown = is_opening ? href : null
+    const is_opening = open_dropdown !== href
+    open_dropdown = is_opening ? href : null
     if (is_opening && focus_first) {
       clearTimeout(focus_timeout)
       focus_timeout = setTimeout(() => dropdown_links(href)[0]?.focus(), 0)
     }
   }
 
-  function open_dropdown(href: string, from_mouse = false) {
-    if (from_mouse && is_touch_device && is_mobile) return
-    if (hide_timeout) clearTimeout(hide_timeout)
-    if (pinned_dropdown && pinned_dropdown !== href) pinned_dropdown = null
-    hovered_dropdown = href
-  }
-
-  function schedule_hide(href: string, is_pinned: boolean) {
-    // Same gate as the hover-open above: a touchscreen laptop opens dropdowns on hover
-    // like any desktop, so suppressing the hide on touch support alone would strand them
-    // open. Only the mobile layout, where a tap is what opened the menu, keeps them.
-    if ((is_touch_device && is_mobile) || is_pinned) return
-    if (hide_timeout) clearTimeout(hide_timeout)
-    hide_timeout = setTimeout(() => {
-      if (hovered_dropdown === href) hovered_dropdown = null
-    }, dropdown_cooldown_ms)
-  }
-
   function onkeydown(event: KeyboardEvent) {
     if (event.key === `Escape`) close_menus()
   }
 
-  const is_dropdown_open = (href: string) =>
-    hovered_dropdown === href || pinned_dropdown === href
+  const is_dropdown_open = (href: string) => open_dropdown === href
 
   function handle_toggle_keydown(event: KeyboardEvent, href: string) {
     const { key } = event
@@ -255,14 +223,6 @@
       (event: MouseEvent) => handle_link_click(event, route),
       link_props?.onclick,
     )
-  // Tabbing onto the toggle must not open the submenu: the toggle is also where focus
-  // lands when a dismissed submenu hands it back, which would reopen what the user
-  // just closed. Enter/Space/ArrowDown open it.
-  const dropdown_focusin_handler = (href: string) => (event: FocusEvent) => {
-    const { target } = event
-    if (target instanceof Element && target.closest(`[data-dropdown-toggle]`)) return
-    open_dropdown(href)
-  }
   function get_external_attrs(route: NavRouteObject) {
     if (!route.external) return {}
     return { target: `_blank`, rel: `noopener noreferrer` }
@@ -320,7 +280,7 @@
   }, rest?.onclick)}
   {@attach click_outside({
     // skip the document listener (and its scrollbar layout read) when nothing is open
-    enabled: is_open || Boolean(pinned_dropdown) || Boolean(hovered_dropdown),
+    enabled: is_open || Boolean(open_dropdown),
     callback: close_menus,
   })}
 >
@@ -365,26 +325,13 @@
         {@const filtered_sub_routes = sub_routes.filter(
           (route) => route !== parsed_route.href,
         )}
-        {@const is_pinned = pinned_dropdown === parsed_route.href}
         {@const dropdown_open = is_dropdown_open(parsed_route.href)}
-        <!-- svelte-ignore a11y_no_static_element_interactions -- native navigation links keep semantics; mouse handlers only control hover disclosure -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -- native navigation links keep semantics; the keydown handler only routes arrows/Escape within the open submenu -->
         <div
           class={[`dropdown`, { active: child_is_active, 'align-right': is_right }]}
           data-href={parsed_route.href}
-          onmouseenter={() => open_dropdown(parsed_route.href, true)}
-          onmouseleave={() => schedule_hide(parsed_route.href, is_pinned)}
           onkeydown={(event: KeyboardEvent) =>
             handle_dropdown_keydown(event, parsed_route.href)}
-          onfocusin={dropdown_focusin_handler(parsed_route.href)}
-          onfocusout={(event: FocusEvent) => {
-            if (
-              event.relatedTarget instanceof Node &&
-              event.currentTarget instanceof HTMLElement &&
-              event.currentTarget.contains(event.relatedTarget)
-            )
-              return
-            if (!is_pinned) hovered_dropdown = null
-          }}
         >
           <div>
             {#if parsed_route.disabled}
@@ -427,50 +374,42 @@
               <Icon icon={ChevronDown} style="width: 1em; height: 1em" />
             </button>
           </div>
-          <!-- svelte-ignore a11y_no_static_element_interactions -- hover keeps the native-link submenu open while traversing it -->
           <div
             class:visible={dropdown_open}
             data-submenu
             tabindex="-1"
-            onmouseenter={() => open_dropdown(parsed_route.href, true)}
-            onmouseleave={(event: MouseEvent) => {
-              // Don't schedule hide if mouse moved to sibling element within same dropdown
-              if (
-                event.relatedTarget instanceof Node &&
-                event.currentTarget instanceof Element &&
-                event.currentTarget.closest(`.dropdown`)?.contains(event.relatedTarget)
-              )
-                return
-              schedule_hide(parsed_route.href, is_pinned)
-            }}
             {@attach focus_trap({
-              enabled: is_pinned, // only a pinned submenu owns the keyboard
+              enabled: dropdown_open, // an open submenu owns the keyboard
               initial: false, // toggle_dropdown already picks the entry point
               restore: dropdown_toggle(parsed_route.href) ?? false,
             })}
           >
-            {#each filtered_sub_routes as child_href (child_href)}
-              {@const child_formatted = format_label(child_href, true)}
-              {@const child_tooltip = get_tooltip({ href: child_href })}
-              {#if link}
-                {@render link({
-                  href: child_href,
-                  label: child_formatted.label,
-                  isActive: is_current(child_href) === `page`,
-                })}
-              {:else}
-                <a
-                  {...link_props}
-                  href={child_href}
-                  aria-current={is_current(child_href)}
-                  style={`${child_formatted.style}; ${link_props?.style ?? ``}`}
-                  onclick={link_click_handler({ href: child_href })}
-                  {@attach child_tooltip}
-                >
-                  {@html child_formatted.label}
-                </a>
-              {/if}
-            {/each}
+            <!-- `display: contents` everywhere except the mobile layout, where this wrapper is
+            the single grid row whose 0fr -> 1fr animates the section open -->
+            <div class="submenu-inner">
+              {#each filtered_sub_routes as child_href (child_href)}
+                {@const child_formatted = format_label(child_href, true)}
+                {@const child_tooltip = get_tooltip({ href: child_href })}
+                {#if link}
+                  {@render link({
+                    href: child_href,
+                    label: child_formatted.label,
+                    isActive: is_current(child_href) === `page`,
+                  })}
+                {:else}
+                  <a
+                    {...link_props}
+                    href={child_href}
+                    aria-current={is_current(child_href)}
+                    style={`${child_formatted.style}; ${link_props?.style ?? ``}`}
+                    onclick={link_click_handler({ href: child_href })}
+                    {@attach child_tooltip}
+                  >
+                    {@html child_formatted.label}
+                  </a>
+                {/if}
+              {/each}
+            </div>
           </div>
         </div>
         <!-- Separator after dropdown if specified -->
@@ -583,14 +522,6 @@
   .dropdown.active > div:first-child :is(a, span) {
     color: var(--nav-link-active-color);
   }
-  .dropdown::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: -5pt;
-    right: -5pt;
-    height: calc(var(--nav-dropdown-margin, 2pt) + 5pt);
-  }
   .dropdown > div:first-child {
     display: flex;
     align-items: center;
@@ -667,6 +598,11 @@
   .dropdown > div:last-child.visible {
     display: flex;
   }
+  /* the links are direct flex/grid items of the popover on desktop; only the mobile layout
+     below gives this wrapper a box of its own */
+  .submenu-inner {
+    display: contents;
+  }
   .dropdown > div:last-child a {
     padding: var(--nav-dropdown-link-padding, 2pt 6pt);
     text-decoration: none;
@@ -684,18 +620,28 @@
   /* Mobile burger button */
   .burger {
     display: none;
-    position: fixed;
+    /* `absolute` scopes the burger to the nearest positioned ancestor instead of the viewport,
+       which is what an embedded demo wants: two Navs on one page otherwise pin two burgers to
+       the same corner and the top one wins every tap. Pair it with --nav-mobile-menu-position. */
+    position: var(--nav-burger-position, fixed);
     top: 1rem;
     inset-inline-start: 1rem;
     flex-direction: column;
     justify-content: space-around;
-    /* 1.4rem bars inside a ~2.4rem hit area: a finger-sized target without moving the bars */
+    /* 1.4rem bars in a 0.3rem-padded box, matching Toc's mobile toggle — the two are the only
+       pinned mobile chrome a page has, so they have to read as a set */
     width: var(--nav-burger-size, 1.4rem);
     height: var(--nav-burger-size, 1.4rem);
     box-sizing: content-box;
-    padding: 0.5rem;
-    margin: -0.5rem;
-    background: transparent;
+    padding: var(--nav-burger-padding, 0.3rem);
+    /* The same opaque chip as Toc's toggle, for the same reason: pinned over scrolling page
+       content, a transparent button leaves the bars sitting on whatever text passes beneath.
+       Both toggles are anchored by their box edge — no negative margin pulling the padding
+       out — so the chip, not the glyph, is what lines up 1rem from the corner. */
+    background: var(--nav-burger-bg, var(--nav-surface-bg));
+    border: 1px solid var(--nav-burger-border-color, var(--nav-surface-border));
+    border-radius: var(--nav-border-radius, 6pt);
+    box-shadow: var(--nav-burger-shadow, var(--nav-surface-shadow));
     z-index: var(--nav-toggle-btn-z-index, 10);
   }
   .burger span {
@@ -727,13 +673,16 @@
     display: flex;
   }
   nav.mobile .menu {
-    position: fixed;
+    position: var(--nav-mobile-menu-position, fixed);
     top: 3rem;
-    /* Span the viewport rather than hugging its content: a content-width panel anchored to
-       one side leaves page text visible right beside the open menu, which reads as a stray
-       box instead of a menu. Hosts wanting the old floating panel can set --nav-mobile-inset
-       to `1rem auto` (or any inset-inline pair) and cap it with a max-width of their own. */
-    inset-inline: var(--nav-mobile-inset, 0.5rem);
+    /* Hug the content and hang off the burger's side rather than spanning the viewport: a
+       full-width bar of mostly empty space reads as a broken layout, and the menu is chrome
+       floating over the page, not a section of it. Capped so a long route label still can't
+       push it off-screen. Hosts wanting the full-width bar can set --nav-mobile-inset to a
+       single value like `0.5rem`. */
+    inset-inline: var(--nav-mobile-inset, 0.5rem auto);
+    width: max-content;
+    max-width: calc(100dvw - 1rem);
     background-color: var(--nav-surface-bg);
     border: 1px solid var(--nav-surface-border);
     box-shadow: var(--nav-surface-shadow);
@@ -776,6 +725,13 @@
     margin: -1pt -8pt;
     padding: 1pt 8pt;
   }
+  /* Same pull-out for dropdown rows, inline-start only — the chevron owns the other end. The
+     link keeps its own --nav-item-padding, which stacked on the row's padding and left every
+     expandable entry indented past its plain siblings. */
+  nav.mobile .dropdown > div:first-child > :is(a, span) {
+    margin-inline-start: -8pt;
+    padding-inline-start: 8pt;
+  }
   /* Mobile separator */
   nav.mobile .menu > .separator {
     width: 100%;
@@ -797,32 +753,84 @@
     border-radius: var(--nav-border-radius);
   }
   nav.mobile .dropdown > div:first-child > button {
-    /* Sit against the row's trailing edge: the row's own padding is the only gap wanted,
-       so the caret's trailing padding would double it */
-    padding: 4pt 0 4pt 8pt;
+    /* The caret is the only way to open a section, so it gets the biggest target the row can
+       give it: full row height via `stretch`, and negative margins pulling it out over the
+       row's own padding so the tap area runs to the painted edge instead of stopping short
+       of it. The padding puts back what the margins take, keeping the glyph where it was. */
+    align-self: stretch;
+    margin: -1pt -8pt -1pt 0;
+    padding: 1pt 8pt 1pt 14pt;
     border-radius: var(--nav-border-radius);
     opacity: 0.6;
   }
   nav.mobile .dropdown > div:first-child > button.open {
     opacity: 1;
   }
+  /* Expand the section rather than switching it on: `display: none` can't transition, so the
+     collapsed state is a zero-height grid row (0fr -> 1fr against the wrapper below) plus a
+     fade. `visibility` rides along because the links stay in the DOM while collapsed and
+     would otherwise keep collecting Tab focus behind a closed section. */
   nav.mobile .dropdown > div:last-child {
     position: static;
     border: none;
     box-shadow: none;
-    margin-top: 2pt;
     padding: 0;
     background-color: transparent;
+    display: grid;
+    grid-template-rows: 0fr;
+    opacity: 0;
+    visibility: hidden;
+    transition:
+      grid-template-rows var(--nav-submenu-duration, 0.25s) ease,
+      opacity var(--nav-submenu-duration, 0.25s) ease,
+      visibility var(--nav-submenu-duration, 0.25s);
+  }
+  nav.mobile .dropdown > div:last-child.visible {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    visibility: visible;
+  }
+  /* The animated row. Its gap above the first link is padding that opens with it, not a
+     margin on the section: `min-height: 0` zeroes the row's content but not its padding, so
+     a static 2pt would sit under every collapsed submenu as a visible sliver. */
+  nav.mobile .submenu-inner {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+    padding-top: 0;
+    transition: padding-top var(--nav-submenu-duration, 0.25s) ease;
+    /* One rule down the whole section instead of one per link: the links abut, so their own
+       borders would nearly join, but the section's opening padding leaves a notch above the
+       first one and the line has to read as a single stroke tying the group to its parent.
+       A hairline sitting close under the parent label — it marks where the section belongs,
+       so it should not compete with the labels beside it. Its own colour rather than
+       --nav-surface-border, which is tuned for a 1px panel edge over the page background,
+       not for a rule over the panel's own fill. */
+    margin-inline-start: 10pt;
+    border-inline-start: 1px solid
+      var(
+        --nav-submenu-line-color,
+        light-dark(rgba(128, 128, 128, 0.55), rgba(200, 200, 200, 0.4))
+      );
+  }
+  nav.mobile .dropdown > div:last-child.visible .submenu-inner {
+    padding-top: 2pt;
   }
   nav.mobile .dropdown > div:last-child a {
-    padding-block: 4pt;
+    padding-block: 2pt;
     padding-inline: 6pt 8pt;
-    /* 8pt of its own indent plus the 8pt the `.dropdown` padding used to contribute */
-    margin-inline-start: 16pt;
-    border-inline-start: 2px solid transparent;
+    /* An inherited 1.6 made every child row taller than the parent it hangs under, which read
+       as a list of headings rather than a nested section. 1.3 is what the top-level rows use. */
+    line-height: 1.3;
+    /* Pull the link's own border onto the wrapper's guide line, so the active row recolours a
+       segment of that line instead of drawing a second one beside it. Same width as the rule
+       it covers, or the two would not line up on both edges. */
+    margin-inline-start: -1px;
+    border-inline-start: 1px solid transparent;
     font-size: 0.9em;
   }
-  nav.mobile .dropdown > div:last-child a:is(:hover, [aria-current='page']) {
+  nav.mobile .dropdown > div:last-child a[aria-current='page'] {
     border-inline-start-color: var(--nav-link-active-color, currentColor);
   }
   /* Mobile right-aligned items stack normally */

--- a/src/lib/NumberRangeInput.svelte
+++ b/src/lib/NumberRangeInput.svelte
@@ -18,18 +18,14 @@
     type NumberRangeInputLabels,
   } from './labels'
 
-  // The same three bounds either way: optional when a schema entry can supply them, required
-  // when nothing else can.
+  // same three bounds either way: optional when a schema can supply them, else required
   type Bounds = { min?: number | string; max?: number | string; step?: number | string }
   type SchemaBounds = Bounds & { setting: string; schema: NumberRangeSchema }
   type ExplicitBounds = Required<Bounds> & { setting?: string; schema?: undefined }
 
-  // Paired number + range input bound to the same value, wrapped in a flex <label>.
-  // The label text/markup is passed as children (supports inline units like <small>Å</small>).
-  // Pass a `title` to show a tooltip; wrapping <label> only names the number input
-  // so the range slider uses that title when present and otherwise gets a fallback name.
-  // Children go in their own <span> so the label is exactly three elements (text, number,
-  // range), which lets a settings pane put every row on one shared column grid.
+  // Paired number + range input on one value in a flex <label>; children carry the label
+  // markup. A wrapping <label> names only the number input, so the slider falls back to
+  // `title`. Children get their own <span> so the row is exactly three grid columns.
   let {
     value = $bindable(),
     setting,
@@ -62,10 +58,8 @@
     max: max ?? setting_config?.maximum,
     step: step ?? setting_config?.multipleOf ?? `any`,
   })
-  // `<input type="range">` with no min/max silently falls back to the spec default 0-100,
-  // while the paired number input stays unbounded. `bind:value` then lets one touch of the
-  // slider clamp and write back a value the caller never limited, destroying it. Fail loudly
-  // instead: a slider with no range is a misconfiguration, not a default.
+  // A range input with no min/max silently defaults to 0-100 while the number input stays
+  // unbounded, so one slider touch clamps and writes back a value the caller never limited.
   $effect(() => {
     if (input_bounds.min === undefined || input_bounds.max === undefined) {
       throw new Error(
@@ -79,8 +73,8 @@
   let resolved_title = $derived(title ?? setting_config?.description)
   const msg = $derived(merge_defaults(NUMBER_RANGE_INPUT_LABELS, labels))
   let range_label = $derived(resolved_title?.trim() || setting?.trim() || msg.value)
-  // With children the wrapping <label> already names the number input and an aria-label would
-  // override that visible text; without them the label is empty, so it needs the fallback too.
+  // With children the <label> already names the number input and an aria-label would override
+  // that visible text; without them the label is empty and needs the fallback.
   const number_label = $derived(children ? undefined : range_label)
 </script>
 

--- a/src/lib/Popover.svelte
+++ b/src/lib/Popover.svelte
@@ -58,8 +58,8 @@
     close_delay_ms?: number
     surface?: HTMLDivElement | null
     role?: PopupRole
-    // Snippets remain owned by the component that declares them. Popover invokes the
-    // trigger and body in that owner's scope; it does not retain either past teardown.
+    // Snippets stay owned by their declaring component; Popover invokes them in that scope
+    // and retains neither past teardown.
     trigger?: Snippet<[TriggerProps]>
     trigger_mode?: TriggerMode
     children: Snippet
@@ -69,8 +69,8 @@
   const surface_id = $derived(id ?? unique_id)
   const native_dismiss = $derived(escape && dismiss_on === `release`)
   let trigger_wrapper = $state<HTMLSpanElement | null>(null)
-  // The wrapper is `display: contents` and has no box of its own — measuring it would
-  // pin every popover to the viewport corner. Anchor to what the snippet rendered.
+  // The `display: contents` wrapper has no box; measuring it would pin every popover to the
+  // viewport corner, so anchor to what the snippet rendered.
   const anchor = $derived(trigger_wrapper?.firstElementChild ?? trigger_wrapper)
   let open_timeout: ReturnType<typeof setTimeout> | undefined
   let close_timeout: ReturnType<typeof setTimeout> | undefined
@@ -101,8 +101,8 @@
     on_close?.({ via })
   }
 
-  // Native auto popovers own light dismissal and Escape. This listener only retains
-  // the non-default reason for on_close; it never performs the dismissal itself.
+  // Native auto popovers own light dismissal and Escape; this only records the close reason
+  // for on_close, never dismisses.
   const track_native_escape = (event: KeyboardEvent) => {
     if (native_dismiss && open && event.key === `Escape`) native_close_via = `escape`
   }

--- a/src/lib/SettingsSearch.svelte
+++ b/src/lib/SettingsSearch.svelte
@@ -166,9 +166,8 @@
       refresh,
       true,
     )
-    // `refresh` reads `query`, so this re-filters on each keystroke. Calling it from the
-    // attachment body instead would re-run the whole attachment, whose teardown unhides
-    // everything and snaps force-opened groups shut between keystrokes.
+    // `refresh` reads `query`, so this re-filters per keystroke; from the attachment body it
+    // would re-run teardown, unhiding everything and snapping force-opened groups shut.
     $effect(refresh)
 
     return () => {
@@ -219,9 +218,9 @@
           class="clear-search"
           aria-label={msg.clear_search}
           onclick={() => {
-            // this button unmounts the moment the query empties, so hand focus back to the
-            // field rather than dropping it on the body. A query the caller supplied leaves
-            // `opened` false, so the field needs pinning open before it can take focus.
+            // This button unmounts once the query empties, so hand focus back to the field
+            // instead of the body — pinned open first, since a caller-supplied query leaves
+            // `opened` false.
             opened = true
             query = ``
             search_input?.focus()
@@ -239,9 +238,8 @@
       >
     {/if}
   </div>
-  <!-- Observe the caller's rows only. Observing the whole component fed our own chrome back
-  into the filter — the clear button mounts and unmounts, the status text rewrites — costing
-  an extra pass per keystroke. `display: contents` keeps this wrapper out of the layout. -->
+  <!-- Observe the caller's rows only: observing the whole component fed our own chrome (clear
+  button, status text) back into the filter, an extra pass per keystroke -->
   <div class="settings-rows" {@attach filter_settings}>{@render children()}</div>
   <!-- Stay mounted so screen readers observe text updates; :empty collapses it. -->
   <p id={status_id} class="no-matches" role="status">
@@ -250,9 +248,8 @@
 </div>
 
 <style>
-  /* Neither the wrapper nor the observed row group should exist as far as layout is
-     concerned — the pane lays our children out directly. Only the corner trigger needs a
-     positioning context, so only that mode opts into being a box. */
+  /* Wrapper and row group are layout-invisible so the pane lays our children out directly;
+     only the corner trigger needs a positioning context, so only it becomes a box. */
   .settings-search.inline,
   .settings-rows {
     display: contents;

--- a/src/lib/SettingsSection.svelte
+++ b/src/lib/SettingsSection.svelte
@@ -31,23 +31,21 @@
     title: string
     // the Explain/Reset strings; the interpolating ones receive `title` verbatim
     labels?: Partial<SettingsSectionLabels>
-    // Omit for a section that only holds actions (export buttons, say) and has nothing to diff.
-    // Values may be primitives, arrays, plain objects, Date, or RegExp. Map, Set, and typed
-    // arrays are unsupported because reset snapshots and comparisons only cover these shapes.
+    // Omit for action-only sections with nothing to diff. Values may be primitives, arrays,
+    // plain objects, Date or RegExp; Map, Set and typed arrays are unsupported.
     current_values?: Record<string, unknown>
-    // Optional reset baseline. Keys absent from this object are treated as additions and
-    // removed when reset; keys not present in current_values are ignored.
+    // Reset baseline: keys absent here count as additions and are removed on reset; keys not
+    // in current_values are ignored.
     reset_values?: Record<string, unknown>
     children: Snippet
-    // `grid` puts every direct label/.setting row on one shared [label][value][wide control]
-    // column rhythm, so controls line up down the whole section instead of starting wherever
-    // each row's label text happens to end. `flow` leaves layout to the caller.
+    // `grid` aligns every direct label/.setting row on one [label][value][wide control]
+    // rhythm instead of wherever each label's text ends; `flow` leaves layout to the caller.
     layout?: `flow` | `grid`
-    // Omit to reset every changed key through `on_reset_key`. Pass one only for sections whose
-    // reset has to do more than restore values (clearing validation state, for instance).
+    // Omit to reset every changed key through `on_reset_key`. Pass one only when reset has to
+    // do more than restore values (clearing validation state, say).
     on_reset?: () => void
-    // Rows opt in with `data-key`. The callback receives the mounted reference value and
-    // whether that key originally existed, so callers can restore or delete it exactly.
+    // Rows opt in with `data-key`. Receives the mounted reference value and whether that key
+    // originally existed, so callers can restore or delete it exactly.
     on_reset_key?: (
       key: string,
       reference_value: unknown,
@@ -103,7 +101,7 @@
     )
   })
 
-  // unique per-instance id so aria-labelledby stays valid with multiple sections on a page
+  // per-instance id so aria-labelledby stays valid with multiple sections on a page
   const section_id = $props.id()
   const title_id = `settings-section-title-${section_id}`
 
@@ -138,8 +136,7 @@
     )
   }
 
-  // Key presence is independent of value: additions/removals count even when the
-  // value is undefined. Only compare values when both sides own the key.
+  // Key presence counts on its own: additions/removals differ even when the value is undefined
   const changed_keys = $derived.by(() => {
     validate_value_shape(current_values)
     return Object.keys({ ...reference_values, ...current_values }).filter(
@@ -168,17 +165,16 @@
 
   const handle_reset = swallow_click(() => {
     if (on_reset) on_reset()
-    // Snapshot first: each reset_key shrinks changed_keys as the caller writes the value back
+    // snapshot: each reset_key shrinks changed_keys as the caller writes the value back
     else for (const key of changed_keys.slice()) reset_key(key)
   })
 
   const DESCRIPTION_SELECTOR = `:scope > .settings-row-description`
   const RESET_SELECTOR = `:scope > .setting-reset-button`
 
-  // A <label> only names its first control, so the slider paired with a number input would go
-  // unnamed. Mark every control we name with the exact text used: that is enough to rename or
-  // revoke it on a later pass without keeping a registry of elements, and it works on rows
-  // Svelte has already detached.
+  // A <label> only names its first control, so a slider paired with a number input goes
+  // unnamed. Recording the text we set lets a later pass rename or revoke it registry-free,
+  // even on rows Svelte already detached.
   const AUTO_LABEL_ATTR = `data-auto-label`
 
   const release_auto_label = (control: Element): void => {
@@ -188,22 +184,19 @@
     control.removeAttribute(AUTO_LABEL_ATTR)
   }
 
-  // Enhance only explicitly keyed rows. Callers that omit both opt-in props never attach this
-  // behavior, preserving the historical DOM and event handling.
+  // Only explicitly keyed rows are enhanced; without either opt-in prop the DOM is untouched.
   const enhance_rows = (section: HTMLElement): (() => void) => {
-    // The only thing worth remembering per row: everything else we add is findable in the row
-    // itself, and a cached node goes stale the moment Svelte re-renders around it. Deliberately
-    // a plain Map, not a SvelteMap: `refresh` runs inside an effect and both reads and writes
-    // this, which reactive entries turn into an endless loop.
+    // Plain Map, not SvelteMap: `refresh` reads and writes this inside an effect, which
+    // reactive entries would turn into an endless loop.
     const original_descriptions = new Map<HTMLElement, string | null>()
-    // What this attachment last wrote to each row's `data-description`. Anything else on
-    // the attribute came from the caller, and re-snapshots rather than being overwritten.
+    // What this attachment last wrote to each row's `data-description`; anything else on the
+    // attribute came from the caller and is re-snapshotted rather than overwritten.
     const written_descriptions = new Map<HTMLElement, string | null>()
 
     const remove_reset_button = (row: HTMLElement): void => {
       const button = row.querySelector(RESET_SELECTOR)
-      // Resetting a value is what removes this button, so a keyboard user who just pressed
-      // it would be left with focus on <body>. Hand focus to the row's own control instead.
+      // Resetting removes this button, so a keyboard user who just pressed it would land on
+      // <body>. Hand focus to the row's own control instead.
       const had_focus = button !== null && button === document.activeElement
       button?.remove()
       row.classList.remove(`has-setting-reset`)
@@ -223,8 +216,8 @@
       else row.setAttribute(`data-description`, original)
     }
 
-    // `data-label` short-circuits the clone, which only exists to strip the controls and our
-    // own appended description out of the row's text before reading it.
+    // `data-label` short-circuits the clone, which only strips controls and our own appended
+    // description out of the row's text.
     const label_text = (row: HTMLLabelElement): string => {
       let text = row.dataset.label
       if (text === undefined) {
@@ -243,8 +236,7 @@
       const label = row instanceof HTMLLabelElement ? label_text(row) : ``
       for (const control of row.querySelectorAll(`input, select, textarea`)) {
         const marker = control.getAttribute(AUTO_LABEL_ATTR)
-        // An author-set name always wins, whether it was there first or replaced ours: any
-        // name that is not the one we recorded is theirs, so drop our claim and leave it be.
+        // An author-set name always wins: any name other than the one we recorded is theirs
         if (control.getAttribute(`aria-label`) !== marker) {
           control.removeAttribute(AUTO_LABEL_ATTR)
           continue
@@ -261,25 +253,22 @@
     const enhance_row = (row: HTMLElement): boolean => {
       const key = row.dataset.key
       if (!key) return false
-      // Re-snapshot whenever the attribute holds something we did not write: that is the
-      // caller updating a reactive `data-description`, and keeping the mount-time value
-      // would write their new text straight back out on the next refresh.
-      // `getAttribute` returns string|null, never undefined, so an unseen row differs from
-      // its absent `written` entry and is snapshotted by the same comparison.
+      // Re-snapshot whenever the attribute holds something we did not write: the caller
+      // updated a reactive `data-description` and the mount-time value would clobber it.
+      // getAttribute returns null, never undefined, so an unseen row snapshots here too.
       const current_description = row.getAttribute(`data-description`)
       if (current_description !== written_descriptions.get(row)) {
         original_descriptions.set(row, current_description)
       }
       sync_labeled_controls(row)
 
-      // `setting_metadata` overrides the row's own `data-description`, which is restored
-      // whenever the mapping drops the key again.
+      // `setting_metadata` overrides the row's `data-description`, restored if the key drops
       const metadata = setting_metadata?.[key]
       const description =
         (typeof metadata === `string` ? metadata : metadata?.description) ??
         original_descriptions.get(row)
-      // Write only on a real change: `setAttribute` queues a mutation record even when the
-      // value is identical, and SettingsSearch observes this attribute.
+      // Write only on real change: setAttribute queues a mutation record even for an identical
+      // value, and SettingsSearch observes this attribute.
       const next_description = description || null
       if (next_description !== current_description) {
         if (next_description) row.setAttribute(`data-description`, next_description)
@@ -295,8 +284,8 @@
           description_element.className = `settings-row-description`
           row.append(description_element)
         }
-        // Avoid notifying our own subtree observer forever: assigning textContent replaces
-        // the text node even when the string is unchanged.
+        // assigning textContent replaces the node even when unchanged, which would notify
+        // our own subtree observer forever
         if (description_element.textContent !== description) {
           description_element.textContent = description
         }
@@ -346,8 +335,7 @@
       refresh,
     )
     // `refresh` reads `changed_keys`, `descriptions_open` and `setting_metadata`, so this
-    // re-enhances when they change. Calling it from the attachment body instead would re-run
-    // the whole attachment, tearing every reset button and description back off first.
+    // re-enhances on change; from the attachment body it would tear everything off first.
     $effect(refresh)
 
     return () => {
@@ -399,8 +387,7 @@
 </section>
 
 <style>
-  /* A flex row rather than absolutely positioned actions, so a long title is squeezed by the
-     buttons instead of running underneath them. */
+  /* flex row, not absolute actions, so a long title is squeezed instead of running under them */
   .settings-section-heading {
     display: flex;
     align-items: center;
@@ -489,8 +476,8 @@
     gap: var(--settings-row-gap, 4pt) 0;
     align-content: start;
   }
-  /* --ctrl-cols is published so a pane can give the same rhythm to rows it nests one level
-     deeper (grouped axis rows, say) without restating the track list. */
+  /* --ctrl-cols is published so panes can give nested rows the same rhythm without restating
+     the track list */
   section.grid > :global(:is(label, .setting)) {
     display: grid;
     grid-template-columns: var(

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -7,8 +7,8 @@
   import type { ToastItem, ToastPosition, ToastStore } from './toast-queue.svelte.ts'
   import { chain_handlers } from './utils'
 
-  // Priorities are widened to `string` throughout: the component renders whatever
-  // ladder its store was built with and never ranks anything itself.
+  // Priorities are widened to `string`: this renders whatever ladder its store was built
+  // with and never ranks anything itself.
   let {
     store = default_store,
     position = `bottom-right`,
@@ -28,8 +28,8 @@
     dismissible?: boolean
     // Hovering suspends the countdown. Focus always does, hover or not.
     pause_on_hover?: boolean
-    // Moves the keyboard to the toast's own controls from anywhere on the page, since a
-    // toast lives at the end of the DOM and Tab may be a long way from it. `null` opts out.
+    // Jumps the keyboard to the toast's controls, which sit at the end of the DOM and can be
+    // a long Tab away. `null` opts out.
     focus_hotkey?: string | string[] | null
     // Rendered into the assertive live region, interrupting whatever is being read.
     // Defaults to the store's sticky priorities, so urgency tracks what stays on screen.
@@ -45,16 +45,15 @@
   let [is_hovered, is_focused] = $state([false, false])
 
   const active_toast = $derived(store.active_toast)
-  // read off the store's own sticky set, not a second copy of its top-two rule: a toast
-  // held on screen until dismissed has to interrupt, or it can sit there unread. Deriving
-  // it here let a custom sticky_priorities be announced politely while never leaving.
+  // Read off the store's own sticky set, not a copy of its rule: a toast held until
+  // dismissed must interrupt, or it can sit there unread.
   const assertive_priorities = $derived(assertive ?? store.sticky_priorities)
   const is_assertive = $derived(
     active_toast !== null && assertive_priorities.includes(active_toast.priority),
   )
 
-  // `is_hovered` records where the pointer is; pause_on_hover is policy applied on top, so
-  // flipping the prop over an already-hovered stack takes effect without a fresh enter
+  // pause_on_hover is applied on top of the recorded pointer state, so flipping the prop over
+  // an already-hovered stack takes effect without a fresh enter
   const should_pause = $derived((is_hovered && pause_on_hover) || is_focused)
   // Called straight from the handlers, not left to the effect below: an effect flushes a
   // microtask later, and a toast whose timer expires in between is already gone.
@@ -67,16 +66,15 @@
     is_focused = value
     sync_pause()
   }
-  // Covers what the handlers cannot: a toast promoted under a pointer that never left has
-  // no enter event, and flipping pause_on_hover fires none at all. pause()/resume() both
-  // early-return when there is nothing to do, so the queue change they cause settles.
+  // Covers what the handlers cannot: a toast promoted under a stationary pointer fires no
+  // enter event, and flipping pause_on_hover fires none at all.
   $effect(() => {
     void should_pause // pinned as a dependency, so a bare prop flip re-runs this too
     if (active_toast) untrack(sync_pause)
   })
 
-  // Where the keyboard was before focus_hotkey pulled it in: removing the toast unmounts
-  // the button holding focus, which would otherwise drop it on <body>.
+  // Where the keyboard was before focus_hotkey pulled it in: removing the toast unmounts the
+  // focused button, which would otherwise drop focus on <body>.
   let focus_origin: HTMLElement | null = null
 
   const focus_toast = () => {
@@ -94,8 +92,8 @@
     const origin = focus_origin
     focus_origin = null
     await tick() // the toast that had focus is gone only after the DOM catches up
-    // Only reclaim focus the toast still holds, or that its removal dropped on <body>:
-    // once the user has tabbed elsewhere, yanking them back is worse than not restoring.
+    // Only reclaim focus the toast still holds or dropped on <body>: once the user tabbed
+    // elsewhere, yanking them back is worse than not restoring.
     const holder = document.activeElement ?? document.body
     if (origin && (holder === document.body || stack?.contains(holder))) origin.focus()
     // Removing the focused button fires no focusout, so re-derive the focus pause or the
@@ -103,10 +101,8 @@
     set_focused(Boolean(stack?.contains(document.activeElement)))
   }
 
-  // The buttons below restore focus themselves, since dismissing one toast can promote
-  // the next and leave `active_toast` non-null. This covers every other way the last toast
-  // leaves — an absolute deadline that focus cannot pause, or the consumer clearing the
-  // queue — where there is no click to hang the restore off.
+  // The buttons restore focus themselves (dismissing can promote the next toast, leaving
+  // `active_toast` non-null); this covers the clickless exits: deadline or queue clear.
   $effect(() => {
     if (!active_toast) void restore_focus()
   })
@@ -125,9 +121,8 @@
       ? [{ keys: focus_hotkey, allow_in_inputs: true, handler: focus_toast }]
       : [],
   )
-  // Scoped to the stack, so Escape only dismisses when the keyboard is already in the
-  // toast — a global Escape would fight every dialog for the same key. Gated on
-  // `dismissible` too, or it stays the one way to close a toast declared undismissable.
+  // Scoped to the stack so a global Escape doesn't fight every dialog, and gated on
+  // `dismissible` or it stays the one way to close an undismissable toast.
   const escape_binding = $derived(
     active_toast && dismissible
       ? [{ keys: `Escape`, handler: () => dismiss(active_toast.id) }]
@@ -144,8 +139,8 @@
       <span class="toast-message" style="min-width: 0">{item.message}</span>
     {/if}
     {#if count > 0}
-      <!-- aria-atomic makes the region read the whole card, so an aria-label here would
-      splice the badge's wording into the message. The count is announced separately. -->
+      <!-- aria-atomic reads the whole card, so an aria-label here would splice the badge's
+      wording into the message; the count is announced separately -->
       <span class="toast-pending" aria-hidden="true">+{count}</span>
       <span class="sr-only">{msg.pending(count)}</span>
     {/if}
@@ -165,10 +160,8 @@
   </div>
 {/snippet}
 
-<!-- Both regions stay mounted and empty rather than being created with their first
-toast: a live region inserted at the same moment as its content is announced by only
-some screen readers. Two of them, because swapping aria-live on one region mid-flight
-is just as unreliable. -->
+<!-- Both regions stay mounted and empty: a live region inserted together with its content is
+announced by only some screen readers, and swapping aria-live mid-flight is as unreliable -->
 <div
   bind:this={stack}
   {...rest}
@@ -201,8 +194,7 @@ is just as unreliable. -->
     flex-direction: column;
     gap: var(--toast-gap, 0.4em);
     max-width: var(--toast-max-width, min(90vw, 28rem));
-    /* the empty region is a zero-height box, but the stack still spans the viewport
-    edge, so it must not swallow presses meant for the page underneath */
+    /* the stack spans the viewport edge even when empty, so it must not swallow presses */
     pointer-events: none;
     &[data-position^='top'] {
       top: var(--toast-inset, 1rem);

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -42,6 +42,7 @@
     nav = $bindable(),
     open = $bindable(false),
     openButtonLabel = `Open table of contents`,
+    closeButtonLabel = `Close table of contents`,
     reactToKeys = [`ArrowDown`, `ArrowUp`, ` `, `Enter`, `Escape`, `Tab`],
     scrollBehavior = `smooth`,
     title = `On this page`,
@@ -84,6 +85,9 @@
     nav?: HTMLElement | undefined
     open?: boolean
     openButtonLabel?: string
+    // the toggle stays put and becomes a close button while the panel is open, so it needs
+    // a second name — same shape as Nav's burger, which is the other pinned mobile toggle
+    closeButtonLabel?: string
     reactToKeys?: false | string[]
     scrollBehavior?: `auto` | `smooth`
     title?: string
@@ -108,6 +112,22 @@
     openButtonIconProps?: SVGAttributes<SVGSVGElement>
   } = $props()
 
+  // An indented bullet list, not a burger: the burger is Nav's, and two identical glyphs
+  // pinned to the same phone screen say nothing about which one opens what. Three rows at
+  // two indent levels is what a table of contents looks like.
+  // The list glyph's viewBox is cropped to its own path bounds so it renders at the button's
+  // full width, like the burger's bars do. The X keeps a roomier box: Nav folds its bars into
+  // an X spanning ~17.9px, and one drawn edge to edge across the same 22.4px button would be
+  // the larger of the two close buttons on a page showing both. Each stroke-width is the one
+  // that lands on Nav's 0.18rem bars once its own box is scaled to the button.
+  const TOGGLE_ICONS = {
+    closed: {
+      view_box: `1.9 3.9 16.2 12.2`,
+      stroke_width: 2.1,
+      path: `M3 5h.01M7 5h10M6 10h.01M10 10h7M6 15h.01M10 15h7`,
+    },
+    open: { view_box: `2.5 2.5 15 15`, stroke_width: 1.95, path: `M5 5l10 10M15 5L5 15` },
+  }
   // fallback to clear scroll_target if scrollend never fires (e.g. no scroll needed)
   const scroll_target_fallback_ms = 1000
   // distance increase (px) that counts as the user manually scrolling away from a target
@@ -696,7 +716,10 @@
     node.toggleAttribute(`inert`, is_overlapping_hide_target)
   }}
 >
-  {#if !open && !desktop && headings.length >= minItems}
+  <!-- The toggle stays mounted while open and becomes the close button, matching Nav's
+  burger. Unmounting it left the panel with no visible way out — only an outside click,
+  Escape or a tab-out, none of which a touch user can see. -->
+  {#if !desktop && headings.length >= minItems}
     <button
       {...openButtonProps}
       onclick={(event) => {
@@ -704,18 +727,32 @@
         if (event.defaultPrevented) return
         event.stopPropagation()
         event.preventDefault()
-        set_open(true, `button`)
+        set_open(!open, `button`)
       }}
       type="button"
-      aria-label={openButtonLabel}
+      aria-expanded={open}
+      aria-label={open ? closeButtonLabel : openButtonLabel}
     >
       {#if openTocIcon}{@render openTocIcon()}{:else}
-        <!-- https://iconify.design/icon-sets/heroicons-solid/menu.html -->
-        <svg width="1em" {...openButtonIconProps} viewBox="0 0 20 20" fill="currentColor">
-          <path
-            d="M3 5a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H4a1 1 0 0 1-1-1zm0 5a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H4a1 1 0 0 1-1-1zm0 5a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H4a1 1 0 0 1-1-1z"
-          />
-        </svg>
+        <!-- Both glyphs stay mounted and cross-fade, so the toggle animates on open/close
+        the way Nav's burger morphs into its X instead of swapping in one frame. -->
+        {#each Object.entries(TOGGLE_ICONS) as [state, icon] (state)}
+          <svg
+            width="1em"
+            height="1em"
+            {...openButtonIconProps}
+            viewBox={icon.view_box}
+            fill="none"
+            stroke="currentColor"
+            stroke-width={icon.stroke_width}
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class:shown={open === (state === `open`)}
+            aria-hidden="true"
+          >
+            <path d={icon.path} />
+          </svg>
+        {/each}
       {/if}
     </button>
   {/if}
@@ -778,6 +815,20 @@
 
 <style>
   :where(aside.toc) {
+    /* A ToC row and a Nav row are the same thing to a reader — a link that lights up under
+       the pointer — so they share one hover language: Nav's --nav-link-bg-hover colour, its
+       --nav-border-radius and its 0.2s background fade. These are the fallbacks behind the
+       public --toc-li-* tokens, which still win. */
+    --toc-item-hover-bg: light-dark(rgba(70, 70, 140, 0.2), rgba(120, 170, 255, 0.2));
+    --toc-item-radius: 3pt;
+    /* shared by the mobile panel and its toggle so the two read as one surface. Values match
+       Nav's --nav-surface-* so a page showing both toggles gets one visual language. */
+    --toc-surface-border: 1px solid
+      light-dark(rgba(128, 128, 128, 0.25), rgba(200, 200, 200, 0.2));
+    --toc-surface-shadow: light-dark(
+      0 2px 8px rgba(0, 0, 0, 0.15),
+      0 4px 12px rgba(0, 0, 0, 0.5)
+    );
     box-sizing: border-box;
     height: max-content;
     overflow-wrap: break-word;
@@ -812,11 +863,11 @@
     color: var(--toc-li-color);
     background: var(--toc-li-bg);
     border: var(--toc-li-border);
-    border-radius: var(--toc-li-border-radius);
+    border-radius: var(--toc-li-border-radius, var(--toc-item-radius));
     margin: var(--toc-li-margin);
     padding: var(--toc-li-padding, 2pt 4pt);
     font: var(--toc-li-font);
-    transition: var(--toc-li-transition);
+    transition: var(--toc-li-transition, background-color 0.2s);
   }
   :where(aside.toc > nav > ol > li > a) {
     color: inherit;
@@ -845,10 +896,6 @@
     padding-block: 0;
     margin-block: 0;
   }
-  aside.toc > nav > ol > li:hover {
-    color: var(--toc-li-hover-color);
-    background: var(--toc-li-hover-bg);
-  }
   aside.toc > nav > ol > li.active {
     background: var(--toc-active-bg);
     color: var(--toc-active-color);
@@ -856,39 +903,102 @@
     text-shadow: var(--toc-active-text-shadow);
     border: var(--toc-active-border);
     border-width: var(--toc-active-border-width);
-    border-radius: var(--toc-active-border-radius, 2pt);
+    border-radius: var(--toc-active-border-radius, var(--toc-item-radius));
   }
+  /* After `.active`, not before: the two selectors have equal specificity, so source order
+     decides, and the active row is the one most likely to be hovered. Nav's active row keeps
+     its hover fill too (there, active is a text colour), and an unset --toc-active-bg made
+     `background` invalid on that row, which swallowed the hover fill entirely. */
+  aside.toc > nav > ol > li:hover {
+    color: var(--toc-li-hover-color);
+    background: var(--toc-li-hover-bg, var(--toc-item-hover-bg));
+  }
+  /* Cosmetics stay in `:where()` so a host can restyle the toggle without fighting
+     specificity. Its box does not: see the structural rule below. */
   :where(aside.toc > button) {
-    border: none;
-    bottom: var(--toc-mobile-btn-bottom, 0);
     cursor: pointer;
-    font: var(--toc-mobile-btn-font, 2em sans-serif);
+    font: var(--toc-mobile-btn-font, 1.4rem sans-serif);
     line-height: var(--toc-mobile-btn-line-height, 0);
-    position: absolute;
+    /* relative, not absolute: the aside lays both children out now, but these two vars are
+       public and still have to be able to nudge the toggle off its flex slot */
+    position: relative;
+    bottom: var(--toc-mobile-btn-bottom, 0);
     right: var(--toc-mobile-btn-right, 0);
     z-index: var(--toc-mobile-btn-z-index, 2);
-    padding: var(--toc-mobile-btn-padding, 2pt 3pt);
-    border-radius: var(--toc-mobile-btn-border-radius, 4pt);
-    background: var(--toc-mobile-btn-bg, rgba(255, 255, 255, 0.2));
-    color: var(--toc-mobile-btn-color, black);
+    border: var(--toc-mobile-btn-border, var(--toc-surface-border));
+    border-radius: var(--toc-mobile-btn-border-radius, 6pt);
+    background: var(--toc-mobile-btn-bg, var(--toc-mobile-bg, rgba(255, 255, 255, 0.2)));
+    color: var(--toc-mobile-btn-color, var(--text, black));
+    box-shadow: var(--toc-mobile-btn-shadow, var(--toc-surface-shadow));
+  }
+  /* A 1.4rem glyph in a 0.3rem-padded box, matching Nav's burger: the two are the only pinned
+     mobile toggles a page has, and at different sizes they read as unrelated chrome. Not
+     `:where()`, for the same reason as the `ol` rule below — a host `button { padding }` reset
+     outweighs a zero-specificity selector and silently resized the hit target. Tune it with
+     --toc-mobile-btn-padding / --toc-mobile-btn-font, which still win. */
+  aside.toc > button {
+    display: grid;
+    place-items: center;
+    box-sizing: content-box;
+    /* 1em so the box tracks --toc-mobile-btn-font, which the icon already sizes itself from */
+    width: 1em;
+    height: 1em;
+    padding: var(--toc-mobile-btn-padding, 0.3rem);
+  }
+  /* Both glyphs share the single grid cell and swap by opacity + quarter turn, matching the
+     0.2s linear the burger's bars use to fold into their X. */
+  aside.toc > button > svg {
+    grid-area: 1 / 1;
+    opacity: 0;
+    transform: rotate(-90deg) scale(0.7);
+    transition:
+      opacity var(--toc-mobile-btn-transition-duration, 0.2s) linear,
+      transform var(--toc-mobile-btn-transition-duration, 0.2s) linear;
+  }
+  aside.toc > button > svg.shown {
+    opacity: 1;
+    transform: none;
   }
   :where(aside.toc > nav > .toc-title) {
     margin-top: var(--toc-title-margin-top, 0);
   }
+  /* column-reverse against the DOM order [button, nav] keeps the toggle pinned in the corner
+     and opens the panel upward above it. Both children used to be absolutely positioned off
+     this zero-size anchor, which stacked them on top of each other once the toggle stopped
+     unmounting on open. */
   aside.toc.mobile {
     position: fixed;
     bottom: var(--toc-mobile-bottom, 1em);
     right: var(--toc-mobile-right, 1em);
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: end;
+    gap: var(--toc-mobile-gap, 0.5em);
+    /* override the desktop --toc-width the base rule applies: on mobile the aside is just a
+       corner anchor and has to size to whichever of the panel or the toggle is wider */
+    width: max-content;
+    /* a long page's toc outgrows a phone screen, and a fixed panel can't scroll with the
+       document, so cap the whole stack against the viewport and let the panel scroll inside */
+    max-height: calc(100dvh - 2 * var(--toc-mobile-bottom, 1em));
+    max-width: calc(100dvw - 2 * var(--toc-mobile-right, 1em));
   }
   aside.toc.mobile > nav {
-    border-radius: var(--toc-mobile-border-radius, 3pt);
-    right: var(--toc-mobile-right, 1em);
-    z-index: -1;
+    /* the desktop 3em inset makes room for the sticky column's left gutter; in a floating
+       panel it is just a blank band down the left of every entry */
+    padding: var(--toc-mobile-padding, 0.5em 1em 1em);
+    border-radius: var(--toc-mobile-border-radius, 6pt);
     box-sizing: border-box;
     background: var(--toc-mobile-bg, white);
     width: var(--toc-mobile-width, 18em);
-    box-shadow: var(--toc-mobile-shadow);
-    border: var(--toc-mobile-border);
+    max-width: 100%;
+    /* flex items floor at their content height without this, so a tall toc would push the
+       toggle off the bottom of the screen instead of scrolling */
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    z-index: var(--toc-mobile-z-index, 2);
+    box-shadow: var(--toc-mobile-shadow, var(--toc-surface-shadow));
+    border: var(--toc-mobile-border, var(--toc-surface-border));
   }
   aside.toc.desktop {
     position: sticky;

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -16,6 +16,7 @@
     unique_heading_id,
   } from './heading-anchors'
   import { get_heading_visibility } from './toc-utils'
+  import { is_editable_event_target } from './utils'
 
   let {
     activeHeading = $bindable(null),
@@ -622,7 +623,10 @@
     const focused = document.activeElement
     const focus_is_idle =
       !focused || focused === document.body || focused === document.documentElement
-    if (!focus_is_idle && !nav?.contains(focused)) return
+    // a text field owns its arrows even when a custom tocItem renders it inside nav
+    const key_belongs_elsewhere =
+      !nav?.contains(focused) || is_editable_event_target(focused)
+    if (!focus_is_idle && key_belongs_elsewhere) return
 
     event.preventDefault()
     const current_toc_li = activeTocLi ?? nav?.querySelector<HTMLLIElement>(`li.active`)

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -615,12 +615,10 @@
       set_open(false, `escape`)
       return
     }
-    // Everything below drives the toc's own list and preventDefaults to do it, which cancels
-    // the activation of whatever else has focus: with the panel open (or the desktop toc merely
-    // hovered) every button on the page went dead to Enter, arrows stopped moving the caret in
-    // a text field, and the toc's own toggle re-activated the current heading instead of
-    // closing. Only run while focus is idle or already inside the list. Escape and Tab are
-    // handled above, so the panel still closes from anywhere.
+    // the list navigation below preventDefaults, which cancelled the activation of whatever
+    // else held focus: every page button went dead to Enter while the panel was open, and
+    // arrows stopped moving the caret in a text field. Escape and Tab are handled above, so
+    // the panel still closes from anywhere.
     const focused = document.activeElement
     const focus_is_idle =
       !focused || focused === document.body || focused === document.documentElement

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -68,11 +68,11 @@
     activeHeadingScrollOffset?: number
     activeTocLi?: HTMLLIElement | null
     aside?: HTMLElement | undefined
-    breakpoint?: number // in pixels (smaller window width is considered mobile, larger is desktop)
+    breakpoint?: number // px window width below which the ToC switches to mobile
     desktop?: boolean
     flash_clicked_headings_for_ms?: number
     getHeadingData?: (node: HTMLHeadingElement) => TocHeadingData | null
-    // the result of document.querySelectorAll(headingSelector). can be useful for binding
+    // the querySelectorAll(headingSelector) result, exposed for binding
     headings?: HTMLHeadingElement[]
     headingSelector?: string
     excludeSelector?: string
@@ -85,17 +85,15 @@
     nav?: HTMLElement | undefined
     open?: boolean
     openButtonLabel?: string
-    // the toggle stays put and becomes a close button while the panel is open, so it needs
-    // a second name — same shape as Nav's burger, which is the other pinned mobile toggle
+    // the toggle stays put and becomes the close button while open, so it needs a second name
     closeButtonLabel?: string
     reactToKeys?: false | string[]
     scrollBehavior?: `auto` | `smooth`
     title?: string
     tocItems?: HTMLLIElement[]
     warnOnEmpty?: boolean
-    // collapse subheadings under inactive parent headings
-    // true = full nested collapse (each level collapses independently)
-    // 'h3' = h3 is deepest collapsing level, h4+ expand together when h3 ancestor visible
+    // collapse subheadings under inactive parents. true = every level collapses
+    // independently; 'h3' = deepest collapsing level, h4+ expand with their h3 ancestor
     collapseSubheadings?: CollapseMode
     slugifyHeading?: SlugifyHeading
     blurParams?: BlurParams | null | undefined
@@ -112,14 +110,10 @@
     openButtonIconProps?: SVGAttributes<SVGSVGElement>
   } = $props()
 
-  // An indented bullet list, not a burger: the burger is Nav's, and two identical glyphs
-  // pinned to the same phone screen say nothing about which one opens what. Three rows at
-  // two indent levels is what a table of contents looks like.
-  // The list glyph's viewBox is cropped to its own path bounds so it renders at the button's
-  // full width, like the burger's bars do. The X keeps a roomier box: Nav folds its bars into
-  // an X spanning ~17.9px, and one drawn edge to edge across the same 22.4px button would be
-  // the larger of the two close buttons on a page showing both. Each stroke-width is the one
-  // that lands on Nav's 0.18rem bars once its own box is scaled to the button.
+  // a list glyph, not a burger: Nav owns the burger, and two identical pinned glyphs say
+  // nothing about which opens what. The list viewBox is cropped to its path bounds so it
+  // fills the button; the X keeps a roomier box so it stays smaller than Nav's ~17.9px X.
+  // Stroke widths are the ones landing on Nav's 0.18rem bars once scaled to the button.
   const TOGGLE_ICONS = {
     closed: {
       view_box: `1.9 3.9 16.2 12.2`,
@@ -138,32 +132,26 @@
     event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey
 
   let window_width: number = $state(0)
-  // page_has_scrolled controls ignoring spurious scrollend events on page load before any actual
-  // scrolling in chrome. see https://github.com/janosh/svelte-toc/issues/57
+  // ignores spurious scrollend events chrome fires on page load before any real scrolling
+  // see https://github.com/janosh/svelte-toc/issues/57
   let page_has_scrolled: boolean = $state(false)
-  // tracks whether TOC overlaps with any hideOnIntersect elements (desktop only)
+  // desktop only
   let is_overlapping_hide_target: boolean = $state(false)
-  // tracks the target heading during programmatic scrolls (click/keyboard-initiated)
-  // prevents scroll events from incorrectly updating activeHeading during smooth scroll
+  // target of a programmatic scroll; keeps scroll events from moving activeHeading to
+  // intermediate headings while a smooth scroll is under way
   let scroll_target: HTMLHeadingElement | null = $state(null)
-  // fallback timeout to clear scroll_target if scrollend doesn't fire
-  // (e.g., no scroll needed, or browser doesn't support scrollend)
   let scroll_target_timeout: ReturnType<typeof setTimeout> | null = null
-  // tracks previous distance to scroll_target to detect manual scroll direction
-  // initialized to Infinity so first scroll event always passes the "distance increasing" check
+  // Infinity so the first scroll event always passes the "distance increasing" check
   let prev_scroll_target_distance: number = Infinity
   // cache selector validity (keyed by `name:selector`) to avoid re-querying every update
   let selector_validity: Record<string, boolean> = {}
-  // tracks which invalid collapseSubheadings values were already warned about
   let collapse_mode_warned: Record<string, boolean> = {}
   let last_reported_open: boolean | undefined = undefined
   let heading_data: TocHeadingData[] = $state([])
-  // whether update_toc_headings has completed a pass. without this, a page that genuinely
-  // has no headings can't tell its first run apart from "nothing changed", since both
-  // compare an empty query result against the empty initial headings array.
+  // without this a heading-less page can't tell its first update_toc_headings pass apart
+  // from "nothing changed": both compare an empty query result against an empty headings
   let headings_initialized = false
 
-  // helper to clear scroll_target state and cancel fallback timeout
   function clear_scroll_target() {
     if (scroll_target_timeout) {
       clearTimeout(scroll_target_timeout)
@@ -186,8 +174,8 @@
 
   function event_targets_custom_interactive(event: LiEvent) {
     if (!tocItem || !(event.target instanceof Element)) return false
-    // only bypass scroll-to-heading when the event lands on an interactive element
-    // nested *inside* the li; fallback li semantics must not count as custom content
+    // only bypass scroll-to-heading for an interactive element nested *inside* the li;
+    // the li's own fallback semantics must not count as custom content
     const interactive = event.target.closest(custom_interactive_selector)
     return interactive !== null && interactive !== event.currentTarget
   }
@@ -195,9 +183,8 @@
   let levels: number[] = $derived(heading_data.map(({ level }) => level))
   let min_level: number = $derived(levels.length ? Math.min(...levels) : 0)
 
-  // the CollapseMode type only permits h2-h6, so a bad level is reachable only from
-  // untyped callers. warn (once per value, like selector_is_valid) and fall back to no
-  // collapsing rather than quietly picking some threshold off a NaN.
+  // CollapseMode only permits h2-h6, so a bad level means an untyped caller. Warn once per
+  // value and disable collapsing rather than picking a threshold off a NaN.
   function normalize_collapse_mode(mode: CollapseMode): CollapseMode {
     if (typeof mode !== `string`) return mode
     const heading_level = Number(mode.slice(1))
@@ -212,8 +199,7 @@
     return false
   }
 
-  // every consumer reads this rather than the raw prop, so an invalid value disables
-  // collapsing everywhere instead of only zeroing out the threshold
+  // read this, never the raw prop, so an invalid value disables collapsing everywhere
   let collapse_mode: CollapseMode = $derived(normalize_collapse_mode(collapseSubheadings))
 
   function get_collapse_threshold(mode: CollapseMode): number {
@@ -222,10 +208,8 @@
     return Number(mode.slice(1))
   }
 
-  // Collapse threshold: true -> 6 (full nesting), 'h3' -> 3, false -> Infinity
   let collapse_threshold: number = $derived(get_collapse_threshold(collapse_mode))
 
-  // Memoized visibility array - computed once per render cycle
   let heading_visibility: boolean[] = $derived.by(() => {
     const active_idx =
       collapse_mode && activeHeading ? headings.indexOf(activeHeading) : null
@@ -244,10 +228,9 @@
     })
   })
 
-  // Re-check overlap when headings or hideOnIntersect change
   $effect(() => {
-    void headings // track headings as dependency
-    void hideOnIntersect // track prop changes
+    void headings // register as dependencies
+    void hideOnIntersect
     check_toc_overlap()
   })
 
@@ -305,9 +288,8 @@
     scroll_target_timeout = setTimeout(clear_scroll_target, scroll_target_fallback_ms)
     node.scrollIntoView?.({ behavior: scrollBehavior, block: `start` })
 
-    // use the raw id as the URL fragment so it matches the DOM id exactly. encodeURIComponent
-    // (used for the <a href> attribute) would emit e.g. #sec%3A1 for id="sec:1", which only
-    // resolves via the browser's percent-decode fallback rather than matching directly.
+    // raw id as the fragment so it matches the DOM id exactly: encodeURIComponent (used for
+    // the <a href>) emits #sec%3A1 for id="sec:1", which only resolves via percent-decoding
     const id = heading_data[idx]?.id
     if (id) history.replaceState({}, ``, `#${id}`)
 
@@ -359,11 +341,9 @@
     selector_is_valid(`headingSelector`, headingSelector) &&
     element.closest(headingSelector) !== null
 
-  // A childList record used to short-circuit to `true`, so every DOM insertion anywhere in
-  // the document — a toast, a tooltip, a dropdown, a virtualized editor row scrolling past —
-  // re-queried every heading in the document. Only nodes that are or contain a heading can
-  // change the result.
-  // NodeList is iterable, so this stays allocation-free on the mutation path
+  // only nodes that are or contain a heading can change the result: short-circuiting every
+  // childList record to `true` re-queried all headings on any DOM insertion (toast, tooltip,
+  // virtualized row). NodeList is iterable, so this stays allocation-free.
   const some_element = (nodes: NodeList, match: (node: Element) => boolean): boolean => {
     for (const node of nodes) if (node instanceof Element && match(node)) return true
     return false
@@ -371,8 +351,8 @@
   const childlist_touches_headings = (record: MutationRecord): boolean => {
     if (!selector_is_valid(`headingSelector`, headingSelector)) return false
     const { target } = record
-    // `heading.textContent = '…'` swaps a text node, so neither node list holds an Element,
-    // but the record targets the heading itself
+    // `heading.textContent = '…'` swaps a text node: no Element in either node list, but
+    // the record targets the heading itself
     if (target instanceof Element && element_matches_heading_selector(target)) return true
     return (
       some_element(
@@ -380,8 +360,8 @@
         (node) =>
           node.matches(headingSelector) || Boolean(node.querySelector(headingSelector)),
       ) ||
-      // a removed node is detached, so `main > h2` can no longer match it — compare
-      // against the headings currently held instead
+      // a removed node is detached, so `main > h2` can't match it — compare against the
+      // headings currently held instead
       some_element(record.removedNodes, (node) =>
         headings.some((heading) => node === heading || node.contains(heading)),
       )
@@ -440,11 +420,10 @@
       })
     }
 
-    // Use untrack to avoid creating dependencies on the state we're about to modify
+    // untrack: this writes the very state it would otherwise depend on
     untrack(() => {
-      // skip state churn when an unrelated DOM mutation left the heading set unchanged.
-      // this must also hold for the empty set, or every mutation on a heading-less page
-      // re-runs the whole rebuild and repeats the warnOnEmpty warning.
+      // skip state churn when an unrelated mutation left the heading set unchanged — the
+      // empty set included, else every mutation on a heading-less page repeats warnOnEmpty
       const unchanged =
         headings_initialized &&
         heading_entries.length === headings.length &&
@@ -499,35 +478,31 @@
     observer.observe(document.body, {
       attributes: true,
       childList: true,
-      characterData: true, // Watch text changes inside existing headings
-      subtree: true, // Watch all descendants, not just direct children
+      characterData: true,
+      subtree: true,
     })
 
     return () => observer.disconnect()
   })
 
-  // clear_scroll_target writes component state, so a pending fallback must not outlive
-  // the component. The flash timer only strips a class off a detached node, so it can run.
+  // clear_scroll_target writes component state, so its timer must not outlive the component.
+  // The flash timer only strips a class off a detached node, so it can run.
   $effect(() => () => {
     if (scroll_target_timeout) clearTimeout(scroll_target_timeout)
   })
 
   function set_active_heading() {
-    // if we're in a programmatic scroll (click/keyboard initiated), keep the target active
-    // until scrollend fires to prevent highlighting intermediate headings during smooth scroll
+    // during a programmatic scroll keep the target active until scrollend, so intermediate
+    // headings aren't highlighted on the way
     if (scroll_target && !headings.includes(scroll_target)) clear_scroll_target()
     if (scroll_target) {
-      // detect if user manually scrolled away from scroll_target by checking if distance
-      // is increasing (user scrolling away) rather than decreasing (smooth scroll in progress)
       const distance = Math.abs(
         scroll_target.getBoundingClientRect().top - activeHeadingScrollOffset,
       )
-      // a large enough increase detects manual scroll while tolerating scroll jitter
+      // growing distance means the user scrolled away; the threshold tolerates jitter
       if (distance > prev_scroll_target_distance + manual_scroll_threshold_px) {
-        // user manually scrolled away from target, clear and allow normal detection
         clear_scroll_target()
       } else {
-        // smooth scroll still in progress (distance decreasing or stable), keep target active
         prev_scroll_target_distance = distance
         return
       }
@@ -537,17 +512,15 @@
     while (idx--) {
       const { top } = headings[idx].getBoundingClientRect()
 
-      // loop through headings from last to first until we find one that the viewport already
-      // scrolled past. if none is found, set make first heading active
+      // last heading the viewport has scrolled past, else the first one
       if (top < activeHeadingScrollOffset || idx === 0) {
         activeHeading = headings[idx]
         activeTocLi = tocItems[idx]
-        return // exit while loop if updated active heading
+        return
       }
     }
   }
 
-  // check if TOC overlaps with any hideOnIntersect elements (desktop only)
   function check_toc_overlap() {
     if (!hideOnIntersect || !aside || !desktop) {
       is_overlapping_hide_target = false
@@ -574,7 +547,7 @@
       : []
   }
 
-  // click and key handler for ToC items that scrolls to the heading
+  // click/key handler on ToC items: scrolls to the heading
   const li_click_key_handler = (node: HTMLHeadingElement) => (event: LiEvent) => {
     if (event instanceof KeyboardEvent) liProps.onkeydown?.(event)
     else liProps.onclick?.(event)
@@ -593,17 +566,15 @@
 
   function scroll_to_active_toc_item(behavior: `auto` | `smooth` | `instant` = `smooth`) {
     if (keepActiveTocItemInView && activeTocLi && nav) {
-      // scroll the active ToC item into the middle of the ToC container. offsetTop and
-      // scrollTop both count from the padding box, so the height to halve is the
-      // scrollport's (clientHeight), not the border box's.
+      // centre the active item: offsetTop and scrollTop both count from the padding box,
+      // so halve clientHeight (the scrollport), not the border box
       const top = activeTocLi.offsetTop - nav.clientHeight / 2
       nav.scrollTo?.({ top, behavior })
     }
   }
 
-  // ensure active ToC is in view when ToC opens on mobile. untracked because both calls
-  // read (and set_active_heading writes) activeTocLi: tracking it would re-run this on
-  // every arrow-key move and snap the selection straight back to the scroll position.
+  // show the active item when the mobile ToC opens. untracked because tracking activeTocLi
+  // (which set_active_heading writes) would re-run this on every arrow-key move.
   $effect(() => {
     if (!open || !nav) return
     untrack(() => {
@@ -612,7 +583,6 @@
     })
   })
 
-  // enable keyboard navigation
   function on_keydown(event: KeyboardEvent) {
     if (event.defaultPrevented) return
     if (!reactToKeys || !reactToKeys.includes(event.key)) return
@@ -645,6 +615,17 @@
       set_open(false, `escape`)
       return
     }
+    // Everything below drives the toc's own list and preventDefaults to do it, which cancels
+    // the activation of whatever else has focus: with the panel open (or the desktop toc merely
+    // hovered) every button on the page went dead to Enter, arrows stopped moving the caret in
+    // a text field, and the toc's own toggle re-activated the current heading instead of
+    // closing. Only run while focus is idle or already inside the list. Escape and Tab are
+    // handled above, so the panel still closes from anywhere.
+    const focused = document.activeElement
+    const focus_is_idle =
+      !focused || focused === document.body || focused === document.documentElement
+    if (!focus_is_idle && !nav?.contains(focused)) return
+
     event.preventDefault()
     const current_toc_li = activeTocLi ?? nav?.querySelector<HTMLLIElement>(`li.active`)
 
@@ -658,10 +639,9 @@
       activeTocLi = sibling_prop
         ? (visible_toc_sibling(current_toc_li, sibling_prop) ?? current_toc_li)
         : current_toc_li
-      // move DOM focus onto the navigated item so the focused link's own keydown handler
-      // can't override arrow-navigation on the next Enter/Space (tab->arrow->Enter)
+      // move DOM focus along, else the previously focused link's keydown handler hijacks
+      // the next Enter/Space (tab -> arrow -> Enter)
       if (sibling_prop) focus_toc_item(activeTocLi)
-      // update active heading
       activeHeading = headings[tocItems.indexOf(activeTocLi)]
     }
     if (activeTocLi && is_activation_key(event.key) && activeHeading) {
@@ -711,14 +691,13 @@
   hidden={hide}
   aria-hidden={hide || is_overlapping_hide_target}
   {@attach (node) => {
-    // while intersecting the aside is only opacity: 0, so without inert it stays in the
-    // tab order while aria-hidden tells assistive tech it is gone
+    // while intersecting the aside is only opacity: 0, so without inert it stays tabbable
+    // even though aria-hidden tells assistive tech it is gone
     node.toggleAttribute(`inert`, is_overlapping_hide_target)
   }}
 >
-  <!-- The toggle stays mounted while open and becomes the close button, matching Nav's
-  burger. Unmounting it left the panel with no visible way out — only an outside click,
-  Escape or a tab-out, none of which a touch user can see. -->
+  <!-- the toggle stays mounted and becomes the close button: unmounting it left touch users
+  no visible way out, only an outside click, Escape or a tab-out -->
   {#if !desktop && headings.length >= minItems}
     <button
       {...openButtonProps}
@@ -734,8 +713,7 @@
       aria-label={open ? closeButtonLabel : openButtonLabel}
     >
       {#if openTocIcon}{@render openTocIcon()}{:else}
-        <!-- Both glyphs stay mounted and cross-fade, so the toggle animates on open/close
-        the way Nav's burger morphs into its X instead of swapping in one frame. -->
+        <!-- both glyphs stay mounted and cross-fade instead of swapping in one frame -->
         {#each Object.entries(TOGGLE_ICONS) as [state, icon] (state)}
           <svg
             width="1em"
@@ -815,14 +793,11 @@
 
 <style>
   :where(aside.toc) {
-    /* A ToC row and a Nav row are the same thing to a reader — a link that lights up under
-       the pointer — so they share one hover language: Nav's --nav-link-bg-hover colour, its
-       --nav-border-radius and its 0.2s background fade. These are the fallbacks behind the
-       public --toc-li-* tokens, which still win. */
+    /* mirrors Nav's --nav-link-bg-hover / --nav-border-radius so ToC and Nav rows share one
+       hover language. Fallbacks only — the public --toc-li-* tokens still win. */
     --toc-item-hover-bg: light-dark(rgba(70, 70, 140, 0.2), rgba(120, 170, 255, 0.2));
     --toc-item-radius: 3pt;
-    /* shared by the mobile panel and its toggle so the two read as one surface. Values match
-       Nav's --nav-surface-* so a page showing both toggles gets one visual language. */
+    /* shared by the mobile panel and its toggle; values match Nav's --nav-surface-* */
     --toc-surface-border: 1px solid
       light-dark(rgba(128, 128, 128, 0.25), rgba(200, 200, 200, 0.2));
     --toc-surface-shadow: light-dark(
@@ -905,22 +880,27 @@
     border-width: var(--toc-active-border-width);
     border-radius: var(--toc-active-border-radius, var(--toc-item-radius));
   }
-  /* After `.active`, not before: the two selectors have equal specificity, so source order
-     decides, and the active row is the one most likely to be hovered. Nav's active row keeps
-     its hover fill too (there, active is a text colour), and an unset --toc-active-bg made
-     `background` invalid on that row, which swallowed the hover fill entirely. */
+  /* must follow `.active`: equal specificity, so source order decides whether the active
+     row (the likeliest hover target) keeps its hover fill. An unset --toc-active-bg made
+     `background` invalid there and swallowed the fill entirely. */
   aside.toc > nav > ol > li:hover {
     color: var(--toc-li-hover-color);
     background: var(--toc-li-hover-bg, var(--toc-item-hover-bg));
   }
-  /* Cosmetics stay in `:where()` so a host can restyle the toggle without fighting
-     specificity. Its box does not: see the structural rule below. */
+  /* an unset --toc-li-hover-color is guaranteed-invalid, so the rule above computes `color`
+     to inherited text instead of dropping out, wiping the accent off the active row on
+     hover. Restating the active colour as the fallback fixes it; an explicit one still wins. */
+  aside.toc > nav > ol > li.active:hover {
+    color: var(--toc-li-hover-color, var(--toc-active-color));
+  }
+  /* cosmetics in `:where()` so a host can restyle without fighting specificity; the box
+     is not, see the structural rule below */
   :where(aside.toc > button) {
     cursor: pointer;
     font: var(--toc-mobile-btn-font, 1.4rem sans-serif);
     line-height: var(--toc-mobile-btn-line-height, 0);
-    /* relative, not absolute: the aside lays both children out now, but these two vars are
-       public and still have to be able to nudge the toggle off its flex slot */
+    /* relative, not absolute: the aside lays both children out, but the public bottom/right
+       vars must still nudge the toggle off its flex slot */
     position: relative;
     bottom: var(--toc-mobile-btn-bottom, 0);
     right: var(--toc-mobile-btn-right, 0);
@@ -931,22 +911,20 @@
     color: var(--toc-mobile-btn-color, var(--text, black));
     box-shadow: var(--toc-mobile-btn-shadow, var(--toc-surface-shadow));
   }
-  /* A 1.4rem glyph in a 0.3rem-padded box, matching Nav's burger: the two are the only pinned
-     mobile toggles a page has, and at different sizes they read as unrelated chrome. Not
-     `:where()`, for the same reason as the `ol` rule below — a host `button { padding }` reset
-     outweighs a zero-specificity selector and silently resized the hit target. Tune it with
-     --toc-mobile-btn-padding / --toc-mobile-btn-font, which still win. */
+  /* sized to match Nav's burger, the only other pinned mobile toggle. Not `:where()`: a host
+     `button { padding }` reset outweighs a zero-specificity selector and silently resized the
+     hit target. Tune with --toc-mobile-btn-padding / --toc-mobile-btn-font, which still win. */
   aside.toc > button {
     display: grid;
     place-items: center;
     box-sizing: content-box;
-    /* 1em so the box tracks --toc-mobile-btn-font, which the icon already sizes itself from */
+    /* 1em so the box tracks --toc-mobile-btn-font, which the icon already sizes from */
     width: 1em;
     height: 1em;
     padding: var(--toc-mobile-btn-padding, 0.3rem);
   }
-  /* Both glyphs share the single grid cell and swap by opacity + quarter turn, matching the
-     0.2s linear the burger's bars use to fold into their X. */
+  /* both glyphs share one grid cell and swap by opacity + quarter turn, on the 0.2s linear
+     Nav's burger bars use */
   aside.toc > button > svg {
     grid-area: 1 / 1;
     opacity: 0;
@@ -962,10 +940,22 @@
   :where(aside.toc > nav > .toc-title) {
     margin-top: var(--toc-title-margin-top, 0);
   }
-  /* column-reverse against the DOM order [button, nav] keeps the toggle pinned in the corner
-     and opens the panel upward above it. Both children used to be absolutely positioned off
-     this zero-size anchor, which stacked them on top of each other once the toggle stopped
-     unmounting on open. */
+  /* in the floating panel the title is a header, not a paragraph, so it drops the desktop
+     1em gap and cancels the panel's inline padding: a divider stopping short of the sides
+     reads as an underline on the words rather than a break above the list */
+  :where(aside.toc.mobile > nav > .toc-title) {
+    margin-block-end: var(--toc-mobile-title-margin-bottom, 0.35em);
+    padding-block-end: var(--toc-mobile-title-padding-bottom, 0.2em);
+    /* the inherited 1.6 is prose leading; on one header line it is just space above and
+       below the words, which reads as padding inside the rule */
+    line-height: var(--toc-mobile-title-line-height, 1.3);
+    margin-inline: calc(-1 * var(--toc-mobile-padding-inline));
+    padding-inline: var(--toc-mobile-padding-inline);
+    border-bottom: var(--toc-mobile-title-border, var(--toc-surface-border));
+  }
+  /* column-reverse against the DOM order [button, nav] pins the toggle in the corner and
+     opens the panel above it. Absolute positioning off this anchor stacked the two once the
+     toggle stopped unmounting on open. */
   aside.toc.mobile {
     position: fixed;
     bottom: var(--toc-mobile-bottom, 1em);
@@ -974,25 +964,33 @@
     flex-direction: column-reverse;
     align-items: end;
     gap: var(--toc-mobile-gap, 0.5em);
-    /* override the desktop --toc-width the base rule applies: on mobile the aside is just a
-       corner anchor and has to size to whichever of the panel or the toggle is wider */
+    /* overrides the base --toc-width/--toc-min-width: on mobile the aside is a corner anchor
+       sized to whichever of panel or toggle is wider. The 15em floor left a closed toggle
+       dragging a transparent 15em box that still ate taps aimed at the page beneath. */
     width: max-content;
-    /* a long page's toc outgrows a phone screen, and a fixed panel can't scroll with the
-       document, so cap the whole stack against the viewport and let the panel scroll inside */
+    min-width: 0;
+    /* a fixed panel can't scroll with the document, so cap the stack against the viewport
+       and let the panel scroll inside */
     max-height: calc(100dvh - 2 * var(--toc-mobile-bottom, 1em));
     max-width: calc(100dvw - 2 * var(--toc-mobile-right, 1em));
   }
   aside.toc.mobile > nav {
-    /* the desktop 3em inset makes room for the sticky column's left gutter; in a floating
-       panel it is just a blank band down the left of every entry */
-    padding: var(--toc-mobile-padding, 0.5em 1em 1em);
+    /* the desktop 3em inset is just a blank band in a floating panel. The inline half is its
+       own token because the title's rule cancels it to reach the panel edge — a host replacing
+       --toc-mobile-padding should set it to match. rem, not em: a custom property substitutes
+       its text, so `em` would resolve against the reading element (the title is larger). */
+    --toc-mobile-padding-inline: 1rem;
+    padding: var(--toc-mobile-padding, 0.5em var(--toc-mobile-padding-inline) 1em);
+    /* --toc-font-size shrinks the desktop column to fit beside the content; the floating
+       panel has no such constraint and is read at arm's length, so it matches Nav's menu */
+    font-size: var(--toc-mobile-font-size, 1rem);
     border-radius: var(--toc-mobile-border-radius, 6pt);
     box-sizing: border-box;
     background: var(--toc-mobile-bg, white);
     width: var(--toc-mobile-width, 18em);
     max-width: 100%;
-    /* flex items floor at their content height without this, so a tall toc would push the
-       toggle off the bottom of the screen instead of scrolling */
+    /* flex items floor at content height, so a tall toc would push the toggle off-screen
+       instead of scrolling */
     min-height: 0;
     overflow-y: auto;
     overscroll-behavior: contain;

--- a/src/lib/Toggle.svelte
+++ b/src/lib/Toggle.svelte
@@ -17,12 +17,12 @@
     input_props?: Omit<HTMLInputAttributes, `checked` | `onkeydown` | `type`>
   } = $props()
 
-  // normally input type=checkbox toggles on space bar, this handler also responds to enter
+  // a checkbox toggles on space only; this adds Enter
   function handle_keydown(event: KeyboardEvent) {
     onkeydown?.(event)
     if (event.key === `Enter`) {
       event.preventDefault()
-      if (event.target instanceof HTMLInputElement) event.target.click() // simulate real user toggle so 'change' is dispatched
+      if (event.target instanceof HTMLInputElement) event.target.click() // so 'change' fires
     }
   }
 </script>

--- a/src/lib/Wiggle.svelte
+++ b/src/lib/Wiggle.svelte
@@ -16,7 +16,7 @@
   }: HTMLAttributes<HTMLSpanElement> & {
     // bind to this state and set it to true from parent
     wiggle?: boolean
-    // intended use case: set max value during wiggle for one of angle, scale, dx, dy through props
+    // max value reached during the wiggle; usually set just one of these
     angle?: number // try 20
     scale?: number // try 1.2
     dx?: number // try 10
@@ -39,8 +39,8 @@
   $effect.pre(() => {
     if (!wiggle) return
     const timer = setTimeout(() => (wiggle = false), duration_ms)
-    // cancel pending timer on re-trigger or unmount so an old timer can't cut
-    // a new wiggle short or write to state after destroy
+    // cancel on re-trigger or unmount, so an old timer can't cut a new wiggle short or
+    // write to state after destroy
     return () => clearTimeout(timer)
   })
 </script>

--- a/src/lib/attachments/click-outside.ts
+++ b/src/lib/attachments/click-outside.ts
@@ -1,8 +1,7 @@
 import { is_primary_press, register_escape_layer } from './shared'
 
 export type DismissDetail = {
-  // Whether focus sat inside the node, so an Escape dismissal can hand focus back
-  // to the trigger instead of stranding it on a removed element
+  // lets an Escape dismissal hand focus back to the trigger rather than strand it
   focus_inside: boolean
   via: `pointer` | `escape`
   event: Event // the press or keydown behind the dismissal, to forward to consumers
@@ -10,21 +9,19 @@ export type DismissDetail = {
 
 export type DismissConfig = {
   enabled?: boolean
-  // Regions that count as inside though they sit outside the node: the trigger above
-  // all, whose own click toggles the surface right after this runs, and portalled
-  // content the node no longer contains. Elements beat selectors where you hold a
-  // reference — they cannot collide with another instance's markup.
+  // Outside regions that still count as inside: chiefly the trigger, whose own click
+  // toggles the surface right after this runs, and portalled content. Prefer elements over
+  // selectors where you hold a reference — they cannot collide with another instance.
   inside?: (Element | string | null | undefined)[]
-  // Confines the selector entries of `inside` to one subtree, so a second instance
-  // of the same component cannot shield this one's surface with its own trigger.
-  // Resolved per press when a function, for a `bind:this` still null at setup time.
+  // Confines `inside`'s selector entries to one subtree, so a second instance of the same
+  // component cannot shield this one's surface. Resolved per press when a function, for a
+  // `bind:this` still null at setup.
   scope?: Element | null | (() => Element | null | undefined)
   escape?: boolean // dismiss on Escape as well, reporting where focus was
-  // `release` waits for the click, for a surface floating over something draggable (starting a
-  // pan or an orbit behind it should not make it vanish under the cursor) and for an outside
-  // checkbox bound to the same state, which cannot close the surface otherwise. It gives up
-  // dismissing on a right-click and on a press the OS turns into a window drag, neither of
-  // which fires a click at all. See dismiss_on_outside_press.
+  // `release` waits for the click: for surfaces floating over draggable content (a pan
+  // behind them shouldn't dismiss) and outside checkboxes bound to the same state. It
+  // dismisses on neither a right-click nor an OS window drag, which fire no click. See
+  // dismiss_on_outside_press.
   dismiss_on?: `press` | `release`
 }
 
@@ -33,23 +30,21 @@ export type ClickOutsideConfig<T extends HTMLElement> = DismissConfig & {
 }
 
 export type DismissOptions = DismissConfig & {
-  // The surface, where a single element is one: it counts as inside and receives the
-  // `dismiss` event. Leave it out and `inside` becomes the whole membership test,
-  // which is what lets one listener cover several surfaces with no shared wrapper —
-  // wrapping them would make every press between them count as inside.
+  // The surface: counts as inside and receives the `dismiss` event. Omit it and `inside`
+  // becomes the whole membership test, letting one listener cover several surfaces without
+  // a shared wrapper (which would make every press between them count as inside).
   node?: Element | null
   callback?: (detail: DismissDetail) => void
 }
 
-// A press on a scrollbar reports the scrolling element as its target, which usually
-// sits outside the surface. Without this, reaching for the page scrollbar would
-// dismiss the very dropdown the user is scrolling toward.
+// A scrollbar press targets the scrolling element, usually outside the surface, so without
+// this, reaching for the page scrollbar dismisses the dropdown being scrolled toward.
 const is_scrollbar_press = (event: Event): boolean => {
   const target = event.target
   if (!(event instanceof MouseEvent) || !(target instanceof Element)) return false
   const root = document.documentElement
-  // Page scrollbars: the root's client box excludes them, so viewport coordinates
-  // beyond it land in the gutter. Zero sizes mean no layout (jsdom), not a hit.
+  // page scrollbars: the root's client box excludes them, so coordinates past it are in
+  // the gutter; zero sizes mean no layout (jsdom), not a hit
   if (target === root || target === document.body) {
     return (
       (root.clientWidth > 0 && event.clientX > root.clientWidth) ||
@@ -57,10 +52,9 @@ const is_scrollbar_press = (event: Event): boolean => {
     )
   }
   const rect = target.getBoundingClientRect()
-  // clientWidth/Height are 0 for non-scrollable boxes (inline elements above all),
-  // hence the overflow check — otherwise every press right of such a box looks like
-  // a scrollbar hit and silently suppresses dismissal. The gutter starts past the
-  // border too, which the border-box rect includes but clientWidth/Height do not.
+  // clientWidth/Height are 0 for non-scrollable boxes (inline elements above all), hence
+  // the overflow check: else every press right of one looks like a scrollbar hit. The
+  // gutter also starts past the border, which the border-box rect includes and client* not.
   return (
     (target.scrollHeight > target.clientHeight &&
       event.clientX > rect.left + target.clientLeft + target.clientWidth) ||
@@ -69,15 +63,15 @@ const is_scrollbar_press = (event: Event): boolean => {
   )
 }
 
-// Outside-press dismiss. Default `pointerdown` (right-click / OS titlebar drag fire no
-// click). Capture + composedPath. Plain function so `node` can be omitted and `inside`
-// alone defines the surface.
+// Outside-press dismiss, on `pointerdown` by default (a right-click or OS titlebar drag
+// fires no click), via capture + composedPath. A plain function, so `node` may be omitted
+// and `inside` alone defines the surface.
 //
-// `dismiss_on: 'release'` waits for the click — pan-behind stays open, and an outside
-// `bind:checked` checkbox can close it (dismiss on the press and Svelte's flush writes
-// checked=false before the click's pre-click activation flips it back, which the bind commits).
-// Neither mode fixes `open = !open` on the control itself; put those in `inside`. `release`
-// also closes an outside trigger that opened on the same gesture's `pointerdown`.
+// `dismiss_on: 'release'` waits for the click, keeping a pan-behind open and letting an
+// outside `bind:checked` checkbox close it (dismissing on the press writes checked=false
+// before pre-click activation flips it back and the bind commits that). `release` also
+// closes an outside trigger opened on the same gesture's pointerdown. Neither mode fixes
+// `open = !open` on the control itself — put those in `inside`.
 export const dismiss_on_outside_press = (options: DismissOptions = {}): (() => void) => {
   const {
     node,
@@ -89,7 +83,7 @@ export const dismiss_on_outside_press = (options: DismissOptions = {}): (() => v
     dismiss_on = `press`,
   } = options
 
-  if (!enabled) return () => {} // Early return avoids registering unused listener
+  if (!enabled) return () => {} // avoids registering an unused listener
 
   const inside_nodes = [node, ...inside].filter((item) => item instanceof Element)
   // Empty entries would make the joined selector invalid and throw on every press
@@ -110,9 +104,8 @@ export const dismiss_on_outside_press = (options: DismissOptions = {}): (() => v
     return !resolved_scope || resolved_scope.contains(match)
   }
 
-  // document.activeElement reports the outermost shadow host, so descend the focus
-  // chain: the host may be inside the node (containment settles it at the first
-  // step) or the node may itself live in that shadow tree alongside the focus.
+  // document.activeElement reports the outermost shadow host, so descend the focus chain:
+  // the host may be inside the node, or the node may live in that shadow tree itself.
   const focus_is_inside = (): boolean => {
     let active = document.activeElement
     while (active) {
@@ -128,8 +121,8 @@ export const dismiss_on_outside_press = (options: DismissOptions = {}): (() => v
   }
 
   // `release` only: ignore a click whose pointerdown was inside (resize released outside).
-  // Cleared on read, on pointercancel and for any press that fires no click of its own (a
-  // right-click, a second finger), else the next Enter-click inherits a stale verdict.
+  // Cleared on read, on pointercancel and for presses that fire no click (right-click,
+  // second finger), else the next Enter-click inherits a stale verdict.
   let press_started_inside = false
   const remember_press = (event: PointerEvent) => {
     press_started_inside =
@@ -138,23 +131,21 @@ export const dismiss_on_outside_press = (options: DismissOptions = {}): (() => v
   const forget_press = () => (press_started_inside = false)
 
   const handle_press = (event: Event) => {
-    // A pointer verdict may only judge a pointer click. `detail` is 0 for keyboard and
-    // programmatic clicks, which carry no pointerdown of their own and would otherwise
-    // inherit a stale `true` from a press that never produced a click.
+    // A pointer verdict may only judge a pointer click: `detail` is 0 for keyboard and
+    // programmatic clicks, which have no pointerdown and would inherit a stale `true`.
     const started_inside =
       press_started_inside && event instanceof MouseEvent && event.detail > 0
     press_started_inside = false
     if (started_inside) return
     const path = event.composedPath()
     if (is_scrollbar_press(event) || is_inside(event.target, path)) return
-    // A press never restores focus — the user already picked where it lands
+    // a press never restores focus — the user already picked where it lands
     dismiss({ focus_inside: false, via: `pointer`, event })
   }
 
   const on_escape = (event: KeyboardEvent) => {
-    // Safe to swallow the key: only the innermost layer gets here, so no outer
-    // surface is waiting on it. Canceling the default keeps a native <dialog>
-    // around the surface open until a second Escape, once this layer is gone.
+    // Safe to swallow: only the innermost layer gets here, so no outer surface waits on it.
+    // Canceling the default keeps a wrapping native <dialog> open until a second Escape.
     event.preventDefault()
     event.stopPropagation()
     dismiss({ focus_inside: focus_is_inside(), via: `escape`, event })
@@ -178,8 +169,8 @@ export const dismiss_on_outside_press = (options: DismissOptions = {}): (() => v
   }
 }
 
-// The attachment form: the element it is attached to is the surface, so containment
-// covers everything under it and `inside` is left for the trigger and portalled parts.
+// Attachment form: the attached element is the surface, so containment covers everything
+// under it and `inside` is left for the trigger and portalled parts.
 export const click_outside =
   <T extends HTMLElement>(config: ClickOutsideConfig<T> = {}) =>
   (node: T): (() => void) | undefined => {

--- a/src/lib/attachments/contrast-color.ts
+++ b/src/lib/attachments/contrast-color.ts
@@ -11,13 +11,11 @@ export interface ContrastOptions {
 }
 
 // === CSS color parsing ===
-// A color authored in a wide-gamut or perceptual space keeps that space in its computed
-// value — `getComputedStyle` hands back `oklch(…)`, `lab(…)` or `color(display-p3 …)`
-// verbatim rather than an sRGB approximation — so reading only `rgb()`/`rgba()` would
-// take a painted ancestor for a transparent one. Everything below converts to sRGB.
-// Not covered: named colors and `color-mix()`, neither of which a computed value can
-// carry (`color-mix()` resolves to a color in its interpolation space at computed-value
-// time). Both are rejected, and callers passing a color by hand get the error.
+// `getComputedStyle` returns wide-gamut and perceptual colors verbatim (`oklch(…)`,
+// `color(display-p3 …)`), not as sRGB, so reading only `rgb()`/`rgba()` would mistake a
+// painted ancestor for a transparent one. Everything below converts to sRGB. Named colors
+// and `color-mix()` are rejected: a computed value never carries either, so only a
+// hand-passed color hits that error.
 const RGB_COLOR = /^rgba?\((?<channels>[^)]+)\)$/iu
 const HEX_COLOR = /^#(?<digits>[\da-f]+)$/iu
 const COLOR_FN = /^(?<name>oklch|oklab|lch|lab|hsla?|hwb|color)\((?<args>[^)]*)\)$/iu
@@ -43,8 +41,8 @@ const parse_percentage = (token: string): number =>
 // alpha is a 0..1 number or a percentage, and absent means opaque
 const parse_alpha = (token: string | undefined): number =>
   token === undefined ? 1 : clamp_unit(parse_component(token, 1))
-// Junk anywhere in a component reaches here as NaN, so one check at the end rejects
-// the whole color rather than every parse site having to guard
+// junk in any component arrives as NaN, so one check here rejects the whole color and no
+// parse site needs its own guard
 const finite_rgba = (rgb: Triple, alpha: number): Rgba | null => {
   const parsed: Rgba = [...rgb, alpha]
   return parsed.every(Number.isFinite) ? parsed : null
@@ -56,8 +54,8 @@ const HUE_PER_UNIT: Record<string, number> = {
   rad: 180 / Math.PI,
   turn: 360,
 }
-// Longest suffix first, so `grad` is never read as the `rad` it ends with. Matching in
-// declaration order would work too, but only until someone alphabetizes the object.
+// longest suffix first, so `grad` is never read as the `rad` it ends with (declaration
+// order would work too, until someone alphabetizes the object)
 const HUE_UNITS = Object.keys(HUE_PER_UNIT).toSorted(
   (one, two) => two.length - one.length,
 )
@@ -156,9 +154,8 @@ const LINEAR_SRGB_TO_XYZ_D65 = [
 const IDENTITY_MATRIX = [1, 0, 0, 0, 1, 0, 0, 0, 1]
 const identity = (channel: number) => channel
 
-// The predefined spaces `color()` accepts, each as its decoding transfer function and
-// the matrix taking its linear form to XYZ. `d50` marks the ones needing adaptation,
-// and the xyz spaces are the degenerate case: their components already are XYZ.
+// Spaces `color()` accepts, each as a decoding transfer function plus the matrix from its
+// linear form to XYZ. `d50` marks those needing adaptation; xyz spaces already are XYZ.
 const COLOR_SPACES: Record<
   string,
   { decode: (channel: number) => number; matrix: readonly number[]; d50?: boolean }
@@ -211,8 +208,8 @@ const components = (tokens: string[], refs: Triple): Triple => [
   parse_component(tokens[1], refs[1]),
   parse_component(tokens[2], refs[2]),
 ]
-// lch and oklch are lab and oklab in polar coordinates, so they convert and reuse the
-// rectangular transform rather than carrying one of their own
+// lch/oklch are lab/oklab in polar coordinates, so they convert and reuse the rectangular
+// transform instead of carrying their own
 const polar_components = (tokens: string[], refs: [number, number]): Triple => {
   const chroma = parse_component(tokens[1], refs[1])
   const hue = (parse_hue(tokens[2]) * Math.PI) / 180
@@ -226,7 +223,7 @@ const polar_components = (tokens: string[], refs: [number, number]): Triple => {
 // Component tokens to sRGB on 0..255; null when they do not fit the function's shape
 const function_to_rgb255 = (name: string, tokens: string[]): Triple | null => {
   if (name === `color`) {
-    // own properties only: a bare lookup would find Object.prototype keys, so
+    // own properties only: a bare lookup finds Object.prototype keys, so
     // `color(constructor 1 1 1)` came back truthy and then blew up on space.decode
     const space_name = tokens[0]?.toLowerCase() ?? ``
     const space = Object.hasOwn(COLOR_SPACES, space_name)
@@ -273,8 +270,8 @@ const parse_color = (color: string): Rgba | null => {
   const trimmed = color.trim()
   const channels = RGB_COLOR.exec(trimmed)?.groups?.channels
   if (channels) {
-    // percentages are legal here too, in the channels (`rgb(50% 0% 0%)`) as much as in
-    // the alpha (`rgb(0 0 0 / 50%)`), even though a computed value never uses them
+    // percentages are legal in channels and alpha (`rgb(50% 0% 0% / 50%)`), even though a
+    // computed value never uses them
     const parts = channels.split(/[\s,/]+/u).filter(Boolean)
     if (parts.length < 3) return null
     const rgb = parts.slice(0, 3).map((token) => parse_component(token, 255)) as Triple
@@ -329,9 +326,8 @@ const composite_color = (top: Rgba, bottom: Rgba): Rgba => {
 const rgb_string = ([red, green, blue]: Rgba): string =>
   `rgb(${Math.round(red)} ${Math.round(green)} ${Math.round(blue)})`
 
-// The effective background behind a node: a translucent ancestor tints whatever it sits
-// on rather than deciding readability alone, so keep walking and blend the layers. A
-// chain with nothing opaque in it shows through to the browser's white canvas.
+// Effective background behind a node: a translucent ancestor only tints what it sits on,
+// so keep walking and blend. A chain with nothing opaque shows the browser's white canvas.
 export const get_bg_color = (element: Element | null): string => {
   let composite: Rgba | undefined
   for (let node = element; node; node = node.parentElement) {
@@ -353,8 +349,8 @@ export const pick_contrast_color = (options: ContrastOptions = {}): string => {
   return luminance(background) > luminance_threshold ? choices[0] : choices[1]
 }
 
-// Set text color once at attachment setup to whichever of `choices` reads better on the
-// background behind the node. For dynamic fills, re-run with an explicit bg_color.
+// Sets text color once at setup to whichever of `choices` reads better on the background
+// behind the node. For dynamic fills, re-run with an explicit bg_color.
 export const contrast_color =
   (options: ContrastOptions = {}) =>
   (node: Element): (() => void) | undefined => {

--- a/src/lib/attachments/draggable.ts
+++ b/src/lib/attachments/draggable.ts
@@ -43,15 +43,14 @@ export const draggable =
 
     function on_pointerdown(event: PointerEvent) {
       // `dragging` bars a second primary pointer mid-drag (mouse while a touch is down),
-      // which would strand the first follower's listeners past cleanup.
+      // which would strand the first follower's listeners past cleanup
       if (dragging || !is_primary_press(event)) return
       if (!(event.target instanceof Node) || !drag_handle.contains(event.target)) return
 
       dragging = true
-      // A fixed node is placed in viewport coordinates, which is what its rect reports;
-      // an absolute one against its offset parent. A relative (or static, promoted so
-      // left/top take effect) node is already in flow, so offsetLeft would double its
-      // position: continue from its current insets instead.
+      // A fixed node is placed in viewport coordinates (what its rect reports), an absolute
+      // one against its offset parent. A relative or promoted-static node is already in
+      // flow, where offsetLeft would double its position, so continue from its insets.
       const styles = getComputedStyle(node)
       const origin =
         styles.position === `fixed`
@@ -60,9 +59,9 @@ export const draggable =
             ? { left: node.offsetLeft, top: node.offsetTop }
             : { left: css_px(styles.left) || 0, top: css_px(styles.top) || 0 }
       if (styles.position === `static`) node.style.position = `relative`
-      // A rect and offsetLeft both report the border edge, but left/top place the margin
-      // edge, so an out-of-flow node with margins would jump by them on the first press.
-      // The in-flow branch read the insets themselves, so it is already in that space.
+      // Rect and offsetLeft report the border edge, but left/top place the margin edge, so
+      // an out-of-flow node with margins would jump by them on the first press. The in-flow
+      // branch read the insets themselves and is already in that space.
       const out_of_flow = [`fixed`, `absolute`].includes(styles.position)
       initial.left = origin.left - (out_of_flow ? css_px(styles.marginLeft) || 0 : 0)
       initial.top = origin.top - (out_of_flow ? css_px(styles.marginTop) || 0 : 0)
@@ -90,8 +89,8 @@ export const draggable =
           bounds_rect.left !== bounds_rect.right ||
           bounds_rect.top !== bounds_rect.bottom)
       ) {
-        // Measure after normalizing active inset styles, since that can move a node
-        // originally positioned from its right or bottom edge.
+        // after normalizing inset styles, which can move a node positioned from its right
+        // or bottom edge
         const node_rect = node.getBoundingClientRect()
         min_delta_x = bounds_rect.left - node_rect.left
         max_delta_x = Math.max(min_delta_x, bounds_rect.right - node_rect.right)

--- a/src/lib/attachments/file-drop.ts
+++ b/src/lib/attachments/file-drop.ts
@@ -11,9 +11,9 @@ export interface FileDropOptions {
   on_error?: (error: unknown) => unknown
 }
 
-// Headless file-drop handling. The data attribute gives CSS consumers the same state
-// the callback receives, while the depth counter prevents child-to-child drags from
-// flickering inactive. Directory expansion and its explicit errors live in file-drop.
+// Headless file-drop handling. The data attribute exposes the callback's state to CSS, and
+// the depth counter keeps child-to-child drags from flickering inactive. Directory expansion
+// and its errors live in file-drop.
 export const file_drop =
   (options: FileDropOptions): Attachment<HTMLElement> =>
   (node): (() => void) | undefined => {

--- a/src/lib/attachments/float.ts
+++ b/src/lib/attachments/float.ts
@@ -4,8 +4,8 @@ import { compute_position } from '../utils'
 
 export type AnchorRect = { top: number; left: number; bottom: number; right: number }
 
-// Coalesce position updates from scrolling, resizing and observed element size changes.
-// The caller performs the initial update; this returns a cleanup function.
+// Coalesces position updates from scroll, resize and observed size changes; the caller
+// does the initial update.
 export const auto_update_position = (
   anchor: Element | null,
   floating: Element,
@@ -43,19 +43,18 @@ export const auto_update_position = (
 }
 
 export interface FloatOptions extends PositionOptions {
-  // A rect instead of an element covers anchors with no markup: the pointer position
-  // a context menu opens at, a text selection, a cell in a canvas.
+  // a rect covers anchors with no markup: a context menu's pointer position, a text
+  // selection, a canvas cell
   anchor?: Element | AnchorRect | null
   enabled?: boolean
-  // `fixed` needs no scroll bookkeeping but is clipped by an ancestor's transform;
-  // `absolute` survives that at the cost of adding page scroll to every update.
+  // `fixed` needs no scroll bookkeeping but an ancestor transform clips it; `absolute`
+  // survives that, paying page scroll on every update
   strategy?: `fixed` | `absolute`
   match_width?: boolean // use the anchor's exact border-box width, for dropdowns
 }
 
-// Park an element next to an anchor and keep it there while the page moves.
-// Geometry comes from compute_position, the same one the tooltip and the portalled
-// dropdown use, so all three flip and shift alike.
+// Parks an element next to an anchor and keeps it there while the page moves. Geometry
+// comes from compute_position, so tooltip, portalled dropdown and this flip and shift alike.
 export const float =
   (options: FloatOptions = {}) =>
   (node: Element): (() => void) | undefined => {
@@ -69,8 +68,8 @@ export const float =
     if (!enabled || !anchor || !(node instanceof HTMLElement)) return undefined
 
     const anchor_element = anchor instanceof Element ? anchor : null
-    // Every inline value `update` may write, so a node that outlives the attachment
-    // (a persistent surface toggled by `enabled`) is handed back as it arrived.
+    // every inline value `update` may write, so a node outliving the attachment (a
+    // persistent surface toggled by `enabled`) is handed back as it arrived
     const original_styles = {
       position: node.style.position,
       left: node.style.left,
@@ -82,8 +81,8 @@ export const float =
     const original_placement = node.dataset.placement
     const scroll_view = strategy === `absolute` ? node.ownerDocument.defaultView : null
     const update = () => {
-      // Out of flow before measuring: an in-flow surface is a sibling that pushes the
-      // very anchor it is about to measure, which lands it half its height off.
+      // out of flow before measuring: in flow it is a sibling pushing the very anchor it
+      // measures, landing half its height off
       node.style.position = strategy
       const anchor_rect =
         anchor instanceof Element ? anchor.getBoundingClientRect() : anchor
@@ -98,8 +97,8 @@ export const float =
         node.getBoundingClientRect(),
         position_options,
       )
-      // compute_position works in viewport coordinates, which `absolute` offsets from
-      // the page origin. Scroll comes from the node's own view, not the top window.
+      // compute_position is in viewport coordinates, which `absolute` offsets from the
+      // page origin; scroll comes from the node's own view, not the top window
       node.style.left = `${left + (scroll_view?.scrollX ?? 0)}px`
       node.style.top = `${top + (scroll_view?.scrollY ?? 0)}px`
       node.dataset.placement = placement

--- a/src/lib/attachments/focus-trap.ts
+++ b/src/lib/attachments/focus-trap.ts
@@ -2,20 +2,20 @@ import { register_escape_layer, register_trap_layer } from './shared'
 
 export interface FocusTrapOptions {
   enabled?: boolean
-  // What to focus on activation: an element, a selector resolved within the root, or
-  // `false` to leave focus where it is. Defaults to the first tabbable descendant.
+  // element, selector resolved within the root, or `false` to leave focus put; defaults to
+  // the first tabbable descendant
   initial?: Element | string | false
-  // Where focus returns on teardown. Defaults to whatever held it on activation;
-  // `false` leaves focus alone, for a trigger the surface itself removed.
+  // where focus returns on teardown, default whatever held it on activation; `false` leaves
+  // it alone, for a trigger the surface itself removed
   restore?: Element | false
   // Further containers the trap covers, for portalled parts of the same surface
   include?: (Element | null | undefined)[]
   // Narrows Tab cycling to a descendant. Resolved per keystroke; falls back to the node.
   root?: Element | string | null | (() => Element | null | undefined)
-  // Escape handler, on the same layer stack `click_outside` uses, so only the innermost
-  // trap hears the key. Omit and Escape passes through untouched.
+  // on `click_outside`'s layer stack, so only the innermost trap hears the key; omit and
+  // Escape passes through untouched
   on_escape?: (event: KeyboardEvent) => void
-  // Pull focus back to where it last sat inside whenever something outside takes it.
+  // pull focus back to where it last sat inside whenever something outside takes it
   recapture?: boolean
 }
 
@@ -150,8 +150,8 @@ export const focus_trap =
         : typeof root === `string`
           ? node.querySelector(root)
           : root) ?? node
-    // `root` narrows Tab order, but the whole node remains inside the trap.
-    // Recollected per keystroke: menus grow, filter and disable items while open
+    // `root` narrows Tab order, but the whole node stays inside the trap. Recollected per
+    // keystroke: menus grow, filter and disable items while open.
     const tabbables = () => get_tab_candidates([resolve_root(), ...extra_containers])
     const is_inside = (target: unknown): target is Element =>
       target instanceof Element &&

--- a/src/lib/attachments/highlight-matches.ts
+++ b/src/lib/attachments/highlight-matches.ts
@@ -11,12 +11,10 @@ export type HighlightOptions = {
   duration_ms?: number
   scroll_to_match?: false | ScrollIntoViewOptions
   on_highlight?: (context: { node: HTMLElement; ranges: Range[] }) => unknown
-  // Re-run when the subtree changes, so consumers stop hand-rolling an observer
-  // around this. `true` re-runs on the mutation microtask; `false` freezes the
-  // highlight at whatever the DOM held on attach. An object coalesces bursts: the
-  // re-run lands `debounce_ms` after the last mutation but no later than
-  // `max_wait_ms` after the first of the burst, so a stream of appended log lines
-  // still refreshes at a steady rate instead of never settling.
+  // Re-run on subtree changes, so consumers need no observer of their own. `true` re-runs
+  // on the mutation microtask, `false` freezes at what the DOM held on attach. An object
+  // coalesces bursts (`debounce_ms` after the last mutation, at most `max_wait_ms` after
+  // the burst's first), so a stream of appended log lines still refreshes steadily.
   observe_mutations?: boolean | TextMutationOptions
 }
 
@@ -36,10 +34,9 @@ export const highlight_matches = (ops: HighlightOptions) => (node: HTMLElement) 
   } = ops
 
   const search = query.trim().toLowerCase().replaceAll(/\s+/gu, ` `)
-  // if disabled or empty query, this instance owns no highlight
-  if (!search || disabled) return undefined
-  // both halves of the CSS Custom Highlight API are needed, same as highlight_ranges
-  // checks: a registry without the constructor would throw in sync_owned_highlight
+  if (!search || disabled) return undefined // this instance owns no highlight
+  // both halves of the CSS Custom Highlight API: a registry without the constructor would
+  // throw in sync_owned_highlight
   const highlight_registry =
     typeof globalThis.Highlight === `function` ? globalThis.CSS?.highlights : undefined
   const highlight_owner = Symbol(css_class)
@@ -57,10 +54,9 @@ export const highlight_matches = (ops: HighlightOptions) => (node: HTMLElement) 
     if (!original_text) return []
     const text = original_text.toLowerCase()
 
-    // Offsets are computed on the lowercased text but applied to the original
-    // node. Lowercasing can grow some Unicode chars (e.g. İ → i̇), while astral
-    // characters span two UTF-16 units. Map each lowered unit to the complete
-    // original code point so ranges never shift or split a character.
+    // Offsets are computed on lowercased text but applied to the original node, and
+    // lowercasing can grow chars (İ → i̇) while astral ones span two UTF-16 units. Map each
+    // lowered unit to its whole original code point so ranges never shift or split a char.
     const node_length = original_text.length
     let original_starts: number[] | null = null
     let original_ends: number[] | null = null
@@ -95,7 +91,7 @@ export const highlight_matches = (ops: HighlightOptions) => (node: HTMLElement) 
     }
 
     if (fuzzy) {
-      // null means not all characters matched, so highlight nothing.
+      // null means not all characters matched, so highlight nothing
       const matching_indices = fuzzy_match_indices(search, text)
       const unique_ranges = new Map<string, Range>()
       for (const index of matching_indices ?? []) {

--- a/src/lib/attachments/keyboard.ts
+++ b/src/lib/attachments/keyboard.ts
@@ -3,14 +3,14 @@ import { run_hotkeys } from '../utils'
 
 export interface HotkeyOptions {
   bindings: Hotkey[]
-  // Listen on the document rather than the node, for shortcuts that work anywhere.
-  // Node-scoped is the default so a shortcut dies with the surface that owns it.
+  // listen on the document, for shortcuts that work anywhere; node-scoped by default so a
+  // shortcut dies with the surface that owns it
   global?: boolean
   enabled?: boolean
 }
 
-// Declarative keybindings. Matching lives in run_hotkeys so components that already
-// own a window listener (CommandMenu) share the same semantics without an element.
+// Declarative keybindings. Matching lives in run_hotkeys so components with their own
+// window listener (CommandMenu) share the semantics without an element.
 export const hotkey =
   (options: HotkeyOptions) =>
   (node: Element): (() => void) | undefined => {
@@ -26,16 +26,16 @@ export const hotkey =
   }
 
 export interface ForwardWindowKeydownOptions {
-  // Report `true` for a key you took, and the browser default (page scroll, quick
-  // find) is suppressed here instead of at every call site.
+  // return `true` for a key you took and the browser default (scroll, quick find) is
+  // suppressed here rather than at every call site
   handle: (event: KeyboardEvent) => boolean
   enabled?: boolean
 }
 
-// Hand a component the page's keydowns while the pointer is over it and focus is on the
-// page or the component root. Several viewers can then share one set of shortcuts without
-// all answering at once, and none takes a key from a focused descendant control.
-// Complements `hotkey`, which binds to an element or the document and arbitrates by focus.
+// Hands a component the page's keydowns while the pointer is over it and focus is on the
+// page or its root, so several viewers share one set of shortcuts without all answering and
+// none steals a key from a focused descendant. Complements `hotkey`, which arbitrates by
+// focus instead.
 export const forward_window_keydown =
   (options: ForwardWindowKeydownOptions) =>
   (node: Element): (() => void) | undefined => {
@@ -47,10 +47,9 @@ export const forward_window_keydown =
     const on_leave = () => (is_hovered = false)
     const on_keydown = (event: Event) => {
       if (!is_hovered || !(event instanceof KeyboardEvent)) return
-      // The root itself may be focusable so keyboard users can aim shortcuts at it, and
-      // an unfocused page targets body or the html element. Anything else, including a
-      // target retargeted through a shadow root, keeps its own keys — composedPath()[0]
-      // exposes that original shadow-DOM target.
+      // The root may be focusable so keyboard users can aim shortcuts at it, and an
+      // unfocused page targets body or html. Anything else keeps its own keys, including a
+      // shadow-retargeted node, which composedPath()[0] exposes.
       const { activeElement, body, documentElement } = node.ownerDocument
       const event_target = event.composedPath()[0]
       const idle = [node, body, documentElement]

--- a/src/lib/attachments/resizable.ts
+++ b/src/lib/attachments/resizable.ts
@@ -12,7 +12,7 @@ export interface ResizableOptions {
   edges?: (`top` | `right` | `bottom` | `left`)[]
   min_width?: number
   min_height?: number
-  // A function is resolved at gesture time, for bounds that move with the node or viewport.
+  // a function is resolved at gesture time, for bounds moving with node or viewport
   max_width?: ResizeLimit
   max_height?: ResizeLimit
   handle_size?: number // px, default 8
@@ -25,10 +25,10 @@ export interface ResizableOptions {
   on_resize_reset?: ResizeCallback
 }
 
-// One `[data-resize-edge]` child per edge, plus a `[data-resize-corner]` child wherever two
-// enabled edges meet (touch-action has no per-region form). Every handle is focusable,
-// takes arrow keys, and resets on Enter. Promotes `position: static` → `relative`. Put
-// overflow on a child — a scrollable node scrolls the handles out of view.
+// One `[data-resize-edge]` child per edge plus a `[data-resize-corner]` wherever two enabled
+// edges meet (touch-action has no per-region form). Handles are focusable, take arrow keys
+// and reset on Enter. Promotes `position: static` to `relative`. Put overflow on a child: a
+// scrollable node scrolls the handles out of view.
 export const resizable =
   (options: ResizableOptions = {}): Attachment =>
   (element: Element): (() => void) | undefined => {
@@ -61,8 +61,7 @@ export const resizable =
     }
 
     type Edge = `top` | `right` | `bottom` | `left`
-    // A corner press drives both axes at once, so the live grab is a pair of edges rather
-    // than a single one. Edge strips fill in only their own axis.
+    // a corner drives both axes, so a grab is a pair; edge strips fill in one side only
     type Grab = { horizontal?: `left` | `right`; vertical?: `top` | `bottom` }
     let is_resizing = false
     let stop_pointer_follow: (() => void) | undefined
@@ -73,8 +72,7 @@ export const resizable =
       computed.position === `static` ? node.style.position : undefined
     if (previous_position !== undefined) node.style.position = `relative`
     // Absolute children anchor to the padding box, so a strip at `edge: 0` sits inside the
-    // border and leaves the visible edge ungrabbable. Negative insets put it back on the
-    // border box, the region the pointer used to be hit-tested against.
+    // border and leaves the visible edge ungrabbable; negative insets restore the border box.
     const inset = (edge: Edge) =>
       -(css_px(computed.getPropertyValue(`border-${edge}-width`)) || 0)
 
@@ -86,7 +84,7 @@ export const resizable =
       const current_style = getComputedStyle(node)
       const style_px = (property: string) =>
         css_px(current_style.getPropertyValue(property)) || 0
-      // What offsetWidth/Height carry beyond the CSS width/height on a content-box node.
+      // what offsetWidth/Height carry beyond CSS width/height on a content-box node
       const content_box_inset = (start: Edge, end: Edge) =>
         current_style.boxSizing === `border-box`
           ? 0
@@ -108,8 +106,8 @@ export const resizable =
         Math.max(0, typeof limit === `function` ? limit(node) : limit)
       return { width: resolve(max_width), height: resolve(max_height) }
     }
-    // Only this instance's own strips — `querySelectorAll` would also rewrite the values of
-    // a nested resizable's separators, which report a different element's size.
+    // this instance's strips only: `querySelectorAll` would also rewrite a nested
+    // resizable's separators, which report a different element's size
     const separators: { handle: HTMLElement; controls_width: boolean }[] = []
     const sync_separator_values = (
       current: Dimensions = { width: node.offsetWidth, height: node.offsetHeight },
@@ -145,7 +143,7 @@ export const resizable =
       let height =
         measured.height +
         (grab.vertical === `bottom` ? delta_y : grab.vertical ? -delta_y : 0)
-      // Content-box padding and borders cannot shrink, so they set the real floor.
+      // content-box padding and borders cannot shrink, so they set the real floor
       const minimum_width = Math.min(
         Math.max(min_width, measured.width_inset),
         maximum.width,
@@ -162,8 +160,8 @@ export const resizable =
         measured.width > 0 &&
         measured.height > 0
       ) {
-        // Both axes are clamped in width space — scaling the height bounds by the ratio makes
-        // the two directions the same computation — and the axis that moved further drives.
+        // clamp both axes in width space (scaling height bounds by the ratio makes the two
+        // directions one computation); the axis that moved further drives
         const aspect_ratio = measured.width / measured.height
         const width_change = Math.abs(width - measured.width) / measured.width
         const height_change = Math.abs(height - measured.height) / measured.height
@@ -188,9 +186,9 @@ export const resizable =
         node.style.top = `${measured.top - (height - measured.height)}px`
         repositioned.top = true
       }
-      // Callbacks and constraints use border-box dimensions; CSS width/height do not
-      // include padding and borders on content-box elements. Only the grabbed axis is
-      // written: pinning the other one would freeze a height-only node's natural width.
+      // Callbacks and constraints are border-box, unlike CSS width/height on content-box
+      // elements. Only the grabbed axis is written; pinning the other would freeze a
+      // height-only node's natural width.
       if (grab.horizontal)
         node.style.width = `${Math.max(0, width - measured.width_inset)}px`
       if (grab.vertical)
@@ -202,7 +200,7 @@ export const resizable =
     }
 
     function on_pointerdown(event: PointerEvent, grab: Grab) {
-      // Bars a second primary mid-resize (mouse while a touch is down).
+      // bars a second primary mid-resize (mouse while a touch is down)
       if (is_resizing || !is_primary_press(event)) return
       is_resizing = true
 
@@ -281,7 +279,7 @@ export const resizable =
       )
       on_resize_end?.(event, dimensions)
     }
-    // An edge grab names one side and drives one axis; a corner names both and drives both.
+    // an edge grab names one side and drives one axis; a corner names and drives both
     const add_handle = (grab: Grab, css: string) => {
       const handle = document.createElement(`div`)
       const edge =
@@ -334,8 +332,8 @@ export const resizable =
             ${[edge, ...cross].map((side) => `${side}: ${inset(side)}px`).join(`; `)}`,
           )
         }),
-      // Where two enabled edges meet, a square handle drives both axes. Appended after the
-      // strips so it paints over their overlap, which otherwise resizes one axis only.
+      // Square handle driving both axes where two enabled edges meet. Appended after the
+      // strips so it paints over their overlap, which would otherwise resize one axis.
       ...vertical_edges.flatMap((vertical) =>
         horizontal_edges.map((horizontal) =>
           add_handle(

--- a/src/lib/attachments/shared.ts
+++ b/src/lib/attachments/shared.ts
@@ -1,5 +1,5 @@
-// Computed CSS lengths resolve to `<number>px`; strip the unit so Number() can coerce.
-// Empty and non-px values (e.g. `none`, `0.5rem`) yield NaN so callers can apply fallbacks.
+// Computed CSS lengths resolve to `<number>px`; strip the unit so Number() coerces. Empty
+// and non-px values (`none`, `0.5rem`) give NaN, leaving fallbacks to the caller.
 export const css_px = (css_length: string): number => {
   const trimmed = css_length.trim()
   return trimmed ? Number(trimmed.replace(/px$/, ``)) : NaN
@@ -42,10 +42,10 @@ export const follow_pointer = (
   return stop
 }
 
-// Layered keys: only the innermost surface hears one, so Escape closes a dropdown
-// inside a modal and leaves the modal standing, and a dialog opened from a dialog
-// owns Tab. Layers register in attach order, which matches nesting in practice.
-// Capture phase so a handler calling stopPropagation cannot suppress them.
+// Layered keys: only the innermost surface hears one, so Escape closes a dropdown inside a
+// modal and leaves the modal standing, and a dialog opened from a dialog owns Tab. Layers
+// register in attach order (nesting order in practice), in the capture phase so a
+// stopPropagation elsewhere cannot suppress them.
 type KeyLayer = (event: KeyboardEvent) => boolean
 
 const key_layer_stack = (wants: (event: KeyboardEvent) => boolean) => {
@@ -67,8 +67,8 @@ const key_layer_stack = (wants: (event: KeyboardEvent) => boolean) => {
   }
 }
 
-// Register a handler on the shared LIFO Escape stack. Only the latest handler runs;
-// already-handled and IME-composition events are skipped. Returns an unregister function.
+// Registers on the shared LIFO Escape stack, returning an unregister. Only the latest
+// handler runs; already-handled and IME-composition events are skipped.
 export const register_escape_layer = key_layer_stack(
   (event) => event.key === `Escape` && !event.isComposing,
 )

--- a/src/lib/attachments/sortable.ts
+++ b/src/lib/attachments/sortable.ts
@@ -16,7 +16,7 @@ export interface SortableOptions {
   disabled?: boolean
 }
 
-// Attachment making an HTML table sortable by clicking column headers (click again to flip direction)
+// sorts a table by clicking column headers; clicking again flips direction
 export const sortable =
   (options: SortableOptions = {}) =>
   (node: HTMLElement) => {
@@ -98,8 +98,8 @@ export const sortable =
         )
         rows.sort((row_1, row_2) => {
           const [cell_1, cell_2] = [row_1.cells[idx], row_2.cells[idx]]
-          // Rows can have fewer cells than the sort column (colspan placeholders,
-          // ragged rows) — treat missing cells as empty so they sort last
+          // rows can have fewer cells than the sort column (colspan, ragged rows), so
+          // missing cells count as empty and sort last
           const val_1 = cell_1 ? get_html_sort_value(cell_1) : ``
           const val_2 = cell_2 ? get_html_sort_value(cell_2) : ``
 

--- a/src/lib/attachments/tooltip.ts
+++ b/src/lib/attachments/tooltip.ts
@@ -44,8 +44,8 @@ export interface TooltipOptions {
   delegate?: boolean | string
   style?: string
   show_arrow?: boolean
-  // HTML is opt-in, including delegated title/aria-label/data-title. Only pass trusted
-  // content; pair user-controlled delegated attributes with sanitize_html.
+  // Opt-in, including delegated title/aria-label/data-title. Trusted content only; pair
+  // user-controlled delegated attributes with sanitize_html.
   allow_html?: boolean
   sanitize_html?: (html: string) => string
 }
@@ -99,8 +99,7 @@ const TOOLTIP_CSS_VARS = [
   `--tooltip-z-index`,
 ] as const
 
-// How an ending interaction names its close: a focus becomes a blur, a pointer keeps
-// its own name.
+// how an ending interaction names its close: focus becomes blur, pointer keeps its name
 const CLOSE_REASON = { pointer: `pointer`, focus: `blur` } as const
 
 const ARROW_PLACEMENT: Record<Placement, readonly [Placement, number]> = {
@@ -110,9 +109,9 @@ const ARROW_PLACEMENT: Record<Placement, readonly [Placement, number]> = {
   right: [`left`, 225],
 }
 
-// The two corners flanking each arrow side, in cross-axis order. The arrow tracks the edge
-// it hangs off, for these and for its border below, which differs from any fixed side only
-// under a consumer stylesheet: every --tooltip-* shorthand sets all four alike.
+// The two corners flanking each arrow side, cross-axis order. Arrow tracks the edge it
+// hangs off (here and for its border below), which only a consumer stylesheet can make
+// differ from a fixed side: every --tooltip-* shorthand sets all four alike.
 const SIDE_CORNERS: Record<Placement, readonly [string, string]> = {
   top: [`top-left`, `top-right`],
   bottom: [`bottom-left`, `bottom-right`],
@@ -125,7 +124,7 @@ const handled_tooltip_events = new WeakSet<Event>()
 const is_transparent = (color: string): boolean =>
   [``, `transparent`, `rgba(0, 0, 0, 0)`].includes(color.trim())
 
-// Computed length or a fallback when the property is unset or not in px.
+// computed length, falling back when the property is unset or not in px
 const css_px_or = (css_length: string, fallback: number): number => {
   const parsed = css_px(css_length)
   return Number.isFinite(parsed) ? parsed : fallback
@@ -138,9 +137,8 @@ const accepts_tooltip_trigger = (
   trigger: `hover` | `focus`,
 ): boolean => [trigger, `hover-focus`].includes(tooltip_trigger(options))
 
-// A trigger that left the document or stopped rendering cannot anchor anything.
-// `checkVisibility` covers detachment, `display: none` and `content-visibility` alike;
-// `isConnected` is the fallback where it is unavailable.
+// A detached or non-rendering trigger anchors nothing. `checkVisibility` covers detachment,
+// `display: none` and `content-visibility` alike; `isConnected` is the fallback.
 const is_trigger_visible = (trigger: HTMLElement): boolean =>
   typeof trigger.checkVisibility === `function`
     ? trigger.checkVisibility()
@@ -171,8 +169,7 @@ const remove_description = (element: Element, id: string): void => {
   else element.removeAttribute(`aria-describedby`)
 }
 
-// The visual viewport (so an open on-screen keyboard shrinks it), clipped to the
-// boundary element when one is given.
+// visual viewport (so an on-screen keyboard shrinks it), clipped to any boundary element
 const resolve_boundary = (options: TooltipOptions, doc: Document) => {
   const view = doc.defaultView
   const visual = view?.visualViewport
@@ -208,7 +205,7 @@ const sync_arrow_styles = (
   const anchor_center = vertical
     ? (trigger_rect.left + trigger_rect.right) / 2 - left
     : (trigger_rect.top + trigger_rect.bottom) / 2 - top
-  // This clamp exists to hold the tip off a curve, so it measures the near corners.
+  // clamp keeps the tip off a curve, so it measures the near corners
   const corner_radius = (corner: string) =>
     css_px_or(styles.getPropertyValue(`border-${corner}-radius`), 0)
   const [start_corner, end_corner] = SIDE_CORNERS[inset_side]
@@ -219,24 +216,24 @@ const sync_arrow_styles = (
   const fill_color = is_transparent(background)
     ? `var(--tooltip-bg, light-dark(#fff, #2a2a2e))`
     : background
-  // The width the surface's border actually occupies, per side. `border_width` is the
-  // painted one: the same measurement, zeroed on a see-through color, which is what the
-  // arrow draws on itself. A transparent border still takes up layout, so the two differ.
+  // Width the border occupies in layout. `border_width` below is the painted width — the
+  // same measurement zeroed on a see-through color — which is what the arrow draws; a
+  // transparent border still takes up layout, so the two differ.
   const layout_border = (side: string) =>
     css_px_or(styles.getPropertyValue(`border-${side}-width`), 0)
-  // The arrow paints the border of the edge it continues, at that edge's width.
+  // the arrow paints the border of the edge it continues, at that edge's width
   const border_color = styles.getPropertyValue(`border-${inset_side}-color`)
   const border_width = is_transparent(border_color) ? 0 : layout_border(inset_side)
   const arrow_side = (arrow_px + border_width) * Math.SQRT2
   arrow.style.cssText = `position: absolute; box-sizing: border-box; width: ${arrow_side}px; height: ${arrow_side}px; pointer-events: none; background: ${fill_color}; border: ${border_width}px solid ${border_color}; clip-path: polygon(0 0, 100% 0, 100% 100%); transform: rotate(${rotation_deg}deg);`
   const set = (property: string, value: string) =>
     arrow.style.setProperty(property, value)
-  // Absolute insets resolve against the padding box while everything measured above is in
-  // border-box space, so both axes have to put the surface's border back.
+  // insets resolve against the padding box, measurements above are border-box, so both
+  // axes add the surface's border back
   const cross_side = vertical ? `left` : `top`
   set(cross_side, `${cross_axis_center - arrow_side / 2 - layout_border(cross_side)}px`)
-  // On the main axis the square's center lands on the border edge, which puts the tip
-  // exactly `arrow_px` clear of the surface — the painted border covers the overlap.
+  // main axis: the square's center sits on the border edge, so the tip clears the surface
+  // by exactly `arrow_px` and the painted border covers the overlap
   set(inset_side, `${-arrow_side / 2 - (layout_border(inset_side) - border_width)}px`)
 }
 
@@ -277,8 +274,8 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
   arrow_el.className = `custom-tooltip-arrow`
   let open_timeout: ReturnType<typeof setTimeout> | undefined
   let close_timeout: ReturnType<typeof setTimeout> | undefined
-  // Subscriptions that live exactly as long as the tooltip is open, each returning its
-  // own stopper. Collecting them means opening cannot start one that closing forgets.
+  // subscriptions that live exactly as long as the tooltip is open; collecting their
+  // stoppers means opening can't start one that closing forgets
   let stop_open_effects: (() => void)[] = []
   let render_cleanup: (() => void) | undefined
   let last_closed_at = -Infinity
@@ -309,9 +306,8 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     surface.style.display = `none`
   }
 
-  // Every exit path has to come through here. A dismissal that hands focus back to the
-  // trigger re-enters and can open again on the way out, so an owner being dropped is
-  // not proof that nothing is subscribed.
+  // Every exit path comes through here: a dismissal that hands focus back to the trigger
+  // re-enters and can reopen, so a dropped owner is no proof nothing is subscribed.
   const stop_open_subscriptions = () => {
     active_observer.disconnect()
     removal_observer.disconnect()
@@ -330,9 +326,9 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
   const track_input = (event: PointerEvent | KeyboardEvent) => {
     last_input_was_touch = event instanceof PointerEvent && event.pointerType === `touch`
     if (!active || !(event instanceof PointerEvent)) return
-    // A press dismisses a hover tooltip, which would otherwise hang over whatever the
-    // press opened; the pointer leaving and re-entering the trigger brings it back.
-    // `hover-focus` keeps its own: the press focuses the trigger, which is a show state.
+    // A press dismisses a hover tooltip that would otherwise hang over whatever it opened;
+    // re-entering the trigger brings it back. `hover-focus` keeps its own, since the press
+    // focuses the trigger, itself a show state.
     if (tooltip_trigger(active.registration.options) !== `hover`) return
     if (event.target instanceof Node && active.trigger.contains(event.target)) {
       request_close(`pointer`, true)
@@ -391,7 +387,7 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     )
   }
 
-  // Wipes whatever the previous owner left inline, so nothing leaks between triggers.
+  // wipes the previous owner's inline styles, so nothing leaks between triggers
   const reset_surface_styles = () => {
     surface.style.cssText = `
       position: fixed; inset: auto; margin: 0; z-index: var(--tooltip-z-index, 9999);
@@ -412,8 +408,8 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     `
   }
 
-  // Theme vars, typography and writing direction come from the trigger, so the surface
-  // reads as part of the thing it describes rather than as page chrome.
+  // theme vars, typography and writing direction come from the trigger, so the surface
+  // reads as part of what it describes rather than as page chrome
   const inherit_trigger_styles = (trigger: HTMLElement) => {
     const trigger_styles = getComputedStyle(trigger)
     for (const css_var_name of TOOLTIP_CSS_VARS) {
@@ -426,7 +422,7 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     surface.style.fontStyle = trigger_styles.fontStyle
     surface.style.fontWeight = trigger_styles.fontWeight
     surface.style.letterSpacing = trigger_styles.letterSpacing
-    // `closest` matches the trigger itself first, so it covers its own lang/dir too.
+    // `closest` matches the trigger itself first, covering its own lang/dir
     const nearest = (attribute: string, ...rest: (string | undefined)[]) =>
       first_nonempty(
         trigger.closest(`[${attribute}]`)?.getAttribute(attribute),
@@ -436,9 +432,9 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     surface.dir = nearest(`dir`, doc.documentElement.dir, trigger_styles.direction)
   }
 
-  // A page that goes dark through CSS vars alone resolves the default light-dark()
-  // background to LIGHT while inheriting near-white text. Follow the OS preference
-  // instead, unless the page declares a scheme or the trigger overrides either var.
+  // A page going dark through CSS vars alone resolves the default light-dark() background
+  // to light while inheriting near-white text, so follow the OS preference unless the page
+  // declares a scheme or the trigger overrides either var.
   const apply_color_scheme_fallback = () => {
     const body_styles = getComputedStyle(doc.body)
     if (body_styles.colorScheme && body_styles.colorScheme !== `normal`) return
@@ -451,12 +447,12 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     surface.style.setProperty(`--text-color`, `light-dark(#222, #eee)`)
   }
 
-  // Ordering is the whole contract here: the consumer's `style` is the last word, and
-  // the scheme fallback judges vars every earlier step may have set.
+  // Ordering is the contract: the consumer's `style` is the last word, and the scheme
+  // fallback judges vars every earlier step may have set.
   const apply_surface_context = (trigger: HTMLElement, options: TooltipOptions): void => {
     reset_surface_styles()
     inherit_trigger_styles(trigger)
-    // The base rules already wrap; only `nowrap` has to undo them.
+    // base rules already wrap; only `nowrap` has to undo them
     const wrap = options.wrap ?? `balance`
     surface.style.textWrap = wrap === `normal` ? `wrap` : wrap
     if (wrap === `nowrap`) {
@@ -507,7 +503,7 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     surface.style.setProperty(`--tooltip-available-width`, available_width)
     compact_balanced_tooltip()
     const trigger_rect = active.trigger.getBoundingClientRect()
-    // A zero-area rect carries no position, so it can never count as scrolled away.
+    // a zero-area rect carries no position, so it never counts as scrolled away
     const has_area =
       trigger_rect.right > trigger_rect.left || trigger_rect.bottom > trigger_rect.top
     const off_screen =
@@ -520,8 +516,7 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
       return
     }
     const tooltip_rect = surface.getBoundingClientRect()
-    // Only placement and offset differ from compute_position's own defaults, so the
-    // remaining options pass straight through.
+    // only placement and offset differ from compute_position's defaults
     const { top, left, placement } = compute_position(trigger_rect, tooltip_rect, {
       placement: options.placement ?? `auto`,
       offset: options.offset ?? 12,
@@ -569,8 +564,8 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     if (keep_active) {
       closing.pointer_surface = false
       if (closing.focus === `surface`) closing.focus = null
-      // Not a self-assignment: handing focus back above re-enters through focusout and
-      // focusin, which can null `active` or install a fresh one over the dismissal.
+      // not a self-assignment: handing focus back re-enters via focusout/focusin, which
+      // can null `active` or install a fresh one over the dismissal
       active = closing
     } else {
       release_delegated_title(closing.registration, closing.trigger)
@@ -599,9 +594,9 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     options.on_open_change?.(false, { trigger: active.trigger, reason })
   }
 
-  // A custom element can put `title` back from its own attributeChangedCallback, so
-  // strip until it stops returning rather than trading one write per round. Returns the
-  // further attributes those synchronous rounds changed, or null if the trigger won.
+  // A custom element can restore `title` from attributeChangedCallback, so strip until it
+  // stops coming back. Returns attributes those synchronous rounds also changed, or null
+  // if the trigger won.
   const restrip_title = (observed: ActiveTooltip): string[] | null => {
     const { original_titles } = observed.registration
     let title = observed.trigger.getAttribute(`title`)
@@ -625,8 +620,8 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     if (changed_attributes.includes(`title`)) {
       const also_changed = restrip_title(observed)
       if (!also_changed) {
-        // Throwing would only reach the global error handler, so give up loudly and
-        // leave the native title in place rather than looping forever.
+        // throwing would only reach the global error handler, so give up loudly and
+        // leave the native title in place rather than loop forever
         console.error(
           `tooltip title could not be stripped from <${observed.trigger.tagName.toLowerCase()}>`,
         )
@@ -652,17 +647,16 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     position_active()
   })
 
-  // Detaching a trigger fires no scroll or resize, so repositioning alone would leave
-  // the surface pinned to geometry nothing owns any more. Detaching is also all a
-  // childList record can report, so this asks `isConnected` rather than paying for the
-  // style resolution behind `checkVisibility` on every batch the whole body produces.
-  // A trigger that stops rendering while still connected is the reposition's business.
+  // Detaching fires no scroll or resize, so repositioning alone would leave the surface
+  // pinned to dead geometry. Detachment is also all a childList record reports, hence
+  // `isConnected` over `checkVisibility`'s style resolution on every body-wide batch; a
+  // still-connected trigger that stops rendering is the reposition's business.
   const removal_observer = new MutationObserver(() => {
     if (active?.open && !active.trigger.isConnected) hide_active(`visibility`)
   })
 
-  // Fill the recycled surface and put it on screen. Top-layer mode degrades to absolute
-  // positioning where the Popover API is missing rather than throwing on every hover.
+  // Fill the recycled surface and show it. Top-layer mode degrades to absolute positioning
+  // without the Popover API rather than throwing on every hover.
   const mount_surface = (trigger: HTMLElement, options: TooltipOptions) => {
     surface.replaceChildren(content_el)
     if (options.show_arrow !== false) surface.append(arrow_el)
@@ -717,26 +711,24 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
         return true
       }),
     ]
-    // Before positioning, which may hide again and must then report a close that
-    // follows an open rather than one out of nowhere.
+    // before positioning, which may hide again and must report a close that follows an
+    // open rather than one out of nowhere
     options.on_open_change?.(true, { trigger: opening.trigger, reason })
     position_active()
   }
 
   const request_open = (reason: `pointer` | `focus` | `controlled`): void => {
-    // Re-entering during the close delay supersedes the pending close.
-    clear_close_timeout()
+    clear_close_timeout() // re-entering during the close delay supersedes it
     if (!active || active.phase === `dismissed` || active.open) return
     const { options } = active.registration
     const elapsed_since_close = Date.now() - last_closed_at
     const warm =
       elapsed_since_close >= 0 && elapsed_since_close <= (options.skip_delay_ms ?? 300)
     const delay = reason === `pointer` && !warm ? (options.open_delay_ms ?? 100) : 0
-    // show_active clears the pending timer itself, so an immediate open supersedes it.
+    // show_active clears the pending timer itself, so an immediate open supersedes it
     if (delay === 0) return show_active(reason)
-    // `pointerover` fires again on every crossing between the trigger's own children, so
-    // a pending open rides out its original delay: restarting it here would keep a
-    // tooltip on a trigger built from several elements from ever reaching its deadline.
+    // `pointerover` refires on every crossing between the trigger's own children, so a
+    // pending open keeps its original deadline instead of restarting forever
     open_timeout ??= setTimeout(() => show_active(reason), delay)
   }
 
@@ -758,7 +750,7 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     )
   }
 
-  // Whether the surface currently serves this registration aimed at this exact trigger.
+  // surface currently serves this registration aimed at this exact trigger
   const owns = (registration: TooltipRegistration, trigger: HTMLElement): boolean =>
     active?.registration === registration && active.trigger === trigger
 
@@ -767,8 +759,8 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
     trigger: HTMLElement,
     reason: `pointer` | `focus`,
   ): void => {
-    // One surface serves the document, so the newest interaction takes it — a controlled
-    // tooltip is preempted like any other and hears the close through on_open_change.
+    // One surface serves the document, so the newest interaction takes it; a controlled
+    // tooltip is preempted like any other and hears the close via on_open_change.
     if (active && !owns(registration, trigger)) hide_active(CLOSE_REASON[reason])
     remember_and_strip_title(registration, trigger)
     active ??= create_active_tooltip(registration, trigger)
@@ -796,9 +788,8 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
   ): void => {
     if (!active || active.registration !== registration) return
     const entered = event.relatedTarget instanceof Node ? event.relatedTarget : null
-    // Moving within the trigger never counts as leaving it.
-    if (entered && active.trigger.contains(entered)) return
-    // Crossing onto the hoverable surface hands the interaction over instead of ending it.
+    if (entered && active.trigger.contains(entered)) return // moving within the trigger
+    // crossing onto the hoverable surface hands the interaction over rather than ending it
     if (entered && surface.contains(entered)) {
       if (reason === `pointer`) {
         active.pointer_trigger = false
@@ -815,8 +806,8 @@ const create_tooltip_manager = (doc: Document, on_empty: () => void) => {
   const enter_focus = (registration: TooltipRegistration, trigger: HTMLElement): void => {
     const { options } = registration
     if (!accepts_tooltip_trigger(options, `focus`)) return
-    // A tap focuses right after suppressing the hover tooltip; only explicit focus
-    // mode still wants to open there.
+    // a tap focuses right after suppressing the hover tooltip; only explicit focus
+    // mode still wants to open there
     if (last_input_was_touch && options.trigger !== `focus`) return
     activate(registration, trigger, `focus`)
   }
@@ -906,8 +897,8 @@ const registration_target = (
   const { root, delegate_selector, original_titles } = registration
   if (!(event_target instanceof Element) || !root.contains(event_target)) return null
   if (!delegate_selector) return root
-  // Walk up to the root: a trigger whose title this registration already holds no longer
-  // matches the default selector, so past ownership counts alongside the selector.
+  // Walk up to the root. A trigger whose title this registration already holds no longer
+  // matches the default selector, so past ownership counts too.
   let candidate: Element | null = event_target
   while (candidate) {
     if (
@@ -951,7 +942,7 @@ export const tooltip =
     const manager = get_tooltip_manager(node.ownerDocument)
     const unregister = manager.register(registration)
 
-    // Nested tooltip containers both see the event; the innermost to claim it wins.
+    // nested tooltip containers both see the event; the innermost to claim it wins
     const claim = (event: Event): HTMLElement | null => {
       if (handled_tooltip_events.has(event)) return null
       const trigger = registration_target(registration, event.target)

--- a/src/lib/clipboard.svelte.ts
+++ b/src/lib/clipboard.svelte.ts
@@ -1,18 +1,16 @@
 import { SvelteSet } from 'svelte/reactivity'
 
-// Headless "recently copied" state for UIs that render their own copy affordances, where
-// CopyButton's markup would be in the way: a table of values each with its own checkmark,
-// a code block with a copy target per line.
+// Headless "recently copied" state for UIs rendering their own copy affordances, where
+// CopyButton's markup is in the way: a value table with a checkmark per row, a code block
+// with a copy target per line.
 
 export interface ClipboardFeedback {
-  // Keys flagged as copied within the last `duration_ms`. Reactive, so reading it in
-  // markup re-renders when a flag comes or goes.
+  // keys copied within the last `duration_ms`; reactive, so markup re-renders on change
   copied: SvelteSet<string>
-  // Writes `text` to the clipboard and flags `key` (the text itself by default). Returns
-  // whether the write succeeded; a failure only resolves to false if `on_error` is set to
-  // handle it, otherwise it throws.
+  // Writes `text` and flags `key` (the text itself by default), returning whether the write
+  // succeeded. A failure resolves false only when `on_error` handles it, else it throws.
   copy: (text: string, key?: string) => Promise<boolean>
-  // Drops the flag and its pending timer, for one key or all of them.
+  // drops the flag and its pending timer, for one key or all
   clear: (key?: string) => void
 }
 

--- a/src/lib/code-editor/CodeEditor.svelte
+++ b/src/lib/code-editor/CodeEditor.svelte
@@ -89,10 +89,8 @@
   type InputSnapshot = EditorSelection & { input_type: string; value_length: number }
   let before_snapshot: InputSnapshot | null = null
   let active_client: ReturnType<typeof create_highlight_client> | null = null
-  // A plain Map, not a SvelteMap: `touch_tokens` reorders it for the LRU on every render
-  // pass, and reactive entries turned each touch into a second full rebuild of
-  // `visible_rows` plus a second DOM reconciliation, for no visual difference. Reads are
-  // sequenced by `token_revision` instead, bumped wherever the contents actually change.
+  // Plain Map, not SvelteMap: the LRU touch on every render pass made reactive entries
+  // rebuild `visible_rows` and reconcile the DOM twice. `token_revision` sequences reads.
   const token_cache = new Map<number, SpanList>()
   const font_size = $derived(editor_font_size(Number(options.font_size)))
   const tab_size = $derived(clamp_integer(Number(options.tab_size), 1, 16, 2))
@@ -123,10 +121,8 @@
     }
     return complete
   }
-  // Drop only the cached spans an edit can actually have invalidated. Every line before
-  // the first edit's offset is untouched text, so its spans stay correct; clearing the
-  // whole cache on each transaction left the entire viewport unhighlighted until the
-  // debounced re-highlight returned, and evicted the full LRU on every keystroke.
+  // Drop only spans an edit can have invalidated: lines before the first edit are untouched.
+  // Clearing the whole cache blanked the viewport until the debounced re-highlight returned.
   const invalidate_tokens = (
     active_model: EditorModel,
     transaction: EditorTransaction,
@@ -135,12 +131,11 @@
     const { edits } = transaction
     if (edits.length === 0) return
     token_revision += 1
-    // `validate_edits` rejects `from < previous_end`, so edits ascend and the first one
-    // starts earliest. Text before it is identical in both documents, so this line index
-    // means the same thing before and after the transaction.
+    // `validate_edits` rejects `from < previous_end`, so edits ascend; text before the first
+    // is identical in both documents, so this line index means the same either side of it.
     const first_line = active_model.line_at(edits[0].from).line_idx
-    // A lone edit that inserts no newline and leaves the line count alone cannot have
-    // removed one either, so it is confined to its own line. That is ordinary typing.
+    // ordinary typing: a lone edit inserting no newline at an unchanged line count removed
+    // none either, so it is confined to its own line
     const single_line_edit =
       edits.length === 1 &&
       !edits[0].insert.includes(`\n`) &&
@@ -239,17 +234,15 @@
     overlay_width = 0
     caret_line = active_model.line_at(active_model.selection.head).line_idx
     before_snapshot = null
-    // Line count as of the previous notification, so a transaction can be classified as
-    // moving a line boundary or not without re-deriving the old document.
+    // count as of the previous notification, so a transaction can be classified as moving a
+    // line boundary without re-deriving the old document
     let previous_line_count = active_model.line_count
     const unsubscribe = active_model.subscribe((update) => {
       if (!is_current()) return
       caret_line = active_model.line_at(update.selection.head).line_idx
       if (update.transaction) {
-        // Only a transaction changes the text, and `line_count`/`visible_rows` read this
-        // to know when to re-read lines from the rope. The model also notifies on a bare
-        // selection change, and bumping it there re-read every visible line on each caret
-        // move — up to two rope descents per row, per keypress.
+        // Bumped only for transactions, which `line_count`/`visible_rows` read to re-read
+        // the rope; bumping on bare selection changes re-read every row on each caret move.
         model_revision += 1
         invalidate_tokens(active_model, update.transaction, previous_line_count)
         active.apply_transaction(update.transaction)
@@ -296,9 +289,8 @@
   })
   $effect(() => {
     void model_revision
-    // Spans arriving is what makes a previously-uncached window cached, so the LRU touch
-    // below has to re-run then. This used to ride on `model_revision`, which every caret
-    // move bumped; now that only a transaction does, the arrival needs its own signal.
+    // Arriving spans are what make an uncached window cached, so the LRU touch below must
+    // re-run then; `model_revision` no longer covers it, hence a signal of its own.
     void token_revision
     const { start, end } = window_lines
     const cached = untrack(() => touch_tokens(start, end))

--- a/src/lib/code-editor/DiffView.svelte
+++ b/src/lib/code-editor/DiffView.svelte
@@ -117,10 +117,8 @@
     }
   }
 
-  // Through a $derived so the effect tracks the *value*, not the `options` object. Reading
-  // `options.context_lines` in the effect made a host passing an inline object re-run a full
-  // backend diff, clear every expanded gap and jump to the top whenever any other field
-  // changed — a font-size tweak was enough.
+  // Through a $derived so the effect tracks the *value*, not the `options` object: reading
+  // `options.context_lines` inside it re-ran the whole diff on any other field change.
   const context_lines = $derived(options.context_lines)
   $effect(() => {
     void load_diff({
@@ -132,8 +130,8 @@
     return () => void load_generation++
   })
 
-  // Rebuild expanded gaps from props; DiffResult only keeps hunk lines. Gap text is
-  // unchanged but has no spans, so renders unhighlighted.
+  // Expanded gaps are rebuilt from props since DiffResult keeps only hunk lines; gap text
+  // has no spans, so it renders unhighlighted.
   const old_lines = $derived(split_text_lines(old_text))
   const new_lines = $derived(split_text_lines(new_text))
 
@@ -306,8 +304,8 @@
 {/snippet}
 
 {#snippet code_cell(line: DiffLine | null, row_class: string, side: string)}
-  <!-- white-space: pre makes stray text nodes real spaces. Fragment-boundary trimming
-  avoids them; the diff-view test pins indented-line reassembly. -->
+  <!-- white-space: pre turns stray text nodes into real spaces, hence the tight fragment
+  boundaries; the diff-view test pins indented-line reassembly -->
   {#if line}
     <span class="code {row_class}" data-side={side}>
       {#each render_tokens(line.text, line.spans) as token (token.start)}

--- a/src/lib/code-editor/edit-ops.ts
+++ b/src/lib/code-editor/edit-ops.ts
@@ -38,10 +38,9 @@ const touched_line_range = (
       : sel_end
   return [block_start, model.line_at(effective_end).to]
 }
-// Every whitespace character trimStart() would take except the line terminators, so the
-// commented-ness test and the width the uncomment slices off agree. Counting only [ \t]
-// let an exotic indent (a non-breaking space, a form feed) shift the slice into the token
-// and leave half of it behind.
+// Everything trimStart() would take except line terminators, so the commented-ness test and
+// the width uncommenting slices off agree. With only [ \t], an exotic indent (non-breaking
+// space, form feed) shifted the slice into the token and left half of it behind.
 const leading_whitespace = (line: string): string => /^[^\S\r\n]*/u.exec(line)?.[0] ?? ``
 const map_rewritten_column = (
   line: string,

--- a/src/lib/code-editor/tokens.ts
+++ b/src/lib/code-editor/tokens.ts
@@ -1,8 +1,6 @@
-// Decode backend SpanList (types.ts). UTF-16 offsets index JS strings directly; the
-// backend never emits a boundary inside a surrogate pair.
-//
-// Malformed spans are a backend bug, but throwing would blank the editor; fall back to
-// unstyled text.
+// Decode backend SpanList (types.ts). UTF-16 offsets index JS strings directly; the backend
+// never emits a boundary inside a surrogate pair. Malformed spans are a backend bug, but
+// throwing would blank the editor, so they fall back to unstyled text.
 
 import { clamp_integer } from '../utils'
 import { CLASS_MASK, EMPHASIS_BIT, TOKEN_CLASS_NAMES } from './types'
@@ -25,13 +23,12 @@ export const decode_spans = (spans: SpanList, line_length: number): DecodedSpan[
 
   if (!Array.isArray(spans) || spans.length < 2)
     return [{ start: 0, end: length, class_name: PLAIN, emphasized: false }]
-  // A trailing odd element is a truncated pair with no class; drop it.
+  // a trailing odd element is a truncated pair with no class
   const pair_count = Math.floor(spans.length / 2)
 
   const decoded: DecodedSpan[] = []
   let start = clamp_integer(spans[0], 0, length)
-  // A first span starting past 0 would silently drop the line's prefix, so paint
-  // the prefix as Plain rather than losing characters.
+  // paint a prefix the first span skips as Plain rather than lose those characters
   if (start > 0) {
     decoded.push({ start: 0, end: start, class_name: PLAIN, emphasized: false })
   }
@@ -46,14 +43,12 @@ export const decode_spans = (spans: SpanList, line_length: number): DecodedSpan[
     decoded.push({
       start,
       end,
-      // An out-of-range class index means the two sides of the wire contract
-      // drifted; render the text unstyled instead of crashing the line.
+      // an out-of-range index means the wire contract drifted; render unstyled, don't crash
       class_name: TOKEN_CLASS_NAMES[packed & CLASS_MASK] ?? PLAIN,
       emphasized: (packed & EMPHASIS_BIT) !== 0,
     })
     start = end
   }
-  // Non-empty lines always yield a span; prefix gaps are filled above.
   return decoded
 }
 
@@ -63,7 +58,7 @@ export interface RenderedToken {
   css: string
 }
 
-// Shared editor/diff tokenization; UTF-16 slicing stays in one place.
+// shared editor/diff tokenization, keeping UTF-16 slicing in one place
 export const render_tokens = (text: string, spans: SpanList): RenderedToken[] =>
   decode_spans(spans, text.length).map((span) => ({
     start: span.start,

--- a/src/lib/dialogs.svelte.ts
+++ b/src/lib/dialogs.svelte.ts
@@ -1,7 +1,6 @@
-// One in-app prompt for every question the app has to ask before proceeding. Mount a
-// single ConfirmDialog high in the tree and any code below can ask without owning a
-// modal of its own. Requests queue rather than overlap: two prompts racing in one modal
-// would leave the second answered by a click meant for the first.
+// One in-app prompt for every question the app must ask before proceeding: mount a single
+// ConfirmDialog high in the tree and any code below can ask without its own modal. Requests
+// queue rather than overlap, else a click meant for one prompt answers the next.
 
 import type { Snippet } from 'svelte'
 import { DIALOG_LABELS } from './labels'
@@ -9,8 +8,7 @@ import { DIALOG_LABELS } from './labels'
 export interface DialogChoice<Id extends string = string> {
   id: Id
   label: string
-  // Set on the answer to reach for, so it reads as the default without being the one a
-  // stray Escape picks.
+  // marks the answer to reach for: reads as the default without being what Escape picks
   tone?: `accent` | `danger`
 }
 
@@ -18,8 +16,8 @@ export type DialogBody =
   | { kind: `text`; text: string }
   | {
       kind: `snippet`
-      // The declaring component retains ownership of the snippet's scope and must stay
-      // mounted until this request settles. The queue stores only the callable reference.
+      // the queue stores only the callable, so the declaring component owns the snippet's
+      // scope and must stay mounted until this request settles
       snippet: Snippet
     }
 
@@ -33,8 +31,8 @@ interface DialogRequestBase {
 export interface ChoiceDialogRequest extends DialogRequestBase {
   kind: `choice`
   choices: DialogChoice[]
-  // Answer used when the dialog is dismissed rather than answered (Escape, a click on
-  // the backdrop). Always the safe one: dismissing is not consent.
+  // answer for a dismissal (Escape, backdrop click); always the safe one, since dismissing
+  // is not consent
   dismiss_id: string
   resolve: (id: string) => void
 }
@@ -86,14 +84,14 @@ export const request_choice = <Id extends string>(
       body: normalize_body(body),
       choices,
       dismiss_id,
-      // The queue is heterogeneous, so it holds the widened `string` form. Only a
-      // choice's own id or `dismiss_id` ever comes back, and both are `Id`.
+      // the heterogeneous queue holds the widened `string`; only a choice's id or
+      // `dismiss_id` comes back, and both are `Id`
       resolve: (id: string) => resolve(id as Id),
     })
   })
 
-// Resolves the request on screen. A no-op once the queue is empty, which is what keeps
-// the dialog's own close from answering the next question.
+// Resolves the on-screen request; a no-op on an empty queue, which keeps the dialog's own
+// close from answering the next question.
 export const answer_dialog = (id: string): void => {
   const request = dialog_queue[0]
   if (request?.kind !== `choice`) return
@@ -109,8 +107,7 @@ export const submit_prompt = (value: string): PromptSubmitResult => {
   const request = dialog_queue[0]
   if (request?.kind !== `prompt`) return { status: `no_prompt` }
   const validation_error = request.validate?.(value)
-  // Empty means valid: validators can directly return a conditional error string
-  // without having to convert their empty success branch to `undefined`.
+  // empty counts as valid, so a validator can return a conditional error string directly
   if (validation_error) return { status: `invalid`, message: validation_error }
   dialog_queue.shift()
   request.resolve(value)

--- a/src/lib/file-drop.ts
+++ b/src/lib/file-drop.ts
@@ -1,12 +1,9 @@
-// Flatten a drop into the files it actually carries.
-//
-// DataTransfer.files stops at the top level: drop a directory and it reports one
-// zero-byte File named after the directory. webkitGetAsEntry is the only way to see
-// inside, and it is only readable during the drop event itself.
+// Flatten a drop into the files it actually carries. DataTransfer.files stops at the top
+// level — a dropped directory reports one zero-byte File named after it — and
+// webkitGetAsEntry, the only way inside, is readable during the drop event alone.
 
-// Match the comma-separated unique file type specifiers accepted by
-// `<input type="file" accept="…">`: filename extensions, exact MIME types and MIME
-// wildcards. Empty accept strings impose no restriction, like the native input.
+// Matches the comma-separated specifiers of `<input type="file" accept="…">`: extensions,
+// exact MIME types and MIME wildcards. Empty accept means no restriction, as natively.
 export const file_matches_accept = (file: File, accept = ``): boolean => {
   const tokens = accept
     .split(`,`)
@@ -23,9 +20,8 @@ export const file_matches_accept = (file: File, accept = ``): boolean => {
   })
 }
 
-// Apply drop/input selection constraints in the same order as a native picker:
-// disallowed files disappear first, then a single-select consumer gets the first
-// remaining file rather than an unacceptable first item blocking later matches.
+// Native picker order: drop disallowed files first, so a single-select consumer gets the
+// first acceptable one rather than being blocked by an unacceptable first item.
 export const filter_accepted_files = (
   files: Iterable<File>,
   accept = ``,
@@ -45,8 +41,7 @@ const read_all_entries = async (
   reader: FileSystemDirectoryReader,
 ): Promise<FileSystemEntry[]> => {
   const entries: FileSystemEntry[] = []
-  // readEntries hands back at most 100 per call and signals the end with an empty batch,
-  // so one call is only enough for a small directory
+  // readEntries returns at most 100 per call and ends with an empty batch
   while (true) {
     const batch = await new Promise<FileSystemEntry[]>(reader.readEntries.bind(reader))
     if (batch.length === 0) return entries
@@ -54,12 +49,11 @@ const read_all_entries = async (
   }
 }
 
-// The entry API resolves symlinks, so a directory linked to one of its own ancestors
-// recurses forever and hangs the tab. Both caps are needed: depth alone stops a single
-// chain before the stack does, but two sibling links to a common ancestor branch as fast
-// as they descend — measured at 300k reads by depth 17 — so only a budget over the whole
-// expansion bounds that. Reported rather than silently truncated: a drop that quietly
-// lost half its files is worse than one that failed.
+// The entry API resolves symlinks, so a directory linked to an ancestor recurses forever.
+// Both caps are needed: depth stops a single chain, but two sibling links to a common
+// ancestor branch as fast as they descend (300k reads by depth 17), which only a
+// whole-expansion budget bounds. Reported, not silently truncated — losing half a drop's
+// files quietly is worse than failing.
 const MAX_DEPTH = 32
 const MAX_DIRS = 20_000
 
@@ -88,12 +82,10 @@ const files_from_entry = async (
   ).flat()
 }
 
-// Every file in a drop, with dropped directories expanded depth-first and in the order
-// the browser lists them. Falls back to the flat DataTransfer.files list when the entry
-// API yields nothing, which is what a paste or a synthetic drop event gives.
-//
-// Rejects on a tree that nests or branches past the caps above, so a drop handler has to
-// catch — a symlink cycle is the realistic way to get there.
+// Every file in a drop, directories expanded depth-first in the browser's own order,
+// falling back to flat DataTransfer.files when the entry API yields nothing (a paste or a
+// synthetic drop). Rejects past the caps above, so drop handlers must catch — a symlink
+// cycle is the realistic way there.
 export const files_from_data_transfer = async (
   data_transfer: DataTransfer,
 ): Promise<File[]> => {

--- a/src/lib/fullscreen.svelte.ts
+++ b/src/lib/fullscreen.svelte.ts
@@ -12,8 +12,8 @@ export type FullscreenSyncOptions = {
   on_request_error?: (error: unknown) => void
 }
 
-// Page background as an explicit color. `get_bg_color` walks body then html — themes
-// usually paint body — and the OS color scheme decides when both are transparent.
+// Page background as an explicit color: `get_bg_color` walks body (which themes usually
+// paint) then html, and the OS color scheme decides when both are transparent.
 export function get_page_background(
   fallback_dark = `#1a1a1a`,
   fallback_light = `#ffffff`,
@@ -69,8 +69,8 @@ export function sync_fullscreen(options: FullscreenSyncOptions): void {
     const fullscreen = options.get_fullscreen()
     reconcile(wrapper)
 
-    // a fullscreened element inherits nothing from the page and would render on black.
-    // Dropped again on the way out so a later theme switch cannot be read off a stale value.
+    // a fullscreened element inherits nothing and would render on black; dropped on the way
+    // out so a later theme switch cannot read a stale value
     const bg_css_var = options.get_bg_css_var?.() ?? `--fullscreen-bg`
     if (fullscreen) wrapper.style.setProperty(bg_css_var, get_page_background())
     else wrapper.style.removeProperty(bg_css_var)
@@ -82,9 +82,8 @@ export function sync_fullscreen(options: FullscreenSyncOptions): void {
     if (!wrapper) return undefined
 
     const handle_change = () => {
-      // key the flag to this wrapper: comparing against document.fullscreenElement alone
-      // would flip every mounted flag whenever any element goes fullscreen, and each
-      // flipped flag then fires its own requestFullscreen
+      // key the flag to this wrapper: a bare document.fullscreenElement check would flip
+      // every mounted flag on any fullscreen, each then firing its own requestFullscreen
       const is_fullscreen = document.fullscreenElement === wrapper
       const request_settling =
         pending_request?.wrapper === wrapper && pending_request.entering === is_fullscreen

--- a/src/lib/heading-anchors.ts
+++ b/src/lib/heading-anchors.ts
@@ -1,10 +1,9 @@
-// Svelte preprocessor that adds IDs to headings at build time, so fragment navigation
+// Svelte preprocessor adding heading IDs at build time, so fragment navigation
 // (#heading-id) works on the initial SSR page load
 
-// Match headings in two contexts:
-// 1. Start of line (for .svelte files with formatted HTML)
-// 2. After > (for mdsvex output where HTML is on single line, e.g., "</p> <h2>")
-// Quoted attributes may contain `>`; only an unquoted `>` ends the opening tag.
+// Headings appear at the start of a line (formatted .svelte HTML) or after `>` (mdsvex's
+// single-line output, e.g. "</p> <h2>"). Quoted attributes may contain `>`, so only an
+// unquoted one ends the opening tag.
 const heading_attrs = String.raw`(?:[^>"']|"[^"]*"|'[^']*')*`
 const heading_pattern = String.raw`<(?<tag>h[1-6])(?<attrs>${heading_attrs})>(?<inner>[\s\S]*?)<\/\k<tag>>`
 const heading_regex = new RegExp(String.raw`(?:^|(?<=>))\s*${heading_pattern}`, `gimu`)
@@ -41,8 +40,8 @@ const encode_vlq = (value: number): string => {
   return encoded
 }
 
-// Apply newline-free insertions and map every unchanged span back to its exact
-// original position. Inserted text maps to the insertion point.
+// Applies newline-free insertions, mapping unchanged spans to their original position and
+// inserted text to the insertion point.
 function insert_with_source_map(
   source: string,
   insertions: TextInsertion[],
@@ -139,8 +138,8 @@ function find_svelte_expression_end(str: string, start: number): number {
   return -1
 }
 
-// Remove Svelte expressions while ignoring braces inside quoted JS strings.
-// Unmatched } remains literal; unmatched { consumes the remaining text as before.
+// Removes Svelte expressions, ignoring braces inside quoted JS strings. An unmatched `}`
+// stays literal; an unmatched `{` consumes the rest.
 function strip_svelte_expressions(str: string): string {
   if (!str.includes(`{`)) return str
   let result = ``
@@ -221,21 +220,18 @@ const extract_math_sources = (inner: string): string =>
     return tex ? decode_entities(tex).replaceAll(/[{}]/gu, ``) : expression
   })
 
-// Preserve Unicode letters and marks, normalize equivalent spellings to NFC, and turn
-// punctuation runs into separators so distinct headings do not collapse to the same slug.
+// keeps Unicode letters and marks, normalizes to NFC, and separates on punctuation runs so
+// distinct headings don't collapse to one slug
 export const slugify_heading = (text: string): string =>
   text
     .toLowerCase()
     .normalize(`NFC`)
-    // Collapse punctuation and whitespace runs into separators so `foo.bar` cannot
-    // collide with `foobar`, while retaining Unicode letters, marks, and numbers.
+    // so `foo.bar` cannot collide with `foobar`
     .replaceAll(/[^\p{L}\p{M}\p{N}_]+/gu, `-`)
     .replaceAll(/^-|-$/gu, ``) // trim leading/trailing dashes
 
-// Allocate and reserve an ID in one operation. All heading-ID producers share this
-// `-1`, `-2`, ... collision policy, including collisions with already suffixed slugs.
-// Every id already in the document, for `unique_heading_id` to avoid. Lazy and memoized:
-// the scan is the expensive part and is only needed when some heading actually lacks an id.
+// Ids already in the document, for `unique_heading_id` to avoid. Lazy and memoized: the
+// scan is expensive and only needed when a heading actually lacks an id.
 export const document_used_ids = (): (() => Set<string>) => {
   let used_ids: Set<string> | undefined
   return () =>
@@ -244,6 +240,8 @@ export const document_used_ids = (): (() => Set<string>) => {
     ))
 }
 
+// Allocates and reserves an id in one step. Every heading-id producer shares this `-1`,
+// `-2`, ... collision policy, including collisions with already suffixed slugs.
 export function unique_heading_id(base_id: string, used_ids: Set<string>): string {
   const base = base_id || `section`
   let id = base
@@ -284,8 +282,8 @@ export function heading_ids() {
             tag: match.groups?.excluded_tag?.toLowerCase() ?? null,
           }),
         )
-        // Strictly inside an excluded span. The span's own opening tag sits at `start`
-        // and must stay eligible so its rendered `id` still reserves a collision slot.
+        // Strictly inside: the span's own opening tag sits at `start` and stays eligible,
+        // so its rendered `id` still reserves a collision slot.
         const is_inside_excluded = (
           index: number,
           range: { start: number; end: number },
@@ -324,12 +322,10 @@ export function heading_ids() {
 const link_svg = `<svg width="16" height="16" viewBox="0 0 16 16" aria-label="Link to heading" role="img"><path d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0z" fill="currentColor"/></svg>`
 
 export interface HeadingAnchorsOptions {
-  // CSS selector for headings (default: h1-h6 direct or 2nd-level children of attached node)
+  // heading selector, default h1-h6 direct or 2nd-level children of the attached node
   selector?: string
-  // Custom SVG icon HTML string (default: link icon)
-  // WARNING: Assigned via innerHTML - only pass trusted/sanitized content
-  // For untrusted input, sanitize first or use DOMParser:
-  // new DOMParser().parseFromString(svg, 'image/svg+xml').documentElement
+  // Assigned via innerHTML, so pass trusted content only; sanitize untrusted input first,
+  // e.g. new DOMParser().parseFromString(svg, 'image/svg+xml').documentElement
   icon_svg?: string
 }
 
@@ -342,7 +338,7 @@ function add_anchor_to_heading(
     heading.querySelector<HTMLAnchorElement>(`a[aria-hidden="true"]`)
   if (existing_anchor && !existing_anchor.hasAttribute(`data-heading-anchor`)) return
   if (!heading.id) {
-    // Generate ID from text content (fallback for dynamic headings)
+    // fall back to the text content, for dynamic headings
     const base_id = slugify_heading((heading.textContent ?? ``).trim())
     if (!base_id) return
     heading.id = unique_heading_id(base_id, get_used_ids())
@@ -364,7 +360,7 @@ const is_heading = (element: Element): boolean => /^H[1-6]$/u.test(element.tagNa
 const get_default_headings = (node: Element): Element[] =>
   [...node.children].flatMap((child) => [child, ...child.children].filter(is_heading))
 
-// Svelte 5 attachment that adds anchor links to headings within a container
+// adds anchor links to headings within a container
 export const heading_anchors =
   (options: HeadingAnchorsOptions = {}) =>
   (node: Element): (() => void) | undefined => {
@@ -383,7 +379,7 @@ export const heading_anchors =
     }
     add_anchors()
 
-    // Requery for new headings and keep existing links aligned with dynamic IDs.
+    // requery for new headings and keep existing links aligned with dynamic IDs
     const observer = new MutationObserver(() => {
       add_anchors()
       observer.takeRecords()

--- a/src/lib/katex.ts
+++ b/src/lib/katex.ts
@@ -49,8 +49,8 @@ const restore = (text: string, parts: string[], part_token: string): string => {
 }
 
 export function katex_preprocess(options: KatexOptions = {}) {
-  // Wire as `[katex.before, mdsvex(…), katex.after, …]`: run after before mdsvex and
-  // markdown linkifies xmlns URLs and smart-quotes the `{@html}` payload.
+  // Wire as `[katex.before, mdsvex(…), katex.after, …]`: `katex.after` has to follow mdsvex,
+  // or markdown linkifies the xmlns URLs and smart-quotes the `{@html}` payload it emits.
   const nonce = random_uuid()
   const part_token = `\0katex-${nonce}-`
   const slot_token = `${SLOT_OPEN}katex-${nonce}-`

--- a/src/lib/katex.ts
+++ b/src/lib/katex.ts
@@ -1,7 +1,6 @@
-// Svelte preprocessor that turns $…$ / $$…$$ into {@html katex…}.
-// Runs as a before/after pair around mdsvex: before stashes rendered KaTeX behind
-// placeholders (so markdown cannot mangle URLs/braces inside the HTML), after
-// expands them to {@html …}. This also avoids remark-math@3 (mdsvex's unified v9
+// Svelte preprocessor turning $…$ / $$…$$ into {@html katex…}. A before/after pair around
+// mdsvex: before stashes rendered KaTeX behind placeholders so markdown cannot mangle URLs
+// or braces in the HTML, after expands them. Also avoids remark-math@3 (mdsvex's unified v9
 // cannot load remark-math@4+).
 
 import { Buffer } from 'node:buffer'
@@ -50,8 +49,8 @@ const restore = (text: string, parts: string[], part_token: string): string => {
 }
 
 export function katex_preprocess(options: KatexOptions = {}) {
-  // Wire as `[katex.before, mdsvex(…), katex.after, …]` — if after runs before
-  // mdsvex, markdown linkifies xmlns URLs and smart-quotes the `{@html}` payload.
+  // Wire as `[katex.before, mdsvex(…), katex.after, …]`: run after before mdsvex and
+  // markdown linkifies xmlns URLs and smart-quotes the `{@html}` payload.
   const nonce = random_uuid()
   const part_token = `\0katex-${nonce}-`
   const slot_token = `${SLOT_OPEN}katex-${nonce}-`

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -1,21 +1,19 @@
 // Default user-facing strings for every widget, attachment and helper that renders text of
-// its own.
-//
-// Each one takes a `labels` prop (or option) accepting a partial of its record, merged over the
-// defaults below by `merge_defaults`, so a caller can translate or reword any string without
-// forking the component. Entries that interpolate a count or a name are functions rather than templates so
-// locales can control word order and their own plural rules (see https://github.com/janosh/svelte-widgets/issues/451).
+// its own. Each takes a `labels` prop (or option) whose partial `merge_defaults` merges over
+// the record below, so callers can translate without forking. Entries interpolating a count
+// or name are functions so locales control word order and plural rules
+// (https://github.com/janosh/svelte-widgets/issues/451).
 //
 // Strings a dedicated prop already supplies (MultiSelect's `removeBtnTitle`,
-// `noMatchingOptionsMsg`, `selectAllOption`, Toc's `title`, ...) are deliberately absent, and
-// so are non-string bits of chrome: icons keep their own `icons` prop. A prop that overrides
-// a string rather than supplying it does keep its default here — `selectAllDisabledTitle`
-// replaces the three select-all titles below, which is why those are still records.
+// `noMatchingOptionsMsg`, `selectAllOption`, Toc's `title`, ...) are deliberately absent, as
+// are non-string bits of chrome: icons keep their own `icons` prop. A prop that overrides
+// rather than supplies a string keeps its default here — `selectAllDisabledTitle` replaces
+// the three select-all titles below, which is why those stay records.
 //
 // Every record declares its defaults and derives its type from them, so the two cannot drift.
 
-// English plural of `noun`. Only the defaults below use it — an override brings its own
-// locale's rules, which is why every count-bearing entry is a function.
+// English plural of `noun`, used only by the defaults below — an override brings its own
+// locale's rules, hence every count-bearing entry being a function.
 const plural = (count: number, noun: string) => (count === 1 ? noun : `${noun}s`)
 
 // keyed by ActionState; per-state icons live in ActionButton's separate `icons` prop
@@ -47,16 +45,16 @@ export const CODE_EXAMPLE_LABELS = {
 export type CodeExampleLabels = typeof CODE_EXAMPLE_LABELS
 
 export const COPY_BUTTON_LABELS = {
-  // CopyButton is icon-only by default, and an empty string suppresses ActionButton's text.
-  // Its `pending` text is ActionButton's, reused for the in-flight copy, so there is no
-  // `pending` key here. Set any of these to show a label beside the icon.
+  // Icon-only by default; an empty string suppresses ActionButton's text. Set any of these
+  // to show a label beside the icon. `pending` is absent: the in-flight copy reuses
+  // ActionButton's own.
   ready: ``,
   success: ``,
   error: ``,
 }
 export type CopyButtonLabels = typeof COPY_BUTTON_LABELS
 
-// shared by every dialogs.svelte.ts helper, none of which is a component with a `labels` prop
+// shared by the dialogs.svelte.ts helpers, none of which is a component with a `labels` prop
 export const DIALOG_LABELS = {
   confirm: `OK`,
   cancel: `Cancel`,
@@ -110,8 +108,8 @@ export const FILE_DETAILS_LABELS = {
 export type FileDetailsLabels = typeof FILE_DETAILS_LABELS
 
 export const FIND_BAR_LABELS = {
-  // `scope` is the FindBar `label` prop, e.g. 'page' or 'settings'. Names both the
-  // search region and, suffixed with an ellipsis, the input placeholder.
+  // `scope` is FindBar's `label` prop ('page', 'settings', ...). Names the search region
+  // and, with an ellipsis, the input placeholder.
   find_in: (scope: string) => `Find in ${scope}`,
   prev_match: `Previous match`,
   next_match: `Next match`,
@@ -142,9 +140,8 @@ export const MULTI_SELECT_LABELS = {
   // composed from the removeBtnTitle prop and the option's label
   remove_option: (remove_btn_title: string, option_label: string) =>
     `${remove_btn_title} ${option_label}`,
-  // the title the disabled select-all row gets for each of its three reasons, and what
-  // `selectAllDisabledTitle` falls back to. 'matching' scope needs local options,
-  // so loadOptions rules it out.
+  // one title per reason the select-all row is disabled, and `selectAllDisabledTitle`'s
+  // fallback; 'matching' scope needs local options, so loadOptions rules it out
   matching_scope_unavailable: `Matching select-all is only available with local options`,
   max_select_reached: (max_select: number) => `Maximum of ${max_select} options selected`,
   all_options_selected: `All options already selected`,
@@ -175,8 +172,7 @@ export const NAV_LABELS = {
 }
 export type NavLabels = typeof NAV_LABELS
 
-// last-resort accessible name for the range slider, used only when the row has no title,
-// no schema description and no `setting` key to fall back on
+// last-resort slider name, only when the row has no title, schema description or `setting` key
 export const NUMBER_RANGE_INPUT_LABELS = {
   value: `Value`,
 }
@@ -223,10 +219,10 @@ export const TOAST_LABELS = {
 }
 export type ToastLabels = typeof TOAST_LABELS
 
-// Merge a caller's partial over a defaults record — label records, but icon sets too.
-// Spreading would keep an explicitly-undefined key as undefined rather than falling back,
-// and `exactOptionalPropertyTypes` is off, so `labels={{ close: cond ? `X` : undefined }}`
-// — an ordinary Svelte idiom — type-checks and then renders nothing at all.
+// Merge a caller's partial over a defaults record (label records, but icon sets too).
+// Spreading would keep an explicitly-undefined key instead of falling back, and with
+// `exactOptionalPropertyTypes` off `labels={{ close: cond ? `X` : undefined }}` type-checks
+// and then renders nothing.
 export const merge_defaults = <Defaults extends object>(
   defaults: Defaults,
   overrides?: Partial<Defaults>,

--- a/src/lib/live-examples/create-highlighter.ts
+++ b/src/lib/live-examples/create-highlighter.ts
@@ -1,6 +1,5 @@
-// Lazy starry-night factory. Kept separate from highlighter.ts so consumers picking
-// their own grammars can import it without evaluating that module's top-level await
-// of the 34-grammar common bundle.
+// Lazy starry-night factory, separate from highlighter.ts so consumers picking their own
+// grammars skip that module's top-level await of the 34-grammar common bundle.
 import type { Grammar } from '@wooorm/starry-night'
 import { type HastNode, escape_html_text, hast_to_html } from './hast.ts'
 
@@ -25,8 +24,8 @@ export type Highlighter = {
 export const optional_peer_error = `svelte-widgets/live-examples requires optional peer dependency @wooorm/starry-night`
 
 const create_instance = async (grammars: readonly Grammar[]): Promise<StarryNight> => {
-  // only the import is guarded: a grammar that fails to compile is a caller's bad input,
-  // not an absent peer dependency, and must not be reported as one
+  // only the import is guarded: a grammar failing to compile is bad caller input, not an
+  // absent peer dependency, and must not be reported as one
   const { createStarryNight } = await import(`@wooorm/starry-night`).catch(
     (cause: unknown) => {
       throw new Error(optional_peer_error, { cause })
@@ -38,9 +37,9 @@ const create_instance = async (grammars: readonly Grammar[]): Promise<StarryNigh
 const escape_svelte = (html: string): string =>
   html.replaceAll(`{`, `&#123;`).replaceAll(`}`, `&#125;`)
 
-// Falls back to plain escaped code when the language is missing or unsupported. Braces
-// are escaped on both paths: this HTML is written into mdsvex/Svelte markup, where a
-// stray `{` opens an expression, and highlight() hands it straight to the caller.
+// Falls back to plain escaped code for a missing or unsupported language. Braces are escaped
+// on both paths: this HTML lands in mdsvex/Svelte markup, where a stray `{` opens an
+// expression.
 const render_html = (
   instance: StarryNight,
   code: string,

--- a/src/lib/live-examples/hast.ts
+++ b/src/lib/live-examples/hast.ts
@@ -1,8 +1,7 @@
-// Minimal HAST-to-HTML serializer (only handles what starry-night outputs).
-// Kept dependency-free so FileDetails.svelte can import it without pulling in
-// the eagerly-initialized starry-night instance from highlighter.ts.
+// Minimal HAST-to-HTML serializer, handling only what starry-night outputs. Dependency-free
+// so FileDetails.svelte can import it without highlighter.ts's eager starry-night instance.
 
-// Structural type compatible with hast Root/Element/Text from starry-night
+// structural type compatible with hast Root/Element/Text
 export interface HastNode {
   type: string
   value?: string
@@ -14,7 +13,7 @@ export interface HastNode {
 // each replaceAll rebuilds the whole string, and most tokens have nothing to escape
 const HAS_ESCAPABLE = /[&<>]/u
 
-// Escape HTML special characters in text content (not for attribute values)
+// text content only, not attribute values
 export const escape_html_text = (str: string): string =>
   HAS_ESCAPABLE.test(str)
     ? str.replaceAll(`&`, `&amp;`).replaceAll(`<`, `&lt;`).replaceAll(`>`, `&gt;`)
@@ -30,8 +29,7 @@ const serialize_children = (children: HastNode[] | undefined): string => {
 export const hast_to_html = (node: HastNode): string => {
   if (node.type === `text`) return escape_html_text(node.value ?? ``)
   if (node.type === `root`) return serialize_children(node.children)
-  // Skip non-element nodes (comment, doctype, raw) - emitting them as elements
-  // would produce malformed `<undefined>` tags
+  // comment/doctype/raw nodes would emit malformed `<undefined>` tags
   if (node.type !== `element` || !node.tagName) return ``
   const { tagName, properties, children } = node
   const cls_val = properties?.className

--- a/src/lib/live-examples/index.ts
+++ b/src/lib/live-examples/index.ts
@@ -1,9 +1,8 @@
-// Live examples - transforms ```svelte example code blocks into rendered components
-// with syntax highlighting and live preview
-// Types only: this barrel also exports `starry_night`, whose top-level await compiles
-// the 34-grammar common bundle, so re-exporting the factory here would hand consumers a
-// route that silently costs them the very thing it exists to avoid. It lives at the
-// `svelte-widgets/live-examples/create-highlighter` subpath instead.
+// Live examples: ```svelte example blocks become rendered components with highlighting and
+// live preview. Types only — this barrel also exports `starry_night`, whose top-level await
+// compiles the 34-grammar common bundle, so the factory stays at the
+// `svelte-widgets/live-examples/create-highlighter` subpath rather than costing importers
+// the very thing it avoids.
 export type { Grammar, Highlighter, StarryNight } from './create-highlighter.ts'
 export { hast_to_html } from './hast.ts'
 export { starry_night, starry_night_highlighter } from './highlighter.ts'

--- a/src/lib/live-examples/index.ts
+++ b/src/lib/live-examples/index.ts
@@ -1,8 +1,8 @@
 // Live examples: ```svelte example blocks become rendered components with highlighting and
-// live preview. Types only — this barrel also exports `starry_night`, whose top-level await
-// compiles the 34-grammar common bundle, so the factory stays at the
-// `svelte-widgets/live-examples/create-highlighter` subpath rather than costing importers
-// the very thing it avoids.
+// live preview. From `./create-highlighter` it re-exports types only: the barrel already
+// pulls in `starry_night`, whose top-level await compiles the 34-grammar common bundle, so
+// the factory stays at the `svelte-widgets/live-examples/create-highlighter` subpath rather
+// than costing importers the very thing it avoids.
 export type { Grammar, Highlighter, StarryNight } from './create-highlighter.ts'
 export { hast_to_html } from './hast.ts'
 export { starry_night, starry_night_highlighter } from './highlighter.ts'

--- a/src/lib/live-examples/mdsvex-transform.ts
+++ b/src/lib/live-examples/mdsvex-transform.ts
@@ -1,4 +1,4 @@
-// Remark plugin - transforms ```svelte example code blocks into rendered components
+// Remark plugin turning ```svelte example code blocks into rendered components
 import { Buffer } from 'node:buffer'
 import path from 'node:path'
 import { language_label_html } from '../internal/language-label.ts'
@@ -14,10 +14,9 @@ const RE_SCRIPT_START = /<script\b(?:[^<>"']|"[^"]*"|'[^']*')*>/u
 const RE_SCRIPT_BLOCK = /<script[\s\S]*?>[\s\S]*?<\/script>/gu
 const RE_STYLE_BLOCK = /<style[\s\S]*?>[\s\S]*?<\/style>/gu
 
-// Parses key=value pairs from a string. Supports strings (with escaped quotes),
-// numbers, booleans, and arrays. Note: nested structures in arrays are not supported.
-// Bare values (key=foo, key=true, key=-1.5) are captured greedily so invalid JSON
-// throws a parse error instead of silently splitting into two bare-word keys.
+// key=value pairs: strings (escaped quotes included), numbers, booleans and flat arrays.
+// Bare values (key=foo, key=-1.5) are captured greedily so invalid JSON throws instead of
+// silently splitting into two bare-word keys.
 const RE_PARSE_META = /(?:\w+="(?:[^"\\]|\\.)*"|\w+=\[[^\]]*\]|\w+=[^\s"[\]]+|\w+)/gu
 
 export const EXAMPLE_MODULE_PREFIX = `___live_example___`
@@ -78,8 +77,7 @@ function remark(options: RemarkOptions = {}): RemarkTransformer {
   return function transformer(tree: RemarkTree, file: RemarkFile): void {
     // csr flag per live example (index = component index); drives the import loop below
     const example_csr: (boolean | undefined)[] = []
-    // Deduped wrapper imports: JSON key identifies the wrapper (string path or
-    // [module, export] tuple), value holds the generated alias + import statement
+    // deduped wrapper imports, keyed by JSON wrapper id (path or [module, export])
     const wrapper_imports = new Map<string, { alias: string; statement: string }>()
 
     const filename = path.relative(file.cwd, file.filename)
@@ -146,9 +144,8 @@ function remark(options: RemarkOptions = {}): RemarkTransformer {
     // Nothing to inject when the file contains no live examples
     if (!scripts) return
 
-    // Try to inject imports into existing script block. Only consider nodes that
-    // *start* with <script> — raw HTML nodes merely containing a <script> tag
-    // mid-content (e.g. inside {@html `...`}) must not receive the imports.
+    // Inject into an existing script block, but only nodes that *start* with <script>:
+    // raw HTML merely containing one mid-content (inside {@html `...`}) must not get them.
     let injected = false
     visit(tree, `html`, (node) => {
       if (injected || !node.value) return
@@ -200,20 +197,19 @@ function create_example_component(
 ): string {
   const code = format_code(value, meta)
   const tree = starry_night.highlight(code, scope)
-  // Convert newlines to &#10; to prevent bundlers from stripping whitespace
+  // &#10; keeps bundlers from stripping the whitespace
   const highlighted = hast_to_html(tree).replaceAll(`\n`, `&#10;`)
 
   if (index === -1) {
-    // Close and reopen <p> to avoid block-in-inline HTML nesting issues
+    // close and reopen <p> to avoid block-in-inline nesting
     return `</p><pre class="highlight highlight-${lang}" style="position:relative">${language_label_html(lang)}<code>{@html ${JSON.stringify(
       highlighted,
     )}}</code></pre><p>`
   }
 
-  // Live examples (svelte, html) - render with CodeExample wrapper.
-  // JSON.stringify alone produces a valid double-quoted JS string literal for the
-  // src={...} expression — escaping backticks/`${` on top of it would double-escape
-  // and inject literal backslashes into the runtime src prop.
+  // Live examples (svelte, html) render with the CodeExample wrapper. JSON.stringify alone
+  // yields a valid literal for src={...}; escaping backticks/`${` on top would double-escape
+  // and inject literal backslashes into the runtime prop.
   const component = `${EXAMPLE_COMPONENT_PREFIX}${index}`
   // base64-encode to prevent preprocessors from modifying the content
   const base64_src = Buffer.from(value, `utf-8`).toString(`base64`)

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -1,16 +1,16 @@
-// Vite plugin - handles virtual module resolution for example components
+// Vite plugin resolving virtual modules for example components
 import { Buffer } from 'node:buffer'
 import process from 'node:process'
 import type { HmrContext, Plugin, ViteDevServer } from 'vite'
-// Vite's own ESTree parser (native OXC, no extra dependency): same node types
-// and start/end offsets acorn produced, module + latest syntax by default
+// Vite's own ESTree parser (native OXC, no extra dependency): acorn's node types and
+// start/end offsets, module + latest syntax by default
 import { parseSync } from 'vite'
 import { EXAMPLE_MODULE_PREFIX } from './mdsvex-transform.ts'
 
 // Matches import paths emitted by mdsvex-transform, e.g. ___live_example___0.svelte
 const RE_EXAMPLE_IMPORT = new RegExp(`${EXAMPLE_MODULE_PREFIX}(\\d+)\\.svelte`, `u`)
 
-// Edit operation: replace text at [start, end) with content
+// replaces text at [start, end)
 type Edit = { start: number; end: number; content: string }
 type TransformResult = {
   code: string
@@ -24,7 +24,7 @@ const with_empty_map = (code: string): TransformResult => ({
 // chars to scan past a property for trailing comma/whitespace (typically just ", ")
 const TRAILING_CLEANUP_BOUND = 50
 
-// Apply edits in reverse order so positions stay valid
+// reverse order so earlier positions stay valid
 const apply_edits = (source: string, edits: Edit[]): string =>
   edits
     .toSorted((a, b) => b.start - a.start)
@@ -39,8 +39,8 @@ function is_record(val: unknown): val is Record<string, unknown> {
 
 type AstNode = Record<string, unknown>
 
-// Single-pass AST walk collecting the two node kinds this plugin rewrites:
-// __live_example_src properties and import declarations/expressions
+// one walk for both node kinds this plugin rewrites: __live_example_src properties and
+// import declarations/expressions
 function collect_nodes(tree: unknown): { src_props: AstNode[]; imports: AstNode[] } {
   const src_props: AstNode[] = []
   const imports: AstNode[] = []
@@ -63,8 +63,8 @@ function collect_nodes(tree: unknown): { src_props: AstNode[]; imports: AstNode[
   return { src_props, imports }
 }
 
-// Normalize a module ID to absolute path for consistent lookups.
-// Can't use path.posix.join because it treats /src/... as already absolute.
+// Absolute module ID for consistent lookups. Not path.posix.join: it treats /src/... as
+// already absolute.
 function to_absolute(id: string, cwd: string): string {
   if (id.startsWith(`${cwd}/`) || id === cwd) return id
   return id.startsWith(`/`) ? `${cwd}${id}` : `${cwd}/${id}`
@@ -75,16 +75,15 @@ export default function live_examples_plugin(
 ): Plugin[] {
   const { extensions = [`.svelte.md`, `.md`, `.svx`] } = options
 
-  // Extracted examples as individual virtual files (id -> svelte source)
+  // extracted examples: virtual id -> svelte source
   const virtual_files = new Map<string, string>()
 
   let vite_server: ViteDevServer | undefined
   let pending_hmr_file: string | null = null
   const cwd = process.cwd().replaceAll(`\\`, `/`)
 
-  // Pre-enforce plugin ensures resolveId runs before vite-plugin-svelte's
-  // load-compiled-css:resolveId, so CSS derived modules get the same absolute
-  // path as the main component (needed for module graph CSS cache lookup).
+  // Pre-enforced so resolveId beats vite-plugin-svelte's load-compiled-css:resolveId and
+  // derived CSS modules get the component's absolute path, which its cache lookup needs.
   const resolve_plugin: Plugin = {
     name: `live-examples-resolve`,
     enforce: `pre`,
@@ -105,8 +104,8 @@ export default function live_examples_plugin(
 
       const [base_id, query = ``] = id.split(`?`)
 
-      // Skip derived module requests (CSS, scripts) - let vite-plugin-svelte handle them.
-      // Must check BEFORE virtual_files lookup to avoid returning Svelte source for CSS.
+      // Leave derived requests (CSS, scripts) to vite-plugin-svelte. Must precede the
+      // virtual_files lookup, else CSS requests get Svelte source back.
       if (/type=(?<type>style|script|module)/u.test(query)) return undefined
 
       const src = virtual_files.get(base_id)
@@ -116,7 +115,7 @@ export default function live_examples_plugin(
       if (process.env.NODE_ENV === `production`) {
         throw new Error(msg)
       }
-      // In dev, warn and return error component to surface issue visibly
+      // in dev, warn and return an error component so the issue is visible
       this.warn(msg)
       return `<script>console.error(${JSON.stringify(
         msg,
@@ -124,22 +123,19 @@ export default function live_examples_plugin(
     },
 
     transform(code: string, id: string): TransformResult | undefined {
-      // Strip query params for extension check (Vite adds ?query for HMR, styles, etc.)
+      // strip Vite's ?query (HMR, styles, ...) before the extension check
       const base_id = id.split(`?`)[0]
 
       const is_example_module = id.includes(EXAMPLE_MODULE_PREFIX)
       const is_markdown = extensions.some((ext) => base_id.endsWith(ext))
       if (!is_example_module && !is_markdown) return undefined
 
-      // Skip derived modules (styles, etc.) - only process the main markdown file.
-      // Match both ?svelte&type= and ?inline&svelte&type= (SSR adds ?inline prefix)
+      // only the main markdown file; matches ?svelte&type= and SSR's ?inline&svelte&type=
       if (id.includes(`svelte&type=`)) return with_empty_map(code)
 
       if (is_markdown) {
-        // Use AST for precise node location, collect edits to apply at end.
-        // parseSync reports errors instead of throwing (unlike acorn): code may
-        // contain Svelte syntax the JS parser can't handle (e.g., template
-        // blocks, special directives) — skip transformation then.
+        // parseSync reports errors instead of throwing (unlike acorn), which matters
+        // because Svelte syntax the JS parser can't handle just skips the transform
         const { program: tree, errors } = parseSync(`file.js`, code)
         if (errors.length > 0) return with_empty_map(code)
         const edits: Edit[] = []
@@ -156,9 +152,8 @@ export default function live_examples_plugin(
             if (mod) server.moduleGraph.invalidateModule(mod)
           }
 
-          // Trigger full-reload only during HMR (not initial page load).
-          // reloadModule alone doesn't work because vite-plugin-svelte's hot-update
-          // handler skips CSS-only changes when the JS output is identical.
+          // full reload during HMR only: reloadModule alone doesn't suffice, since
+          // vite-plugin-svelte skips CSS-only changes when the JS output is identical
           if (pending_hmr_file !== base_id) return
           pending_hmr_file = null
           setTimeout(() => {
@@ -167,7 +162,6 @@ export default function live_examples_plugin(
         }
 
         for (const [idx, prop] of src_props.entries()) {
-          // Read the property value directly instead of recursively searching nested literals.
           const prop_value = prop.value
           if (!is_record(prop_value)) continue
           if (prop_value.type !== `Literal` || typeof prop_value.value !== `string`)
@@ -175,12 +169,12 @@ export default function live_examples_plugin(
 
           const src = Buffer.from(prop_value.value, `base64`).toString(`utf-8`)
 
-          // Use base_id (without query params) to ensure consistent virtual file IDs
+          // base_id, without query params, keeps virtual file IDs consistent
           const virtual_id = `${base_id}${EXAMPLE_MODULE_PREFIX}${idx}.svelte`
 
           if (src !== virtual_files.get(virtual_id)) {
             virtual_files.set(virtual_id, src)
-            // Invalidate after updating the source so load() serves the new content.
+            // after updating the source, so load() serves the new content
             invalidate_virtual_modules(virtual_id)
           }
 
@@ -193,8 +187,7 @@ export default function live_examples_plugin(
           }
         }
 
-        // Clear pending state even if no examples changed — stale flag would
-        // cause an unnecessary full-reload on a future edit
+        // clear even when no examples changed; a stale flag forces a needless full reload
         if (pending_hmr_file === base_id) pending_hmr_file = null
 
         // Update import paths (static and dynamic) to use virtual file IDs
@@ -227,9 +220,9 @@ export default function live_examples_plugin(
       if (extensions.some((ext) => file.endsWith(ext))) {
         pending_hmr_file = file
       }
-      // Don't add virtual modules here — they'd be loaded with stale content
-      // since the parent .md hasn't been re-transformed yet. The transform
-      // hook handles invalidation + reload after virtual_files is updated.
+      // No virtual modules here: the parent .md is not re-transformed yet, so they'd load
+      // stale content. The transform hook invalidates and reloads once virtual_files is up
+      // to date.
       return ctx.modules
     },
   }

--- a/src/lib/live-examples/vite-plugin.ts
+++ b/src/lib/live-examples/vite-plugin.ts
@@ -63,8 +63,8 @@ function collect_nodes(tree: unknown): { src_props: AstNode[]; imports: AstNode[
   return { src_props, imports }
 }
 
-// Absolute module ID for consistent lookups. Not path.posix.join: it treats /src/... as
-// already absolute.
+// Absolute module ID for consistent lookups. Not path.posix.join: it would double a cwd the
+// id already carries (`join('/repo', '/repo/src/x')` gives `/repo/repo/src/x`).
 function to_absolute(id: string, cwd: string): string {
   if (id.startsWith(`${cwd}/`) || id === cwd) return id
   return id.startsWith(`/`) ? `${cwd}${id}` : `${cwd}/${id}`

--- a/src/lib/portal.ts
+++ b/src/lib/portal.ts
@@ -4,10 +4,10 @@ import { compute_position } from './utils'
 
 type PortalActionParams = PortalParams & { open: boolean }
 
-// MultiSelect keeps this as an action wrapped by `fromAction`, so updates can toggle
-// portalling without replacing the node. It also owns width matching and DOM restoration.
-// Reposition after a tick so rendered dropdown content contributes to offsetHeight.
-// No SSR guard: Svelte only invokes actions on the client.
+// MultiSelect keeps this an action wrapped by `fromAction`, so updates can toggle portalling
+// without replacing the node; it also owns width matching and DOM restoration. Repositions
+// after a tick so rendered dropdown content counts toward offsetHeight. No SSR guard needed:
+// Svelte only runs actions on the client.
 export function portal_action(node: HTMLElement, initial_params: PortalActionParams) {
   let params = initial_params
   let home_parent: ParentNode | null = null
@@ -25,9 +25,9 @@ export function portal_action(node: HTMLElement, initial_params: PortalActionPar
     node.style.width = `${rect.width}px`
     node.hidden = false
     const dropdown_height = node.offsetHeight
-    // Only ever above or below: a dropdown beside its input is not a dropdown. Height
-    // 0 means the list has not rendered yet, so there is nothing to fit — stay below.
-    // No shift: the list scrolls, and sliding it up would cover the input.
+    // Only above or below: a dropdown beside its input is not a dropdown. Height 0 means
+    // the list has not rendered, so nothing to fit — stay below. No shift either: the list
+    // scrolls, and sliding it up would cover the input.
     const can_flip = placement === `auto` && dropdown_height > 0
     const { placement: chosen } = compute_position(
       rect,

--- a/src/lib/print.ts
+++ b/src/lib/print.ts
@@ -1,47 +1,42 @@
-// Print one element as a document of its own: the print dialog offers no handle on the
-// suggested PDF filename (it comes from document.title) or on pagination (a long element
-// is chopped across sheets), so both are set up here and undone on afterprint.
+// Print one element as its own document. The dialog exposes no handle on the suggested PDF
+// filename (it comes from document.title) or on pagination, so both are set up here and
+// undone on afterprint.
 
 export interface PrintOptions {
-  // Suggested PDF filename, applied by swapping document.title for the duration of the
-  // print and restoring it afterward. Omit to leave the title alone.
+  // suggested PDF filename, applied by swapping document.title for the print's duration
   filename?: string
-  // Size the page to the element instead of paginating it, so the output is a single
-  // continuous sheet however long the element is.
+  // size the page to the element rather than paginate it, however long the element is
   single_page?: boolean
-  // Printed page width in mm, only used with single_page. Defaults to A4 portrait.
+  // printed page width in mm, single_page only; defaults to A4 portrait
   page_width_mm?: number
-  // Converts the measured height into the mm @page takes. 96 is the CSS definition of an
-  // inch and what every engine prints at; override it where zoom scales absolute units,
-  // so a rect measured there converts at the ratio actually in force.
+  // Converts the measured height into @page's mm. 96 is the CSS inch every engine prints
+  // at; override where zoom scales absolute units, so the rect converts at the real ratio.
   px_per_inch?: number
 }
 
-// `prefix-YYYY-MM-DD`, the shape most people want out of a "save as PDF" button.
+// `prefix-YYYY-MM-DD`, the shape most "save as PDF" buttons want
 export const format_print_filename = (prefix: string, date = new Date()): string => {
   const month = String(date.getMonth() + 1).padStart(2, `0`)
   const day = String(date.getDate()).padStart(2, `0`)
   return `${prefix}-${date.getFullYear()}-${month}-${day}`
 }
 
-// Marks the element the injected rules apply to, so nothing about the caller's markup
-// (a class, an id, a tag name) has to be known here.
+// marks the element the injected rules apply to, so the caller's markup stays unknown here
 const print_attr = `data-print-target`
 
 // afterprint lands a turn of the event loop after print() returns, so back-to-back calls
-// overlap. Without this the second one reads the first one's filename as the title to put
-// back, and the page keeps that filename for good.
+// overlap: without this the second reads the first's filename as the title to restore, and
+// the page keeps that filename for good
 let title_swap_in_flight = false
 
-// Headless and embedded webviews return from print() without ever firing afterprint,
-// which leaves the swapped title and the injected rules standing for good and
-// title_swap_in_flight disabling every later swap. Long enough that a dialog a user
-// actually opened has closed first.
+// Headless and embedded webviews return from print() without firing afterprint, leaving the
+// swapped title and injected rules standing and title_swap_in_flight blocking later swaps.
+// Long enough that a dialog a user actually opened has closed first.
 const AFTERPRINT_TIMEOUT_MS = 60_000
 
-// Stamped into the marker attribute so a print only ever clears its own. The attribute is
-// shared state on the node, and disarming does not cover a watchdog that is still armed
-// because its own print never ended: it would strip a later print's marker off the node.
+// Stamped into the marker attribute so a print only clears its own: the attribute is shared
+// node state, and a watchdog still armed from a print that never ended would otherwise strip
+// a later print's marker.
 let print_seq = 0
 
 export const print_element = (node: HTMLElement, options: PrintOptions = {}): void => {
@@ -54,14 +49,13 @@ export const print_element = (node: HTMLElement, options: PrintOptions = {}): vo
   const token = `${++print_seq}`
 
   const cleanup = () => {
-    // afterprint and the watchdog both undo this print, so each disarms the other: a
-    // leftover one would fire mid-print later and strip that print's setup instead
+    // afterprint and the watchdog each disarm the other; a leftover one would fire during
+    // a later print and strip that print's setup
     clearTimeout(watchdog)
     globalThis.removeEventListener(`afterprint`, cleanup)
     if (restore_title !== null) {
       document.title = restore_title
-      // Prevent another cleanup from restoring this title again.
-      restore_title = null
+      restore_title = null // stops a second cleanup restoring it again
       title_swap_in_flight = false
     }
     // the selector matches on presence, so the token is invisible to the printed rules
@@ -77,13 +71,12 @@ export const print_element = (node: HTMLElement, options: PrintOptions = {}): vo
 
   if (single_page) {
     node.setAttribute(print_attr, token)
-    // Measured as the element stands on screen (getBoundingClientRect flushes layout): an
-    // @media print rule of the caller's own that changes it is not reflected here.
+    // measured as the element stands on screen, so a caller's own @media print rule that
+    // changes its height is not reflected here
     const height_px = node.getBoundingClientRect().height
     const height_mm = Math.ceil((height_px * 25.4) / px_per_inch)
 
-    // Ancestors are cleared as well, since a scrolling container clips the element to
-    // its own height and prints only what was in view.
+    // ancestors are cleared too: a scrolling container clips the element to its own height
     style = document.createElement(`style`)
     style.textContent = `@media print {
   @page { size: ${page_width_mm}mm ${height_mm}mm; margin: 0 }
@@ -93,14 +86,13 @@ export const print_element = (node: HTMLElement, options: PrintOptions = {}): vo
     document.head.append(style)
   }
 
-  // No setup means no listener/watchdog needs to retain `node`.
+  // no setup means no listener/watchdog needs to retain `node`
   if (restore_title !== null || style) {
-    // afterprint covers both saving and canceling the print dialog.
+    // afterprint covers both saving and canceling the dialog
     globalThis.addEventListener(`afterprint`, cleanup, { once: true })
     watchdog = setTimeout(cleanup, AFTERPRINT_TIMEOUT_MS)
   }
-  // A print() that throws never fires afterprint, so the swapped title and the injected
-  // rules would outlive the call and follow the page around.
+  // a print() that throws fires no afterprint, so title and rules would outlive the call
   try {
     globalThis.print()
   } catch (error) {

--- a/src/lib/source-links/index.ts
+++ b/src/lib/source-links/index.ts
@@ -1,9 +1,8 @@
-// Turns inline code spans that name a project's source into GitHub links, so docs never
-// hand-maintain source URLs: a file (`Footer`, `Footer.svelte`, `utils.ts`) links to the
-// file, an exported definition (`make_config`, `ThemeMode`) to its line. Only exact,
-// unambiguous names match: `index.ts` exists in many folders and `label` is a prop, so
-// neither links. Links pin the commit the site was built from so line numbers stay right.
-// The data comes from `virtual:source-symbols`, emitted by ./vite-plugin.ts.
+// Turns inline code spans naming a project's source into GitHub links, so docs never
+// hand-maintain URLs: a file (`Footer.svelte`) links to the file, an exported definition
+// (`make_config`) to its line. Only exact, unambiguous names match — `index.ts` exists in
+// many folders, `label` is a prop. Links pin the built commit so line numbers stay right.
+// Data comes from `virtual:source-symbols`, emitted by ./vite-plugin.ts.
 
 import { merge_defaults, SOURCE_LINKS_LABELS, type SourceLinksLabels } from '../labels'
 
@@ -22,8 +21,8 @@ export type SourceLinks = {
   link_source_mentions: (root: HTMLElement) => () => void
 }
 
-// Marks the anchors this module owns, and records the code-span text each was built
-// from, so a later scan can tell a stale link from an up-to-date one.
+// marks our own anchors and records the code-span text each was built from, so a later
+// scan can tell a stale link from a current one
 const OWN_LINK_ATTR = `data-source-link`
 
 export function create_source_links(
@@ -54,10 +53,9 @@ export function create_source_links(
     return location && href_of(location)
   }
 
-  // Client-side navigation swaps the page inside the same root, so a MutationObserver keeps
-  // linking. The anchor goes inside the code element and adopts its existing child nodes, so
-  // Svelte's references to those nodes (dynamic text, block boundaries) stay valid; code
-  // that already holds a link (ours or the author's) is left alone.
+  // Client-side navigation swaps the page inside the same root, hence the MutationObserver.
+  // The anchor goes inside the code element and adopts its child nodes, keeping Svelte's
+  // references to them valid; code already holding a link is left alone.
   const link_source_mentions = (root: HTMLElement): (() => void) => {
     const scan = (): void => {
       for (const code of root.querySelectorAll(`code`)) {
@@ -68,9 +66,9 @@ export function create_source_links(
         if (existing && built_from === null) continue
         const name = (code.textContent ?? ``).trim()
         if (existing) {
-          // Our anchor owns the code span's text nodes, so Svelte patches the text in
-          // place and the span stops matching the name the link was built from. Without
-          // this the link keeps pointing at whatever the span used to say, forever.
+          // Our anchor owns the span's text nodes, so Svelte patches text in place and the
+          // span stops matching the name the link was built from — without this the link
+          // points at what the span used to say, forever.
           if (built_from === name) continue
           code.append(...existing.childNodes)
           existing.remove()
@@ -95,8 +93,8 @@ export function create_source_links(
     schedule()
     const observer = new MutationObserver(schedule)
     // `characterData` because a reactive `<code>{name}</code>` rewrites its text node in
-    // place: no childList change, but the link built from the old text is now wrong. The
-    // rAF above coalesces the extra traffic down to one scan per frame.
+    // place: no childList record, but the link built from the old text is now wrong. The
+    // rAF above coalesces the extra traffic to one scan per frame.
     observer.observe(root, { childList: true, subtree: true, characterData: true })
     return () => {
       observer.disconnect()

--- a/src/lib/source-links/vite-plugin.ts
+++ b/src/lib/source-links/vite-plugin.ts
@@ -1,6 +1,6 @@
-// Vite plugin behind `virtual:source-symbols`: the repository URL, the commit the site is
-// built from, every source file under `dir` and the line of every exported definition, so
-// docs can turn inline code mentions into pinned GitHub links (see ./index.ts).
+// Vite plugin behind `virtual:source-symbols`: repo URL, built commit, every source file
+// under `dir` and each exported definition's line, so docs can turn inline code mentions
+// into pinned GitHub links (see ./index.ts).
 import { execSync } from 'node:child_process'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join, relative } from 'node:path'
@@ -15,9 +15,8 @@ const is_source_file = (name: string): boolean =>
 const EXPORT_DEFINITION_RE =
   /^export (?:async function|function|abstract class|class|const|let|interface|type|enum) (?<name>[A-Za-z_$][\w$]*)/
 
-// `repository` as package.json allows it: a URL string, a `{ url }` record (often with a
-// `git+` prefix and `.git` suffix, or an SSH remote) or a GitHub shorthand like `user/repo`.
-// Always yields the browsable https URL.
+// Accepts every package.json `repository` form — URL string, `{ url }` record (`git+`
+// prefix, `.git` suffix or SSH remote), `user/repo` shorthand — and yields the https URL.
 export const repository_url = (repository: unknown): string => {
   const raw =
     typeof repository === `string` ? repository : (repository as { url?: unknown })?.url

--- a/src/lib/source-links/vite-plugin.ts
+++ b/src/lib/source-links/vite-plugin.ts
@@ -15,8 +15,10 @@ const is_source_file = (name: string): boolean =>
 const EXPORT_DEFINITION_RE =
   /^export (?:async function|function|abstract class|class|const|let|interface|type|enum) (?<name>[A-Za-z_$][\w$]*)/
 
-// Accepts every package.json `repository` form — URL string, `{ url }` record (`git+`
-// prefix, `.git` suffix or SSH remote), `user/repo` shorthand — and yields the https URL.
+// Accepts every package.json `repository` form — URL string or `{ url }` record — and
+// normalizes the ones it knows: `user/repo` shorthand becomes a GitHub https URL, and a
+// `git+` prefix, SSH remote or `.git` suffix is rewritten. Any other URL passes through
+// as-is, `git://` and plain `http://` included.
 export const repository_url = (repository: unknown): string => {
   const raw =
     typeof repository === `string` ? repository : (repository as { url?: unknown })?.url

--- a/src/lib/text-search.ts
+++ b/src/lib/text-search.ts
@@ -92,8 +92,8 @@ type NormalizedText = { text: string; offsets: MatchBounds[] }
 
 const WHITESPACE = /\s/u
 
-// Each normalized unit maps back to its source bounds despite case/decomposition
-// expansion, astral UTF-16 pairs, and collapsed whitespace.
+// maps each normalized unit back to source bounds despite case/decomposition expansion,
+// astral UTF-16 pairs and collapsed whitespace
 type NormalizedToken = MatchBounds & { char: string }
 
 const normalize_with_offsets = (source: string): NormalizedText => {
@@ -234,11 +234,9 @@ const source_bounds = (
   return { start: source_start, end: source_end }
 }
 
-// Find every occurrence of query under root, case- and whitespace-insensitively.
-// `search_text` re-normalizes every segment on every keystroke, though the result depends
-// only on the segment's own text — and normalization is character-by-character, allocating a
-// token per code point. Memoize it, bounded, so typing re-walks the query rather than every
-// word in the document. The returned value is only ever read, so sharing it is safe.
+// `search_text` re-normalizes every segment per keystroke, char by char with a token per
+// code point, though the result depends only on the segment's own text. Bounded memoization
+// keeps typing off every word in the document; the result is read-only, so sharing is safe.
 const NORMALIZE_CACHE_LIMIT = 512
 const normalize_cache = new Map<string, NormalizedText>()
 const normalize_cached = (source: string): NormalizedText => {
@@ -257,6 +255,7 @@ const normalize_cached = (source: string): NormalizedText => {
   return normalized
 }
 
+// every occurrence of query under root, case- and whitespace-insensitively
 export const search_text = (
   root: Element,
   query: string,
@@ -292,8 +291,8 @@ type OwnedHighlight = {
   installed?: Highlight
 }
 
-// Union package-owned ranges by registry and name. Releasing the last owner restores
-// the previous highlight; outside writers retain ownership.
+// Unions package-owned ranges by registry and name; releasing the last owner restores the
+// previous highlight, and outside writers keep ownership.
 const owned_highlights = new WeakMap<HighlightRegistry, Map<string, OwnedHighlight>>()
 
 // Callers handle feature detection; a missing Highlight constructor throws.
@@ -325,7 +324,7 @@ export const sync_owned_highlight = (
     else registry.delete(css_class)
     return
   }
-  // Yield to another writer, but reclaim a name merely cleared from the registry.
+  // yield to another writer, but reclaim a name merely cleared from the registry
   if (highlight_entry.installed && current && current !== highlight_entry.installed)
     return
   highlight_entry.installed = new Highlight(
@@ -334,8 +333,8 @@ export const sync_owned_highlight = (
   registry.set(css_class, highlight_entry.installed)
 }
 
-// Register ranges and return their release; same-name callers share the union.
-// Returns undefined where CSS Custom Highlights are unavailable.
+// Registers ranges and returns their release; same-name callers share the union. Returns
+// undefined where CSS Custom Highlights are unavailable.
 export const highlight_ranges = (
   ranges: readonly Range[],
   options: HighlightRangesOptions = {},
@@ -355,9 +354,8 @@ export type TextMutationOptions = {
   max_wait_ms?: number
 }
 
-// Run callback once a burst of triggers settles, without letting a stream that never
-// pauses (a streaming response, say) defer it indefinitely: it lands debounce_ms after
-// the last trigger but no later than max_wait_ms after the first one of the burst.
+// Fires debounce_ms after the last trigger but no later than max_wait_ms after the burst's
+// first, so a never-pausing stream cannot defer the callback indefinitely.
 export const create_burst_debounce = (
   callback: () => void,
   { debounce_ms = 75, max_wait_ms = debounce_ms * 4 }: TextMutationOptions = {},
@@ -365,7 +363,7 @@ export const create_burst_debounce = (
   let timeout: ReturnType<typeof setTimeout> | undefined
   let burst_started_at: number | undefined
 
-  // Reset the max-wait window for the next burst.
+  // also resets the max-wait window for the next burst
   const cancel = (): void => {
     clearTimeout(timeout)
     timeout = undefined

--- a/src/lib/toast-queue.svelte.ts
+++ b/src/lib/toast-queue.svelte.ts
@@ -1,6 +1,6 @@
 // Toast notifications: a pure queue reducer plus the reactive store Toast.svelte reads.
-// Only one toast is visible at a time; the rest wait their turn ranked by priority, so a
-// burst of notices cannot bury the one that matters or scroll past before it is read.
+// One toast visible at a time, the rest ranked by priority, so a burst can't bury the
+// one that matters.
 
 export const TOAST_PRIORITIES = [
   `progress`,
@@ -20,10 +20,9 @@ export type ToastPosition =
   | `bottom-center`
   | `bottom-right`
 
-// Rank is array position: a later priority outranks an earlier one and preempts it. The
-// ladder is per queue and every type here is generic over it, so a consumer can name
-// their own tiers and still have them type-check. An unlisted name would rank -1, below
-// every real tier, silently inverting the queue — a bug to surface, not a lowest rung.
+// Rank is array position: later priorities preempt earlier ones. The ladder is per queue
+// and everything here is generic over it, so consumers can name their own tiers. Throws
+// rather than letting an unlisted name rank -1 and silently invert the queue.
 const priority_rank = <Priority extends string>(
   priorities: readonly Priority[],
   priority: Priority,
@@ -42,10 +41,8 @@ export const DEFAULT_TOAST_DURATION_MS = 5000
 // Where a request that names no priority lands, on any ladder that has this rung
 const DEFAULT_TOAST_PRIORITY = `info`
 
-// Both callbacks take the widened item rather than the queue's own ladder, which keeps
-// ToastItem covariant in its priority type: a parameter typed to the narrow ladder makes
-// ToastItem<'watch' | ...> unassignable to ToastItem<string> and would pin <Toast /> and
-// every other consumer of a toast to a single ladder.
+// Both callbacks take the widened item, not the queue's ladder, keeping ToastItem covariant
+// in its priority type — a narrow parameter would pin <Toast /> to a single ladder.
 export interface ToastAction {
   label: string
   on_click?: (toast: ToastItem<string>) => void
@@ -59,13 +56,13 @@ export type ToastCloseHandler = (
 export interface ToastRequest<Priority extends string = ToastPriority> {
   message: string
   priority?: Priority
-  // Absolute wall-clock deadline. Keeps counting down while the toast waits its turn,
-  // for notices that go stale on their own schedule rather than after N seconds seen.
+  // Absolute deadline, still counting while the toast waits its turn — for notices that
+  // go stale on their own schedule rather than after N seconds seen.
   expires_at_ms?: number | null
   // Visible-only budget; pauses on demotion and overrides expires_at_ms when both are set.
   visible_duration_ms?: number
-  // Repeats of the same key update the existing toast instead of queueing behind it.
-  // Defaults to the message, so identical text collapses without any bookkeeping.
+  // Repeats of a key update the existing toast rather than queueing behind it. Defaults
+  // to the message, so identical text collapses on its own.
   dedupe_key?: string
   action?: ToastAction
   on_close?: ToastCloseHandler
@@ -73,8 +70,7 @@ export interface ToastRequest<Priority extends string = ToastPriority> {
 
 export interface ToastItem<Priority extends string = ToastPriority> {
   id: string
-  // Insertion order, breaking ties between toasts created in the same millisecond
-  seq: number
+  seq: number // insertion order, breaking ties within one millisecond
   message: string
   priority: Priority
   created_at_ms: number
@@ -90,16 +86,14 @@ export interface ToastQueue<Priority extends string = ToastPriority> {
   pending: readonly ToastItem<Priority>[]
   next_id: number
   max_pending: number
-  // Carried on the queue rather than passed to each call, so every transition ranks by
-  // the same ladder and a queue stays self-describing when handed around.
+  // on the queue, not per call, so every transition ranks by the same ladder
   priorities: readonly Priority[]
   default_priority: Priority
 }
 
 export interface ToastQueueOptions<Priority extends string = ToastPriority> {
   max_pending?: number
-  // Ordered lowest rank first. Defaults to TOAST_PRIORITIES.
-  priorities?: readonly Priority[]
+  priorities?: readonly Priority[] // lowest rank first; defaults to TOAST_PRIORITIES
   // NoInfer so a stray name is rejected against the ladder instead of widening it
   default_priority?: NoInfer<Priority>
 }
@@ -127,8 +121,8 @@ const is_expired = (toast: ToastItem<string>, now_ms: number): boolean =>
 const queued_toasts = <Priority extends string>(queue: ToastQueue<Priority>) =>
   queue.active_toast ? [queue.active_toast, ...queue.pending] : queue.pending
 
-// Bank the unspent part of a visibility budget. A toast pushed back into the queue has
-// not been read, so its clock stops until it is on screen again.
+// Bank the unspent visibility budget: a toast pushed back into the queue was not read,
+// so its clock stops until it is on screen again.
 const pause_visibility_timeout = <Priority extends string>(
   toast: ToastItem<Priority>,
   now_ms: number,
@@ -144,10 +138,9 @@ const pause_visibility_timeout = <Priority extends string>(
             : Math.max(0, toast.expires_at_ms - now_ms),
       }
 
-// A budget beats a deadline (see ToastRequest.visible_duration_ms), so a queued toast
-// carrying both stops running its wall clock. The budget itself is untouched: nothing has
-// been spent yet, and banking here would mistake the caller's deadline for one this queue
-// had derived and adopt the distance to it as the budget.
+// A budget beats a deadline (see ToastRequest.visible_duration_ms), so a queued toast with
+// both stops its wall clock. The budget stays untouched: nothing was spent yet, and banking
+// would mistake the caller's deadline for one this queue derived.
 const drop_unseen_deadline = <Priority extends string>(
   toast: ToastItem<Priority>,
 ): ToastItem<Priority> =>
@@ -188,8 +181,7 @@ const rebalance_queue = <Priority extends string>(
 
   const overflow: ToastItem<Priority>[] = []
   while (pending.length > queue.max_pending) {
-    // An unseen action must remain available even if actions temporarily push
-    // the queue above the soft cap; only non-destructive notices may overflow.
+    // only notices without an unseen action may overflow, even past the soft cap
     const overflow_idx = pending.findLastIndex((toast) => !toast.action)
     if (overflow_idx === -1) break
     overflow.push(...pending.splice(overflow_idx, 1))
@@ -220,8 +212,8 @@ export const create_toast_queue = <const Priority extends string = ToastPriority
   options: ToastQueueOptions<Priority> = {},
 ): ToastQueue<Priority> => {
   const { max_pending = DEFAULT_MAX_PENDING } = options
-  // Priority defaults to exactly the element type of TOAST_PRIORITIES, but that
-  // correlation is invisible from inside a generic body, hence the widen-then-narrow
+  // Priority defaults to TOAST_PRIORITIES' element type, but that correlation is invisible
+  // inside a generic body, hence the widen-then-narrow
   const priorities: readonly Priority[] =
     options.priorities ?? (TOAST_PRIORITIES as readonly string[] as readonly Priority[])
   const ladder = priorities.join(`, `)
@@ -272,8 +264,8 @@ export const expire_toasts = <Priority extends string>(
 
 export const enqueue_toast = <Priority extends string>(
   queue: ToastQueue<Priority>,
-  // NoInfer so the queue's ladder types the request rather than the request widening
-  // the ladder, which would let an off-ladder priority past the compiler
+  // NoInfer so the queue's ladder types the request; otherwise the request widens the
+  // ladder and an off-ladder priority slips past the compiler
   request: ToastRequest<NoInfer<Priority>>,
   now_ms: number,
 ): EnqueueToastTransition<Priority> => {
@@ -281,8 +273,8 @@ export const enqueue_toast = <Priority extends string>(
   queue = expired_transition.queue
   const effects = [...expired_transition.effects]
   const priority = request.priority ?? queue.default_priority
-  // Rank eagerly: a lone toast is promoted without ever being compared, so an unknown
-  // priority would otherwise sit in the queue until a second toast exposed it.
+  // rank eagerly: a lone toast is promoted uncompared, hiding an unknown priority until
+  // a second toast arrives
   const rank = priority_rank(queue.priorities, priority)
   const expires_at_ms = request.expires_at_ms ?? null
   const dedupe_key = request.dedupe_key ?? request.message
@@ -291,14 +283,12 @@ export const enqueue_toast = <Priority extends string>(
   if (existing) {
     const existing_rank = priority_rank(queue.priorities, existing.priority)
     const request_is_lower_priority = rank < existing_rank
-    // An equal-priority repeat escalates nothing, so an omitted field means "leave this
-    // as it was" rather than "clear it" — a plain repeat of a toast carrying a duration
-    // used to wipe it and strand the toast on screen for good. Only a louder repeat
-    // replaces the original's timing and action outright.
+    // In an equal-priority repeat an omitted field means "leave as was", not "clear":
+    // repeating a toast with a duration used to wipe it and strand it on screen forever.
+    // Only a louder repeat replaces timing and action outright.
     const carried: Partial<ToastItem<Priority>> = rank === existing_rank ? existing : {}
 
-    // A lower-priority repeat only refreshes the text; the higher-priority
-    // original keeps its priority, timing, and action.
+    // a lower-priority repeat only refreshes the text
     const updated: ToastItem<Priority> = request_is_lower_priority
       ? { ...existing, message: request.message }
       : {
@@ -380,8 +370,8 @@ export const activate_toast_action = <Priority extends string>(
   toast_id: string,
   now_ms: number,
 ): ToastQueueTransition<Priority> => {
-  // A click already dispatched by the browser wins over a delayed expiry
-  // timer. Remove the target first, then expire unrelated queue items.
+  // a click the browser already dispatched beats a late expiry timer, so remove the
+  // target before expiring the rest
   const toast = queued_toasts(queue).find((item) => item.id === toast_id)
   if (!toast?.action) return expire_toasts(queue, now_ms)
   const [without_target] = remove_toast(queue, toast_id, now_ms)
@@ -398,8 +388,8 @@ export type ToastOptions<Priority extends string = ToastPriority> = Omit<
   ToastRequest<Priority>,
   `message` | `visible_duration_ms`
 > & {
-  // Counts only while the toast is on screen, so a hover or a higher-priority
-  // interruption does not eat the reading time. `null` stays up until dismissed.
+  // counts only while on screen, so a hover or interruption doesn't eat reading
+  // time; `null` stays up until dismissed
   duration_ms?: number | null
 }
 
@@ -407,9 +397,8 @@ export interface ToastStoreOptions<
   Priority extends string = ToastPriority,
 > extends ToastQueueOptions<Priority> {
   duration_ms?: number
-  // Priorities that stay up until dismissed. Defaults to the ladder's top two.
-  // NoInfer for the same reason default_priority has it: without it a typo here widens
-  // the ladder instead of failing, and the toast just never becomes sticky
+  // Priorities that stay up until dismissed, default the ladder's top two. NoInfer, else
+  // a typo widens the ladder instead of failing and the toast silently never sticks.
   sticky_priorities?: readonly NoInfer<Priority>[]
 }
 
@@ -422,8 +411,7 @@ export class ToastStore<Priority extends string = ToastPriority> {
   constructor(options: ToastStoreOptions<Priority> = {}) {
     this.#queue = $state.raw(create_toast_queue<Priority>(options))
     this.#default_duration_ms = options.duration_ms ?? DEFAULT_TOAST_DURATION_MS
-    // a warning or error the user never saw is a bug report waiting to happen, so the
-    // ladder's top two stay up until dismissed while the lower ones time out
+    // a warning or error the user never saw is a bug report waiting to happen
     this.#sticky_priorities =
       options.sticky_priorities ?? this.#queue.priorities.slice(-2)
   }
@@ -434,16 +422,16 @@ export class ToastStore<Priority extends string = ToastPriority> {
   get pending(): readonly ToastItem<Priority>[] {
     return this.#queue.pending
   }
-  // The ladder this store ranks by, lowest first
+  // ladder this store ranks by, lowest first
   get priorities(): readonly Priority[] {
     return this.#queue.priorities
   }
-  // The rungs that stay up until dismissed, so `<Toast assertive={...} />` can be pointed
-  // at them: a toast held on screen while announced politely defeats both rules
+  // Rungs that stay up until dismissed, to point `<Toast assertive={...} />` at: holding a
+  // toast on screen while announcing it politely defeats both rules.
   get sticky_priorities(): readonly Priority[] {
     return this.#sticky_priorities
   }
-  // Everything the queue is holding, visible one first
+  // everything the queue holds, visible one first
   get items(): readonly ToastItem<Priority>[] {
     return queued_toasts(this.#queue)
   }
@@ -478,7 +466,7 @@ export class ToastStore<Priority extends string = ToastPriority> {
     this.#apply(activate_toast_action(this.#queue, toast_id, Date.now()))
   }
 
-  // Dismisses everything matching, defaulting to the whole queue
+  // dismisses everything matching, defaulting to the whole queue
   clear(predicate: (toast: ToastItem<Priority>) => boolean = () => true): void {
     const now_ms = Date.now()
     let queue = this.#queue
@@ -504,18 +492,16 @@ export class ToastStore<Priority extends string = ToastPriority> {
 
   resume(): void {
     const { active_toast } = this.#queue
-    // Nothing to resume unless a toast is actually paused: resuming a running one
-    // would hand it a second full duration rather than the remainder it had left.
+    // resuming a running toast would grant a second full duration, not its remainder
     if (active_toast?.expires_at_ms !== null) return
     const resumed = start_visibility_timeout(active_toast, Date.now())
     if (resumed === active_toast) return
     this.#apply({ queue: { ...this.#queue, active_toast: resumed }, effects: [] })
   }
 
-  // Drops the pending timer and every toast without firing on_close, for teardown
-  // between tests or routes; clear() first if a consumer relies on on_close. The id
-  // counter carries over, so an id held from before teardown cannot address a toast
-  // shown after it.
+  // Drops the timer and every toast without firing on_close, for teardown between tests or
+  // routes; clear() first if on_close matters. The id counter carries over so a stale id
+  // can't address a post-teardown toast.
   destroy(): void {
     clearTimeout(this.#timer)
     this.#queue = { ...this.#queue, active_toast: null, pending: [] }
@@ -524,8 +510,7 @@ export class ToastStore<Priority extends string = ToastPriority> {
   #apply(transition: ToastQueueTransition<Priority>): void {
     this.#queue = transition.queue
     this.#schedule()
-    // Dispatched after the queue is committed so a handler that enqueues a follow-up
-    // toast sees the state its own toast left behind.
+    // after the queue is committed, so a handler enqueuing a follow-up sees current state
     for (const { toast, reason } of transition.effects) {
       if (reason === `action`) toast.action?.on_click?.(toast)
       toast.on_close?.(toast, reason)
@@ -546,12 +531,9 @@ export class ToastStore<Priority extends string = ToastPriority> {
   }
 }
 
-// Default store, so `toast.show(...)` works from anywhere without threading an instance
-// through props. Pass your own to <Toast store={...} /> when a page needs its own queue.
-//
-// Client-only. Importing it is inert — nothing is queued and no timer runs until a toast
-// is shown — but module scope on a server is per-process, not per-request, so a toast
-// shown during SSR would render into other users' responses and count down against a
-// queue they share. Show toasts from event handlers or onMount, or give the server
-// request its own `new ToastStore()`.
+// Default store, so `toast.show(...)` works anywhere; pass your own to
+// <Toast store={...} /> when a page needs its own queue.
+// Client-only: importing is inert, but server module scope is per-process, not per-request,
+// so a toast shown during SSR leaks into other users' responses. Show from event handlers
+// or onMount, or give the request its own `new ToastStore()`.
 export const toast = new ToastStore()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,8 +28,7 @@ export type TabItem<Value extends string = string> = {
 export type AccordionItem<Value extends string = string> = TabItem<Value>
 export type AccordionValue<Value extends string = string> = Value | Value[] | null
 
-// single CSS string or an object with optional 'option' and 'selected' keys,
-// which only apply to the dropdown list and list of selected options, respectively
+// `option` styles the dropdown list, `selected` the list of selected options
 export type OptionStyle = string | { option?: string; selected?: string }
 
 export type ObjectOption = {
@@ -64,23 +63,21 @@ export type PageSearchNavigateDetails = {
   description: string
 }
 
-// placeholder can be a simple string or object with extended options
 export type PlaceholderConfig = {
   text: string
   persistent?: boolean // keep placeholder visible even when options are selected
 }
 
-// custom events created by MultiSelect
 export interface MultiSelectEvents<T extends Option = Option> {
   onadd?: (data: { option: T; selected: T[] }) => unknown
   oncreate?: (data: {
     option: T
-  }) => false | T | undefined | Promise<false | T | undefined> // return false to reject, return T to transform, undefined to accept as-is (sync or async)
+  }) => false | T | undefined | Promise<false | T | undefined> // false rejects, T transforms, undefined accepts as-is
   onremove?: (data: { option: T; selected: T[] }) => unknown
   onremoveAll?: (data: { options: T[] }) => unknown
   onselectAll?: (data: { options: T[]; scope?: SelectAllScope }) => unknown
   onrangeSelect?: (data: { added: T[]; from: T; to: T; selected: T[] }) => unknown
-  onreorder?: (data: { options: T[]; previous: T[] }) => unknown // fires when selected options are reordered via drag-and-drop
+  onreorder?: (data: { options: T[]; previous: T[] }) => unknown // drag-and-drop reorder
   onchange?: (data: {
     option?: T
     options?: T[]
@@ -91,21 +88,20 @@ export interface MultiSelectEvents<T extends Option = Option> {
   ongroupToggle?: (data: { group: string; collapsed: boolean }) => unknown
   oncollapseAll?: (data: { groups: string[] }) => unknown
   onexpandAll?: (data: { groups: string[] }) => unknown
-  onsearch?: (data: { searchText: string; matchingOptions: T[] }) => unknown // fires (debounced) when search text changes
+  onsearch?: (data: { searchText: string; matchingOptions: T[] }) => unknown // debounced
   onmaxreached?: (data: {
     selected: T[]
     maxSelect: number
     attemptedOption: T
-  }) => unknown // fires when user tries to exceed maxSelect
-  onduplicate?: (data: { option: T }) => unknown // fires when user tries to add duplicate (when duplicates=false)
+  }) => unknown // user tried to exceed maxSelect
+  onduplicate?: (data: { option: T }) => unknown // user tried to add a dupe (duplicates=false)
   onparsed_paste?: (data: {
     added: T[]
     rejected: T[]
     overflow: T[]
     raw_text: string
   }) => unknown
-  onactivate?: (data: { option: T | null; index: number | null }) => unknown // fires on keyboard navigation through options
-  // History/undo-redo events
+  onactivate?: (data: { option: T | null; index: number | null }) => unknown // keyboard nav
   onundo?: (data: { previous: T[]; current: T[] }) => unknown
   onredo?: (data: { previous: T[]; current: T[] }) => unknown
 }
@@ -164,7 +160,7 @@ export type GroupedOptions<T extends Option = Option> = {
 }
 
 export interface MultiSelectSnippets<T extends Option = Option> {
-  // custom icon indicating the input is expandable into a dropdown (position controlled by expandIconPosition prop)
+  // icon marking the input as expandable into a dropdown; placed by expandIconPosition
   expandIcon?: Snippet<[{ open: boolean; disabled: boolean }]>
   selectedItem?: Snippet<[{ option: T; idx: number }]>
   children?: Snippet<[{ option: T; idx: number; type: `option` | `selected` }]>
@@ -184,21 +180,18 @@ export interface MultiSelectSnippets<T extends Option = Option> {
 
 export interface PortalParams {
   target_node?: HTMLElement | null
-  // portal the dropdown to document.body; honored at runtime, so toggling
-  // portals/un-portals the open dropdown in place
+  // portal the dropdown to document.body; honored at runtime, so toggling portals or
+  // un-portals the open dropdown in place
   active?: boolean
-  // `auto` (default): below the input, flips above when the dropdown would overflow
-  //   the viewport bottom and there's more space above
-  // `bottom`: always below the input
-  // `top`: always above the input
+  // `auto` (default) sits below the input and flips above when it would overflow the
+  // viewport bottom and there is more space above
   placement?: `auto` | `bottom` | `top`
 }
 
 export type SelectAllScope = `visible` | `matching`
 
-// why the select-all row is disabled, handed to a `selectAllDisabledTitle` callback. The
-// three booleans name the reason; `default_title` is the string the callback replaces, so
-// it can wrap or prefix the default rather than rebuilding the three-way choice.
+// Why the select-all row is disabled, handed to `selectAllDisabledTitle`. The booleans name
+// the reason; `default_title` lets a callback wrap the default instead of rebuilding it.
 export interface SelectAllDisabledState {
   max_reached: boolean
   maxSelect: number | null
@@ -236,24 +229,23 @@ export interface MultiSelectProps<T extends Option = Option>
   allowEmpty?: boolean // added for https://github.com/janosh/svelte-widgets/issues/192
   autocomplete?: HTMLInputAttributes[`autocomplete`]
   autoScroll?: boolean
-  breakpoint?: number // any screen with more horizontal pixels is considered desktop, below is mobile
+  breakpoint?: number // wider screens count as desktop, narrower as mobile
   defaultDisabledTitle?: string
   disabled?: boolean
   disabledInputTitle?: string
   duplicateOptionMsg?: string
-  // Controls duplicate detection: false (default, case-sensitive), true (allow all), 'case-insensitive' (block case variants)
+  // false (default) blocks dupes case-sensitively, true allows all, 'case-insensitive'
+  // also blocks case variants
   duplicates?: boolean | `case-insensitive`
-  // Where to render the expand icon, or 'none' to hide it.
   expandIconPosition?: `left` | `right` | `none`
-  // keepSelectedInDropdown controls whether selected options remain in dropdown: false (default),
-  // 'plain' (left border and background color to differentiate selected options),
-  // 'checkboxes' (each option is prefixed by a checkbox).
+  // keep selected options in the dropdown, marked either by a left border and background
+  // ('plain') or a checkbox prefix ('checkboxes')
   keepSelectedInDropdown?: false | `plain` | `checkboxes`
-  // Function to generate unique keys for options. Default: value ?? label for objects, primitive for strings/numbers.
-  // Duplicate detection also checks labels, so typing "Apple" when any "Apple" is selected is blocked (unless duplicates=true).
+  // Unique option key, default value ?? label for objects and the primitive otherwise.
+  // Dupe detection also checks labels, so a second "Apple" is blocked unless duplicates=true.
   key?: (opt: T) => unknown
   filterFunc?: (opt: T, searchText: string) => boolean
-  fuzzy?: boolean // whether to use fuzzy matching (default: true) or substring matching (false)
+  fuzzy?: boolean // fuzzy (default) vs substring matching
   closeDropdownOnSelect?: boolean | `if-mobile` | `retain-focus`
   form_input?: HTMLInputElement | null
   formSerialize?: FormSerialize<T>
@@ -265,8 +257,7 @@ export interface MultiSelectProps<T extends Option = Option>
   inputStyle?: string | null
   inputmode?: HTMLInputAttributes[`inputmode`] | null
   invalid?: boolean
-  // Override any string MultiSelect renders itself, for i18n. Shallow-merged over
-  // MULTI_SELECT_LABELS; see labels.ts for the full set and their defaults.
+  // i18n overrides, shallow-merged over MULTI_SELECT_LABELS (see labels.ts)
   labels?: Partial<MultiSelectLabels>
   liActiveOptionClass?: ClassValue
   liActiveUserMsgClass?: ClassValue
@@ -278,25 +269,21 @@ export interface MultiSelectProps<T extends Option = Option>
   loading?: boolean
   matchingOptions?: T[]
   maxOptions?: number | undefined
-  // Virtualized dropdown rendering for large option lists: only rows near the scroll
-  // viewport are rendered as DOM nodes. Pass true for defaults or { itemHeight, overscan }
-  // to tune row height (px, default 30, applies to group headers too) and extra rows
-  // rendered above/below the visible window (default 10). Grouped options are supported,
-  // but combining them with stickyGroupHeaders is invalid because a virtualized header that
-  // has left the render window cannot remain pinned.
+  // Render only rows near the scroll viewport. `itemHeight` (px, default 30, group headers
+  // included) and `overscan` (extra rows each side, default 10) tune it. Groups work, but
+  // not with stickyGroupHeaders: a header outside the render window cannot stay pinned.
   virtualList?: boolean | { itemHeight?: number; overscan?: number }
   maxSelect?: number | null // null means there is no upper limit for selected.length
   maxSelectMsg?: ((current: number, max: number) => string) | null
   maxSelectMsgClass?: ClassValue
-  // Max selected chips rendered before the rest collapse into a "+N more" toggle
-  // chip (click to expand/collapse). null (default) renders all chips. Ignored in
-  // selectedDisplay="input" mode. Keyboard chip navigation auto-expands.
+  // Chips rendered before the rest collapse into a "+N more" toggle; null (default) renders
+  // all. Ignored for selectedDisplay="input"; keyboard chip navigation auto-expands.
   maxVisibleChips?: number | null
   name?: string | null
   noMatchingOptionsMsg?: string
   open?: boolean
-  // Mostly reaches portalled dropdowns: with the input focused, a press outside blurs it and
-  // that closes an in-place dropdown before any click. See dismiss_on_outside_press.
+  // Mostly reaches portalled dropdowns: an outside press blurs the focused input, which
+  // already closes an in-place dropdown before any click. See dismiss_on_outside_press.
   dismiss_on?: DismissConfig[`dismiss_on`]
   options?: T[] // static options, or omit when using loadOptions
   outerDiv?: HTMLDivElement | null
@@ -312,8 +299,7 @@ export interface MultiSelectProps<T extends Option = Option>
   parse_paste?: (text: string) => T[]
   searchText?: string
   selected?: T[] // don't allow more than maxSelect preselected options
-  // Defaults to 'chips', which renders selected options as tags. 'input' is only
-  // valid with maxSelect === 1; other maxSelect values are rejected.
+  // 'chips' (default) renders selected options as tags; 'input' requires maxSelect === 1
   selectedDisplay?: `chips` | `input`
   sortSelected?: boolean | ((op1: T, op2: T) => number)
   selectedOptionsDraggable?: boolean
@@ -331,15 +317,16 @@ export interface MultiSelectProps<T extends Option = Option>
   selectAllDisabledTitle?: string | ((state: SelectAllDisabledState) => string) | null
   liSelectAllClass?: ClassValue // CSS class for the select all <li>
   loadOptions?: LoadOptions<T>
-  // Animation parameters for selected options flip animation (https://github.com/janosh/svelte-widgets/issues/356)
-  // Set { duration: 0 } to disable animation
+  // flip animation for selected options; { duration: 0 } disables
+  // (https://github.com/janosh/svelte-widgets/issues/356)
   selectedFlipParams?: FlipParams
   // Option grouping feature (https://github.com/janosh/svelte-widgets/issues/135)
   collapsibleGroups?: boolean // enable click-to-collapse groups
   collapsedGroups?: Set<string> // externally controlled collapsed state (bindable)
-  groupSelectAll?: boolean // add "select all" action per group header (toggles between select/deselect)
+  groupSelectAll?: boolean // per-group header select/deselect-all toggle
   ungroupedPosition?: `first` | `last` // where to render options without a group
-  groupSortOrder?: `none` | `asc` | `desc` | ((a: string, b: string) => number) // group ordering, default 'none' (source order); 'asc'/'desc' sort alphabetically or pass a comparator
+  // group order: 'none' (default, source order), alphabetical 'asc'/'desc', or a comparator
+  groupSortOrder?: `none` | `asc` | `desc` | ((a: string, b: string) => number)
   searchExpandsCollapsedGroups?: boolean // auto-expand collapsed groups when search matches their options
   searchMatchesGroups?: boolean // include group name in search matching
   keyboardExpandsCollapsedGroups?: boolean // auto-expand collapsed groups when navigating with arrow keys
@@ -351,24 +338,18 @@ export interface MultiSelectProps<T extends Option = Option>
   expandAllGroups?: () => void
   // Keyboard shortcuts for common actions
   shortcuts?: Partial<KeyboardShortcuts>
-  // Selection history for undo/redo support (enabled by default)
-  // true (default) = 50 max states, number = custom max, false/0 = disabled
-  // Note: need at least 2 states for undo (history=2 allows 1 undo, history=1 effectively disables)
+  // Undo/redo history size: true (default) = 50 states, a number sets the max, false/0 is
+  // off. Undo needs 2 states, so history=1 disables it in effect.
   history?: boolean | number
-  undo?: () => boolean // bindable method to undo last selection change
-  redo?: () => boolean // bindable method to redo last undone change
-  canUndo?: boolean // bindable read-only state for UI indicators
-  canRedo?: boolean // bindable read-only state for UI indicators
+  undo?: () => boolean // bindable
+  redo?: () => boolean // bindable
+  canUndo?: boolean // bindable, read-only
+  canRedo?: boolean // bindable, read-only
 }
 
-// Keyboard shortcuts for MultiSelect actions.
-// Shortcut format: "modifier+...+key" where modifiers can be: ctrl, shift, alt, meta, cmd
-// Examples: 'ctrl+a', 'ctrl+shift+a', 'meta+a', 'cmd+a', 'alt+s'
-// Set to null to disable a shortcut.
-//
-// PRECEDENCE: Custom shortcuts are evaluated BEFORE built-in key handlers (Enter, Escape,
-// ArrowUp/Down, Backspace). This means if you set shortcuts={{ open: 'enter' }}, the Enter
-// key will open the dropdown instead of selecting the active option (intentional to allow full customization).
+// "modifier+...+key" with modifiers ctrl, shift, alt, meta, cmd (e.g. 'ctrl+shift+a');
+// null disables. Evaluated BEFORE built-in handlers (Enter, Escape, arrows, Backspace), so
+// shortcuts={{ open: 'enter' }} deliberately overrides Enter's select.
 export interface KeyboardShortcuts {
   select_all?: string | null // default: null (opt-in, e.g. 'ctrl+a')
   clear_all?: string | null // default: 'ctrl+backspace' (meta+backspace on Mac)
@@ -392,11 +373,7 @@ export type NavRouteObject = {
   [key: string]: unknown // allow additional custom properties
 } & ({ href: string } | { separator: true; href?: string })
 
-// NavRoute shorthand formats:
-// - string: path only ("/about")
-// - [string, string]: [path, custom_label] ("/about", "About Us")
-// - [string, string[]]: [parent_path, child_paths] ("/docs", ["/docs/intro"])
-// - NavRouteObject: full object with all options
+// shorthands: "/about", ["/about", "About Us"], ["/docs", ["/docs/intro"]]
 export type NavRoute = string | [string, string] | [string, string[]] | NavRouteObject
 
 // === Toc ===

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,8 +7,7 @@ export const chain_handlers =
   (event: EventType): void =>
     handlers.forEach((handler) => handler?.(event))
 
-// Generates a UUID for component IDs. Uses native crypto.randomUUID when available.
-// Fallback uses timestamp+counter - sufficient for DOM IDs (uniqueness, not security).
+// UUID for DOM IDs. Fallback is timestamp+counter: unique enough, not secure.
 export function get_uuid(): string {
   if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
   const hex = (Date.now().toString(16) + (uuid_counter++).toString(16)).padStart(32, `0`)
@@ -58,8 +57,7 @@ export const get_label = (opt: Option) => {
 export const get_option_key = (opt: Option): unknown =>
   is_object(opt) ? (opt.value ?? get_label(opt)) : opt
 
-// Extract a CSS string from an option's style (string or {option, selected} object).
-// A non-empty result is semicolon-terminated.
+// CSS from an option's style (string or {option, selected}); non-empty result ends in `;`
 export function get_style(
   option: Option,
   key: `selected` | `option` | null | undefined = null,
@@ -72,7 +70,7 @@ export function get_style(
   const { style } = option
   if (typeof style === `string`) css_str = style
   else {
-    // partial style objects (e.g. only `selected`) are fine; reject unknown keys
+    // partial style objects are fine; unknown keys are not
     if (
       Object.keys(style).some(
         (style_key) => style_key !== `option` && style_key !== `selected`,
@@ -90,21 +88,20 @@ export function get_style(
 }
 
 // === Floating geometry ===
-// "Pick a side that fits, then stay on screen", shared by every floating surface.
+// "pick a side that fits, then stay on screen", shared by every floating surface
 
 export type Placement = `top` | `right` | `bottom` | `left`
 
 export type PositionOptions = {
   placement?: Placement | `auto`
-  // `start` and `end` line up the corresponding physical anchor and floating edges.
-  align?: `center` | `start` | `end`
+  align?: `center` | `start` | `end` // start/end line up the matching anchor/floating edges
   offset?: number // gap between anchor and floating box
   cross_axis_offset?: number // nudge perpendicular to the chosen side
   padding?: number // closest the floating box may come to a viewport edge
   boundary?: { top: number; left: number; right: number; bottom: number }
   fallback_placements?: Placement[] // tried after a fixed placement; restricts `auto`
-  // `true` tries the opposite side then the perpendicular ones; pass an explicit
-  // list to keep a dropdown from ever landing beside its input
+  // true tries the opposite side then the perpendicular ones; an explicit list keeps e.g.
+  // a dropdown from ever landing beside its input
   flip?: boolean | Placement[]
   shift?: boolean // slide along the viewport edge rather than overflow it
 }
@@ -163,27 +160,26 @@ export function compute_position(
     left: anchor.left - boundary.left - padding - offset,
     right: boundary.right - padding - anchor.right - offset,
   }
-  // Only the main axis decides a flip: cross-axis overflow is what shifting is for, and
-  // letting it count would make an edge-aligned bottom tooltip jump to the left instead.
+  // Only main-axis overflow flips; counting the cross axis (shifting's job) would send an
+  // edge-aligned bottom tooltip to the left instead.
   const main_axis_overflow = (side: Placement): number => {
     const needed = side === `top` || side === `bottom` ? floating.height : floating.width
     return Math.max(0, needed - free_space[side])
   }
 
-  // `flip: false` pins the requested side; otherwise the first candidate with the least
-  // main-axis overflow wins.
+  // `flip: false` pins the requested side, else least main-axis overflow wins
   const explicit_order = fallback_placements ?? (Array.isArray(flip) ? flip : null)
   const candidate_placements = (): Placement[] => {
     if (flip === false) return [requested]
     if (!explicit_order) return FLIP_ORDER[requested]
-    // A named placement stays the first choice, its fallbacks only queue up behind it.
+    // a named placement stays first choice, its fallbacks queue up behind it
     if (fallback_placements && placement !== `auto`) {
       return [requested, ...explicit_order.filter((side) => side !== requested)]
     }
     return explicit_order
   }
 
-  // Plain `auto` has no preferred side, so it breaks overflow ties by picking the roomiest.
+  // plain `auto` has no preferred side, so it breaks overflow ties on free space
   const rank_by_space = flip !== false && placement === `auto` && !explicit_order
   let chosen = requested
   let least_overflow = Infinity
@@ -208,7 +204,7 @@ export function compute_position(
     const max_left = boundary.right - floating.width - padding
     const min_top = boundary.top + padding
     const max_top = boundary.bottom - floating.height - padding
-    // Oversize boxes have reversed limits; the interval between them has minimum overflow.
+    // oversize boxes reverse the limits; between them overflow is minimal
     left = clamp(left, Math.min(min_left, max_left), Math.max(min_left, max_left))
     top = clamp(top, Math.min(min_top, max_top), Math.max(min_top, max_top))
   }
@@ -224,8 +220,8 @@ const is_apple_platform = (): boolean =>
 const resolve_mod = (shortcut: string): string =>
   shortcut.replaceAll(/\bmod\b/giu, is_apple_platform() ? `meta` : `ctrl`)
 
-// `,`, `+` and space are spelled out in a combo string so it can always be split on
-// `+`; matching needs the literal `event.key` back.
+// `,`, `+` and space are spelled out so a combo can always be split on `+`;
+// matching needs the literal `event.key` back
 const KEY_TOKENS: Record<string, string> = { ',': `comma`, '+': `plus`, ' ': `space` }
 const TOKEN_KEYS: Record<string, string> = { comma: `,`, plus: `+`, space: ` ` }
 
@@ -262,8 +258,7 @@ export function matches_shortcut(
 ): boolean {
   if (!shortcut) return false
   const { key, ctrl, shift, alt, meta } = parse_shortcut(shortcut)
-  // Require non-empty key to prevent "ctrl+" from matching any key with ctrl pressed
-  if (!key) return false
+  if (!key) return false // else "ctrl+" would match any key held with ctrl
   return (
     event.key.toLowerCase() === key &&
     event.ctrlKey === ctrl &&
@@ -273,8 +268,7 @@ export function matches_shortcut(
   )
 }
 
-// Shortcut segments as display symbols.
-// Only `mod` reads the platform; every other segment renders the same everywhere.
+// Display symbols per segment. Only `mod` is platform-dependent, the rest render alike.
 const key_symbols: Record<string, string> = {
   meta: `⌘`,
   cmd: `⌘`,
@@ -309,17 +303,17 @@ export type Hotkey = {
   keys: string | string[] // e.g. `mod+k`, `ctrl+shift+p`, `Escape`
   handler: (event: KeyboardEvent) => void
   enabled?: boolean
-  // Bare keys are ignored while typing in a text field, where they are just
-  // characters. Chords always fire. Set true for keys that must work either way.
+  // bare keys are ignored while typing in a text field (chords always fire);
+  // set true for keys that must work either way
   allow_in_inputs?: boolean
   prevent_default?: boolean // default true
 }
 
-// Runs the first binding whose shortcut matches and reports whether one fired.
-// Shared by the `hotkey` attachment and components that own a window listener.
+// Runs the first matching binding and reports whether one fired. Shared by the `hotkey`
+// attachment and components that own a window listener.
 export function run_hotkeys(event: KeyboardEvent, bindings: Hotkey[]): boolean {
   if (event.isComposing) return false // mid-IME the keystroke belongs to the editor
-  // Outside a chord a bare key in a text field is ordinary typing, not a shortcut
+  // outside a chord, a bare key in a text field is typing, not a shortcut
   const typing = !is_modifier_chord(event) && is_editable_event_target(event.target)
   for (const binding of bindings) {
     if (binding.enabled === false) continue
@@ -333,7 +327,7 @@ export function run_hotkeys(event: KeyboardEvent, bindings: Hotkey[]): boolean {
   return false
 }
 
-// True when the event came from a text-entry control, where a bare key is typing
+// event came from a text-entry control, where a bare key is typing
 export const is_editable_event_target = (target: EventTarget | null): boolean =>
   target instanceof Element &&
   target.closest(
@@ -344,12 +338,10 @@ export const is_editable_event_target = (target: EventTarget | null): boolean =>
 export const is_modifier_chord = (event: KeyboardEvent): boolean =>
   event.altKey || event.ctrlKey || event.metaKey
 
-// Move focus within a list of items, wrapping at both ends, and hand back what took it
-// so a radio group can carry its selection along. Returns undefined when the key is not
-// a navigation key or the list is empty, in which case the event is left untouched.
-// Left/Right are opt-in: a vertical menu should leave them to the page.
-// Focus entering from outside gives idx -1, where each key still lands where it implies
-// — Home and a forward step on the first item, End and a backward step on the last.
+// Move focus within items, wrapping at both ends, returning the newly focused item so a
+// radio group can carry its selection along; undefined (event untouched) for a non-nav key
+// or empty list. Left/Right are opt-in so vertical menus leave them to the page. Focus from
+// outside gives idx -1: forward/Home land on the first item, backward/End on the last.
 export function step_focus<T extends HTMLElement>(
   event: KeyboardEvent,
   items: T[],
@@ -373,12 +365,11 @@ export function step_focus<T extends HTMLElement>(
 }
 
 // === Shortcut rebinding ===
-// The reverse of parse_shortcut, for UIs that let users record their own shortcuts.
-// Combos come back in one canonical spelling: modifiers in a fixed order, `mod` for
-// the platform's primary modifier, and no segment that would break a split on `+`.
+// Reverse of parse_shortcut, for UIs recording user shortcuts. Canonical spelling:
+// modifiers in fixed order, `mod` for the platform primary, nothing that breaks a `+` split.
 
 const MODIFIER_ORDER = [`mod`, `meta`, `ctrl`, `alt`, `shift`]
-// other spellings users and `event.key` produce for the modifiers named above
+// other spellings users and `event.key` produce for the modifiers above
 const MODIFIER_ALIASES: Record<string, string> = {
   cmd: `meta`,
   command: `meta`,
@@ -395,9 +386,8 @@ const MODIFIER_EVENT_KEYS = new Set(
 )
 
 // Canonical combo for a keydown, e.g. `mod+shift+t`; null for a pure-modifier press.
-// `mod` stands in for Cmd on Apple and Ctrl elsewhere, so one recorded combo works on
-// both and round-trips through matches_shortcut. Pass mod: false to record the
-// physical modifier instead, which a combo bound to one platform wants.
+// `mod` keeps one recording working on both platforms; mod: false records the physical
+// modifier instead, for a combo deliberately bound to one platform.
 export function event_to_combo(
   event: KeyboardEvent,
   { mod = true }: { mod?: boolean } = {},
@@ -419,10 +409,9 @@ export function event_to_combo(
   return [...mods, KEY_TOKENS[key] ?? key].join(`+`)
 }
 
-// Canonical form of a combo written by hand or read back from storage; null for junk
-// (no key, several keys, or a lone modifier). Bare keys like `escape` are valid here
-// because run_hotkeys accepts them; require_modifier rejects them for rebinding UIs,
-// where an unmodified key would swallow ordinary typing.
+// Canonical form of a hand-written or stored combo; null for junk (no key, several keys,
+// lone modifier). Bare keys like `escape` pass since run_hotkeys accepts them;
+// require_modifier rejects them for rebinding UIs, where they'd swallow ordinary typing.
 export function normalize_combo(
   combo: string,
   { require_modifier = false }: { require_modifier?: boolean } = {},
@@ -436,9 +425,8 @@ export function normalize_combo(
   return [...MODIFIER_ORDER.filter((name) => mods.has(name)), key].join(`+`)
 }
 
-// `mod` is Cmd on Apple and Ctrl everywhere else, so `mod+k` and the platform's own
-// spelling of the same chord are one shortcut and have to collide. Conflicts are judged
-// on this resolved form; what gets stored stays in the canonical `mod` spelling.
+// `mod+k` and the platform's own spelling of that chord are one shortcut and must collide,
+// so conflicts are judged on this resolved form; storage keeps the `mod` spelling.
 const resolve_combo = (combo: string): string => {
   const primary = is_apple_platform() ? `meta` : `ctrl`
   const parts = combo.split(`+`)
@@ -452,10 +440,8 @@ const resolve_combo = (combo: string): string => {
   return [...MODIFIER_ORDER.filter((name) => mods.has(name)), ...keys].join(`+`)
 }
 
-// Validates stored `action id -> combo` overrides against a map of defaults, dropping
-// unknown ids, junk combos and overrides that merely restate the default. Overrides
-// that would leave two actions on one combo are dropped too, so an override can never
-// shadow another action's shortcut.
+// Validate stored `action id -> combo` overrides against defaults, dropping unknown ids,
+// junk combos, ones restating the default, and ones that would shadow another action.
 export function sanitize_shortcut_overrides(
   value: unknown,
   defaults: Record<string, string>,
@@ -486,10 +472,8 @@ export function sanitize_shortcut_overrides(
   }
 }
 
-// Compare arrays/values for equality to avoid unnecessary updates.
-// Prevents infinite loops when value/selected are bound to reactive wrappers
-// that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.
-// Treats null/undefined/[] as equivalent empty states to prevent extra updates on init (#369).
+// Skips updates when nothing changed, so reactive wrappers that clone arrays on assignment
+// (Superforms, stores) can't loop forever (#309). null/undefined/[] all count as empty (#369).
 export function values_equal(val1: unknown, val2: unknown): boolean {
   if (val1 === val2) return true
   const is_empty = (val: unknown) =>
@@ -505,9 +489,8 @@ export function values_equal(val1: unknown, val2: unknown): boolean {
 const HAS_COLLAPSIBLE_WHITESPACE = /\s\s|[^\S ]/u
 const HAS_NON_PLAIN_WHITESPACE = /[^\S ]/u
 
-// Case-insensitive subsequence match: returns the indices in target_text where
-// the characters of search_text appear in order, or null if not all characters
-// can be matched. An empty search matches with no indices.
+// Case-insensitive subsequence match: indices in target_text where search_text's chars
+// appear in order, or null if any is missing. An empty search matches with no indices.
 export function fuzzy_match_indices(
   search_text: string,
   target_text: string,
@@ -525,8 +508,8 @@ export function fuzzy_match_indices(
       const normalized = character.toLowerCase()
       target += normalized
       for (let unit_idx = 0; unit_idx < normalized.length; unit_idx++) {
-        // Preserve UTF-16 code-unit indices for astral characters while mapping extra
-        // case-folded units (İ -> i + combining dot) back to their one source unit.
+        // keep UTF-16 indices for astral chars while folding extra case-folded units
+        // (İ -> i + combining dot) back onto their one source unit
         target_offsets.push(source_offset + Math.min(unit_idx, character.length - 1))
       }
       source_offset += character.length
@@ -534,7 +517,7 @@ export function fuzzy_match_indices(
   }
   if (HAS_NON_PLAIN_WHITESPACE.test(target)) target = target.replaceAll(/\s/gu, ` `)
 
-  // Greedy leftmost match; pos only moves forward, so scanning stays linear.
+  // greedy leftmost match; pos only moves forward, so scanning stays linear
   const indices: number[] = []
   let pos = -1
   // by code unit, not for...of: code points emit one index per astral char, two expected
@@ -549,16 +532,13 @@ export function fuzzy_match_indices(
 
 // True if search is a subsequence of target, e.g. "tageoo" matches "tasks/geo-opt"
 export function fuzzy_match(search_text: string, target_text: string): boolean {
-  // guard null/undefined inputs (fuzzy_match_indices would throw on .toLowerCase())
+  // fuzzy_match_indices would throw on .toLowerCase() of null/undefined
   if (search_text == null || target_text == null) return false
-  // empty search matches everything, empty target matches nothing - both already
-  // handled by fuzzy_match_indices (empty search -> [], else vs empty target -> null)
   return fuzzy_match_indices(search_text, target_text) !== null
 }
 
-// A titled run of actions for ActionMenu, optionally a radio group: `selected` matches
-// an action's `id ?? label`, null being a group with nothing chosen yet. Left off, the
-// section is a plain heading and its items stay ordinary menu items.
+// A titled run of ActionMenu actions. Setting `selected` (matched against an action's
+// `id ?? label`, null for nothing chosen) makes it a radio group instead of a plain heading.
 export type CmdSection = {
   title: string
   actions: CmdAction[]
@@ -591,11 +571,10 @@ export function cmd_action_matches(
   )
 }
 
-// Coalesces subtree mutations into one refresh per microtask, including mutations caused by
-// `refresh` itself. Callers perform their own initial refresh.
-// Svelte updates a reactive `{value}` by writing the text node's `nodeValue`, which is a
-// characterData mutation and fires no childList record — so text that changes in place is
-// invisible to an observer that does not opt in.
+// Coalesces subtree mutations (including ones `refresh` causes) into one refresh per
+// microtask; callers do their own initial refresh. watch_text is needed because Svelte
+// updates a reactive `{value}` via the text node's `nodeValue`, a characterData mutation
+// that fires no childList record.
 export function observe_subtree(
   root: Element,
   attribute_filter: string[],
@@ -627,12 +606,12 @@ export function observe_subtree(
 
 // === Masonry ===
 export const order_options = [
-  `balanced`, // Rebalances all items to shortest columns (items may jump)
-  // New items go to the shortest column and placed items stay put, except when the
-  // column count grows: assignments reset so the new columns get used
+  `balanced`, // rebalances all items to shortest columns (items may jump)
+  // new items go to the shortest column, placed items stay put; a growing column count
+  // resets assignments so the new columns get used
   `balanced-stable`,
-  `row-first`, // Round-robin: 1->2->3->1->2->3...
-  `column-sequential`, // Purely sequential: first N items in col 1, next N in col 2
-  `column-balanced`, // Height-aware: fill col 1 to target height, then col 2, etc.
+  `row-first`, // round-robin: 1->2->3->1->2->3...
+  `column-sequential`, // first N items in col 1, next N in col 2
+  `column-balanced`, // height-aware: fill col 1 to target height, then col 2, etc.
 ] as const
 export type MasonryOrder = (typeof order_options)[number]

--- a/src/lib/vite-config.ts
+++ b/src/lib/vite-config.ts
@@ -5,13 +5,12 @@
 // Sections merge over the defaults — lint's object-valued members a second level down,
 // so retuning one rule or staged glob restates nothing else, while its arrays replace.
 //
-// The shapes below are spelled out instead of reused from vite-plus's UserConfig and
-// OxlintConfig (a test keeps that import out). Those come from the `oxlint` package, so a
-// consumer on a different vite-plus has a second, unrelated copy, and comparing the two
-// exhausts TS's stack depth where this config is spread into their `defineConfig`. For the
-// same reason the members are literal unions and carry no index signature: oxlint's own
-// names are unions a widened `string` cannot satisfy, and an unlisted option typed
-// `unknown` satisfies nothing. Extra options belong in the consumer's own literal.
+// Shapes are spelled out rather than reused from vite-plus's UserConfig/OxlintConfig (a test
+// keeps that import out): those originate in `oxlint`, so a consumer on a different vite-plus
+// has a second copy, and comparing the two exhausts TS's stack depth when this config is
+// spread into their `defineConfig`. Hence also literal unions and no index signature —
+// oxlint's names are unions a widened `string` cannot satisfy, and an unlisted `unknown`
+// option satisfies nothing. Extra options belong in the consumer's own literal.
 type Severity = `error` | `warn` | `off`
 // a rule is a severity, or a severity plus its options
 type Rules = Record<string, Severity | [Severity, ...unknown[]]>
@@ -27,8 +26,8 @@ export type SharedConfig = {
   }
   fmt: { semi: boolean; singleQuote: boolean; printWidth: number; svelte: boolean }
   build: { cssTarget: string }
-  // lint-staged lets a whole staged config be one function; ours is always a glob map, and
-  // vite-plus JSON.stringifies it to reach its Rust side, where a function is dropped
+  // lint-staged allows a function here, but vite-plus JSON.stringifies this to reach its
+  // Rust side, which drops functions, so ours is always a glob map
   staged: Record<string, string>
 }
 
@@ -123,8 +122,7 @@ const error_rules = [
   eslint-plugin-unicorn/prefer-string-replace-all @typescript-eslint/dot-notation radix
   prefer-exponentiation-operator no-implicit-coercion
   eslint-plugin-vitest/prefer-to-have-length`,
-  // named capture groups self-document a regex match; positional ones must be
-  // renamed. And `export ... from` beats importing purely to re-export
+  // named capture groups self-document a match; `export ... from` beats importing to re-export
   `prefer-named-capture-group eslint-plugin-unicorn/prefer-export-from`,
 ]
   .join(` `)
@@ -140,7 +138,7 @@ const lint: SharedConfig[`lint`] = {
     ...Object.fromEntries(error_rules.map((rule) => [rule, `error`] as const)),
     // the rest carry an option, or a reason for being off
     'no-promise-executor-return': [`error`, { allowVoid: true }],
-    // `void` explicitly marks intentionally ignored Promise-executor return values.
+    // `void` marks intentionally ignored Promise-executor return values
     'typescript/no-meaningless-void-operator': `off`,
     'no-console': [`error`, { allow: [`info`, `warn`, `error`] }],
     'eslint-plugin-unicorn/max-nested-calls': [`error`, { max: 3 }],
@@ -156,25 +154,25 @@ const lint: SharedConfig[`lint`] = {
     '@typescript-eslint/no-unsafe-type-assertion': `off`,
     '@typescript-eslint/restrict-template-expressions': `off`,
     'no-await-in-loop': `off`,
-    // Permit sorting fresh/local arrays as a standalone statement.
+    // permit sorting fresh/local arrays as a standalone statement
     'eslint-plugin-unicorn/no-array-sort': [`error`, { allowExpressionStatement: true }],
     'oxc/no-map-spread': `off`,
     'eslint-plugin-vitest/no-conditional-expect': `off`,
     // Vitest default rules — too noisy
     'eslint-plugin-vitest/require-mock-type-parameters': `off`,
-    // Tests mock non-existent globals/DOM APIs via assignment (`globalThis.fetch = vi.fn()`,
-    // `el.requestFullscreen = vi.fn()`); vi.spyOn throws on absent props and tightens mock types
+    // tests mock absent globals by assignment (`globalThis.fetch = vi.fn()`), which vi.spyOn
+    // throws on
     'eslint-plugin-vitest/prefer-spy-on': `off`,
-    // autofix rewrites `toHaveBeenCalled()` → `toHaveBeenCalledWith()` (asserts zero args, wrong);
-    // can't infer expected args, and `toHaveBeenCalled()` is the intended check in most spots
+    // its autofix rewrites `toHaveBeenCalled()` to `toHaveBeenCalledWith()`, wrongly asserting
+    // zero args; the plain check is what most call sites mean
     'eslint-plugin-vitest/prefer-called-with': `off`,
-    // benign barrel-file cycles (components import from their package `index.ts` that re-exports
-    // them); resolving them conflicts with the `$lib/foo` barrel-import convention
+    // benign barrel cycles (components import from the `index.ts` that re-exports them);
+    // breaking them conflicts with the `$lib/foo` barrel-import convention
     'eslint-plugin-import/no-cycle': `off`,
     // maxArgs 2 because vitest supports expect(actual, message)
     'eslint-plugin-vitest/valid-expect': [`error`, { maxArgs: 2 }],
-    // count any *assert*/*expect* helper as an assertion so expect-expect doesn't flag tests
-    // that delegate to helpers (oxlint glob `*` matches one [a-z\d] run, so name them camelCase)
+    // count *assert*/*expect* helpers as assertions so tests delegating to them pass
+    // (oxlint's `*` matches one [a-z\d] run, so such helpers must be camelCase)
     'eslint-plugin-vitest/expect-expect': [
       `error`,
       { assertFunctionNames: [`*assert*`, `*expect*`] },
@@ -182,9 +180,8 @@ const lint: SharedConfig[`lint`] = {
   },
   overrides: [
     {
-      // vitest mock assertions like `expect(obj.method).toHaveBeenCalled()` trip
-      // unbound-method (false positive on spies) and no-underscore-dangle (mock
-      // internals). Relaxing them in tests is the typescript-eslint-recommended approach.
+      // `expect(obj.method).toHaveBeenCalled()` trips unbound-method (false positive on
+      // spies) and no-underscore-dangle; typescript-eslint recommends relaxing both in tests
       files: [`tests/**`, `**/*.test.ts`, `**/*.test.svelte.ts`],
       rules: {
         '@typescript-eslint/unbound-method': `off`,
@@ -201,8 +198,7 @@ const fmt: SharedConfig[`fmt`] = {
   svelte: true,
 }
 
-// the default chrome111 lacks light-dark(), which LightningCSS then polyfills into
-// broken space toggles
+// the default chrome111 lacks light-dark(), which LightningCSS polyfills into broken toggles
 const build: SharedConfig[`build`] = { cssTarget: `esnext` }
 
 const staged: SharedConfig[`staged`] = {
@@ -210,8 +206,8 @@ const staged: SharedConfig[`staged`] = {
   '*.{ts,svelte}': `sh -c 'npx svelte-kit sync && npx svelte-check --threshold error'`,
 }
 
-// `staged` is not wrapped in Partial: it is an index-signature record, so a subset of
-// globs already type-checks, and Partial would widen every value to `| undefined`.
+// `staged` skips Partial: an index-signature record already accepts a subset of globs, and
+// Partial would widen every value to `| undefined`.
 export type ConfigOverrides = {
   lint?: Partial<SharedConfig[`lint`]>
   fmt?: Partial<SharedConfig[`fmt`]>
@@ -219,12 +215,10 @@ export type ConfigOverrides = {
   staged?: SharedConfig[`staged`]
 }
 
-// A factory rather than an object the caller spreads and patches: spreading a function
-// trips no-misused-spread, and vite-plus JSON.stringifies these members to reach its Rust
-// side, where a function value is dropped without a word.
+// A factory, not a spreadable object: spreading a function trips no-misused-spread, and
+// vite-plus JSON.stringifies these members to reach Rust, silently dropping functions.
 export const make_config = (overrides: ConfigOverrides = {}): SharedConfig => {
-  // deep copy, so a caller mutating `cfg.lint.rules` or pushing onto
-  // `cfg.lint.ignorePatterns` cannot rewrite the defaults behind the next call
+  // deep copy, so a caller mutating `cfg.lint.rules` can't rewrite the defaults
   const base = structuredClone({ lint, fmt, build, staged })
   return {
     lint: {

--- a/src/routes/(demos)/(attachments)/attachments/+page.md
+++ b/src/routes/(demos)/(attachments)/attachments/+page.md
@@ -3,8 +3,7 @@
   import { SubpageGrid } from '$lib'
   import { demo_labels } from '../..'
 
-  // Keyed by route slug; the card title comes from demo_labels so it stays the exact
-  // export name and can't drift from the nav.
+  // keyed by route slug; titles come from demo_labels so they can't drift from the nav
   const descriptions: Record<string, string> = {
     tooltip: `Top-layer tooltips with automatic placement, delegation and controlled state.`,
     draggable: `Pointer dragging with handles, axis locks and position callbacks.`,
@@ -21,8 +20,8 @@
     'forward-window-keydown': `Route page-level keys to the viewer under the pointer.`,
     'file-drop': `Drag-and-drop files with directory expansion and MIME filtering.`,
   }
-  // resolve's arg type distributes over the Pathname union, so a slug built at runtime
-  // can't match a single arm; every demo route is param-free
+  // resolve's arg type distributes over the Pathname union, so a runtime slug can't match a
+  // single arm; every demo route is param-free
   const resolve_path = resolve as (path: string) => string
   const subpages = Object.entries(descriptions).map(
     ([slug, description]): [string, string, string] => [

--- a/src/routes/(demos)/(attachments)/attachments/file-drop/+page.md
+++ b/src/routes/(demos)/(attachments)/attachments/file-drop/+page.md
@@ -22,8 +22,9 @@
     multiple: allow_multiple,
     on_drag_active: (active) => (drag_active = active),
     on_files: async (files, signal) => {
-      // `signal` only aborts on a newer drop, so the picker below could win a race with this
-      // await; every writer replaces `names`, so its identity settles who was last
+      // `signal` aborts on a newer drop and on teardown, but not for the picker below, which
+      // could win a race with this await; every writer replaces `names`, so its identity
+      // settles who was last
       const reported = names
       await Promise.all(files.map((file) => file.arrayBuffer()))
       if (!signal.aborted && names === reported) show_files(files)

--- a/src/routes/(demos)/(attachments)/attachments/file-drop/+page.md
+++ b/src/routes/(demos)/(attachments)/attachments/file-drop/+page.md
@@ -22,8 +22,8 @@
     multiple: allow_multiple,
     on_drag_active: (active) => (drag_active = active),
     on_files: async (files, signal) => {
-      // `signal` only aborts on a newer drop, so the picker below would lose a race
-      // with this await. Every writer replaces `names`, so its identity settles it.
+      // `signal` only aborts on a newer drop, so the picker below could win a race with this
+      // await; every writer replaces `names`, so its identity settles who was last
       const reported = names
       await Promise.all(files.map((file) => file.arrayBuffer()))
       if (!signal.aborted && names === reported) show_files(files)

--- a/src/routes/(demos)/(attachments)/attachments/sortable/+page.md
+++ b/src/routes/(demos)/(attachments)/attachments/sortable/+page.md
@@ -13,29 +13,32 @@
   ]
 </script>
 
-<table {@attach sortable()} class="demo-table">
-  <thead>
-    <tr>
-      <th>Planet</th>
-      <th>Moons</th>
-      <th>Discovery</th>
-      <th>Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    {#each planets as { planet, moons, discovery, notes }}
+<!-- four columns do not fit a phone; scroll the table in its own box rather than the page -->
+<div style="overflow-x: auto">
+  <table {@attach sortable()} class="demo-table">
+    <thead>
       <tr>
-        <td>{planet}</td>
-        <td>{moons}</td>
-        <td>{discovery}</td>
-        <td>{notes}</td>
+        <th>Planet</th>
+        <th>Moons</th>
+        <th>Discovery</th>
+        <th>Notes</th>
       </tr>
-    {/each}
-  </tbody>
-  <caption style="caption-side: bottom; padding-top: 0.5em">
-    Click headers to sort; click again to reverse
-  </caption>
-</table>
+    </thead>
+    <tbody>
+      {#each planets as { planet, moons, discovery, notes }}
+        <tr>
+          <td>{planet}</td>
+          <td>{moons}</td>
+          <td>{discovery}</td>
+          <td>{notes}</td>
+        </tr>
+      {/each}
+    </tbody>
+    <caption style="caption-side: bottom; padding-top: 0.5em">
+      Click headers to sort; click again to reverse
+    </caption>
+  </table>
+</div>
 
 <style>
   .demo-table {

--- a/src/routes/(demos)/(attachments)/attachments/tooltip/+page.md
+++ b/src/routes/(demos)/(attachments)/attachments/tooltip/+page.md
@@ -66,8 +66,7 @@ One recycled tooltip node serves the whole document, rendered in the browser's t
   </button>
 </div>
 
-<!-- Scrolling leaves too little room below or above, so the default flip changes sides.
-Padding leaves room to scroll both ways while keeping the button visible. -->
+<!-- scrolling starves one side, flipping the tooltip; padding keeps the button visible -->
 <div
   bind:this={scroll_boundary}
   class="demo-box"
@@ -153,8 +152,7 @@ Attach `tooltip()` once to a container and every descendant carrying `title`, `a
   <button
     aria-label="More info"
     {@attach tooltip({
-      // only enable allow_html for trusted or sanitized content, never raw
-      // user input — HTML tooltips are an XSS vector otherwise
+      // allow_html on raw user input is an XSS vector: trusted or sanitized content only
       content: `<strong>Bold</strong> and <em>italic</em> markup`,
       allow_html: true,
       placement: `right`,

--- a/src/routes/(demos)/(code-editor)/code-editor/+page.md
+++ b/src/routes/(demos)/(code-editor)/code-editor/+page.md
@@ -177,8 +177,8 @@ app startup.
 
   const token = (name: (typeof TOKEN_CLASS_NAMES)[number], emphasized = false) =>
     TOKEN_CLASS_NAMES.indexOf(name) | (emphasized ? EMPHASIS_BIT : 0)
-  // A tiny fixture tokenizer: enough to demonstrate token color and changed-word emphasis
-  // without bundling a language grammar or diff engine into the docs site.
+  // fixture tokenizer: shows token color and changed-word emphasis without bundling a
+  // language grammar or diff engine into the docs site
   const spans_for = (text: string) => {
     const match = /\b(?:log|info|function|const)\b/u.exec(text)
     if (!match) return []
@@ -234,7 +234,7 @@ app startup.
   } satisfies DiffResult
 
   const backend: DiffBackend = {
-    // Fixed fixture: a production backend inspects all DiffTextArgs fields.
+    // fixed fixture; a production backend inspects all DiffTextArgs fields
     diff_text: () => Promise.resolve(result),
   }
 </script>

--- a/src/routes/(demos)/(dialogs)/dialogs/+page.md
+++ b/src/routes/(demos)/(dialogs)/dialogs/+page.md
@@ -220,8 +220,8 @@ an ancestor would otherwise recurse without end — which is why the handler bel
     event.preventDefault()
     is_dragging = false
     if (!event.dataTransfer) return
-    // rejects on a tree that nests or branches past its caps, which a symlink cycle
-    // reaches — unhandled, the drop would look like it silently did nothing
+    // rejects past its nesting/branching caps, which a symlink cycle reaches; unhandled, the
+    // drop would look like it silently did nothing
     try {
       dropped = await files_from_data_transfer(event.dataTransfer)
       drop_error = ``

--- a/src/routes/(demos)/(extras)/extras/+page.md
+++ b/src/routes/(demos)/(extras)/extras/+page.md
@@ -72,6 +72,8 @@ Pass the glyph value (`<Icon icon={Info} />`), not a name.
   import type { IconData } from '$lib/icons'
 
   const catalog = Object.entries<IconData>(icons)
+  // zero-width spaces let long CamelCase names wrap between words instead of mid-word
+  const wrappable = (name: string) => name.replace(/(?<=[a-z\d])(?=[A-Z])/g, `​`)
   let query = $state(``)
   let filtered_catalog = $derived(
     catalog.filter(([name]) => name.toLowerCase().includes(query.trim().toLowerCase())),
@@ -86,20 +88,20 @@ Pass the glyph value (`<Icon icon={Info} />`), not a name.
 <p aria-live="polite">{filtered_catalog.length} matching icons</p>
 
 <div
-  style="display: grid; grid-template-columns: repeat(auto-fill, minmax(10em, 1fr)); gap: 0.6em"
+  style="display: grid; grid-template-columns: repeat(auto-fill, minmax(12em, 1fr)); gap: 0.6em; --card-bg: var(--sms-options-bg, light-dark(white, #333))"
 >
   {#each filtered_catalog as [name, icon] (name)}
     <CopyButton
       content={`import { ${name} } from 'svelte-widgets/icons'`}
       title={`Copy ${name} import`}
       aria-label={`Copy ${name} import`}
-      style="display: flex; align-items: center; gap: 0.5em; padding: 0.65em; border: 1px solid var(--sms-border, light-dark(lightgray, #555)); border-radius: 5px; background: var(--sms-options-bg, light-dark(white, #333)); color: inherit; cursor: pointer; text-align: left"
+      style="position: relative; display: grid; padding: 0.65em; width: 100%; white-space: normal; border: 1px solid var(--sms-border, light-dark(lightgray, #555)); border-radius: 5px; background: var(--card-bg); color: inherit; cursor: pointer"
     >
       {#snippet children({ state })}
-        <Icon {icon} style="font-size: 1.5em" />
-        <code>{name}</code>
+        <Icon {icon} style="font-size: 1.5em; flex: none" />
+        <code style="line-height: 1.3">{wrappable(name)}</code>
         <small
-          style="margin-inline-start: auto"
+          style="position: absolute; inset: 0; display: grid; place-items: center; background: var(--card-bg)"
           style:visibility={state === `ready` ? `hidden` : `visible`}
           >{state === `error` ? `Failed` : `Copied`}</small
         >

--- a/src/routes/(demos)/(multiselect)/infinite-scroll/+page.md
+++ b/src/routes/(demos)/(multiselect)/infinite-scroll/+page.md
@@ -11,17 +11,16 @@ Provide a `loadOptions` function that fetches data:
   import { MultiSelect } from '$lib'
   import type { LoadOptionsParams, LoadOptionsResult } from '$lib/types'
 
-  // Simulated large dataset - in practice, this would be a database/API
+  // stands in for a database/API
   const all_items: string[] = Array.from({ length: 10000 }, (_, idx) => `Item ${idx + 1}`)
 
   async function load_options(
     params: LoadOptionsParams,
   ): Promise<LoadOptionsResult<string>> {
     const { search, offset, limit } = params
-    // Simulate network delay
+    // simulated network delay
     await new Promise((resolve) => setTimeout(resolve, 300))
 
-    // Filter and paginate
     const filtered = search
       ? all_items.filter((item) => item.toLowerCase().includes(search.toLowerCase()))
       : all_items

--- a/src/routes/(demos)/(multiselect)/kit-form-actions/+page.md
+++ b/src/routes/(demos)/(multiselect)/kit-form-actions/+page.md
@@ -104,7 +104,8 @@ export const actions = {
     const data = await request.formData()
     let colors = data.get(`colors`)
 
-    // failures return an empty array so the client can always bind it to `selected`
+    // every failure returns an array — `boring` echoes the valid picks, the rest send none —
+    // so the client can always bind it to `selected`
     if (!colors || typeof colors !== `string`) {
       return fail(400, { colors: [], error: `missing` })
     }

--- a/src/routes/(demos)/(multiselect)/kit-form-actions/+page.md
+++ b/src/routes/(demos)/(multiselect)/kit-form-actions/+page.md
@@ -104,8 +104,7 @@ export const actions = {
     const data = await request.formData()
     let colors = data.get(`colors`)
 
-    // failure branches return an empty array so the client can always bind the
-    // result to MultiSelect's `selected` prop without type checks
+    // failures return an empty array so the client can always bind it to `selected`
     if (!colors || typeof colors !== `string`) {
       return fail(400, { colors: [], error: `missing` })
     }
@@ -119,8 +118,8 @@ export const actions = {
     if (!Array.isArray(colors)) {
       return fail(400, { colors: [], error: `array` })
     }
-    // only the offered colors may reach the response, so a hand-crafted POST can't
-    // echo arbitrary strings or objects back into the page
+    // only offered colors may reach the response, so a hand-crafted POST can't echo
+    // arbitrary values back into the page
     const valid_colors = colors.filter(
       (color: unknown): color is string =>
         typeof color === `string` && allowed_colors.includes(color),

--- a/src/routes/(demos)/(multiselect)/kit-form-actions/+page.server.ts
+++ b/src/routes/(demos)/(multiselect)/kit-form-actions/+page.server.ts
@@ -2,17 +2,16 @@ import { fail } from '@sveltejs/kit'
 import { colors as allowed_colors } from '$site/options'
 import type { Actions } from './$types'
 
-// Form actions require a server and cannot work on static sites.
-// The underscore prefix disables this export during static build.
-// To test locally with `npm run dev`, rename `_actions` to `actions`.
+// Form actions need a server, so the underscore prefix disables this export during static
+// build. Rename `_actions` to `actions` to test locally with `npm run dev`.
 // eslint-disable-next-line no-underscore-dangle -- intentionally disabled for static builds
 export const _actions = {
   'validate-form': async ({ request }) => {
     const data = await request.formData()
     let colors = data.get(`colors`)
 
-    // failure branches return an empty array so the client can always bind the
-    // result to MultiSelect's `selected` prop without type checks
+    // failures return an empty array so the client can bind the result to MultiSelect's
+    // `selected` prop without type checks
     if (!colors || typeof colors !== `string`) {
       return fail(400, { colors: [], error: `missing` })
     }
@@ -30,7 +29,7 @@ export const _actions = {
       return fail(400, { colors: [], error: `array` })
     }
     // filtered so a hand-crafted POST cannot echo arbitrary strings back into the page,
-    // deduplicated so a repeated `Red` cannot slip past the single-color check below
+    // deduped so a repeated `Red` cannot slip past the single-color check below
     const valid_colors = colors.filter(
       (color: unknown, color_idx): color is string =>
         typeof color === `string` &&

--- a/src/routes/(demos)/(multiselect)/multiselect/+page.md
+++ b/src/routes/(demos)/(multiselect)/multiselect/+page.md
@@ -27,8 +27,8 @@
     'parse-labels-as-html': `Render option labels as HTML.`,
     portal: `Portaled dropdown rendering and layering.`,
   }
-  // resolve's arg type distributes over the Pathname union, so a slug built at runtime
-  // can't match a single arm; every demo route is param-free
+  // resolve's arg type distributes over the Pathname union, so a runtime slug can't match a
+  // single arm; every demo route is param-free
   const resolve_path = resolve as (path: string) => string
   const subpages = Object.entries(descriptions).map(
     ([slug, description]): [string, string, string] => [

--- a/src/routes/(demos)/(multiselect)/persistent/+page.md
+++ b/src/routes/(demos)/(multiselect)/persistent/+page.md
@@ -44,8 +44,7 @@ Tests that binding to reactive wrappers (Svelte stores, Superforms, etc.) that c
   import { MultiSelect } from '$lib'
   import { type Writable, writable } from 'svelte/store'
 
-  // Regression test for issue #309: store subscriptions would cause infinite
-  // loops without the values_equal() fix in MultiSelect.svelte
+  // issue #309: store subscriptions looped forever before values_equal() in MultiSelect.svelte
   const options: string[] = [`Red`, `Green`, `Blue`]
   let increment = $state(0)
   let list_store: Writable<string[]> = writable([])

--- a/src/routes/(demos)/(multiselect)/ui/+page.md
+++ b/src/routes/(demos)/(multiselect)/ui/+page.md
@@ -22,7 +22,7 @@
   placeholder="Pick your favorite foods"
   removeAllTitle="Remove all foods"
   closeDropdownOnSelect
-  style="width: 500px"
+  style="width: min(500px, 100%)"
   invalid
 />
 ```

--- a/src/routes/(demos)/(multiselect)/ui/+page.md
+++ b/src/routes/(demos)/(multiselect)/ui/+page.md
@@ -7,8 +7,7 @@
   import { MultiSelect } from '$lib'
   import { foods } from '$site/options'
 
-  // golden-angle hue rotation gives distinct colors that stay identical
-  // between prerender and hydration (Math.random() would not)
+  // golden-angle hues are distinct and stable across prerender/hydration (Math.random() isn't)
   let options = $derived(
     foods.map((label, idx) => ({
       label,
@@ -45,8 +44,7 @@
 
 This page is the fixture for the Playwright UI tests in `tests/playwright/MultiSelect.test.ts`, which cover the remove-all button, focus and dropdown open/close behavior, filtering, and the ARIA attributes.
 
-<!-- Smooth scroll is required for arrow key navigation tests to work correctly.
-The Playwright test 'loops through the dropdown list with arrow keys' depends on this. -->
+<!-- the Playwright arrow-key navigation test depends on this smooth scroll -->
 <style>
   @media (prefers-reduced-motion: no-preference) {
     :global(html) {

--- a/src/routes/(demos)/(nav)/nav/+page.md
+++ b/src/routes/(demos)/(nav)/nav/+page.md
@@ -18,7 +18,7 @@ Flexible, accessible navigation with dropdown support, mobile burger menu, and k
   const link_props = { onclick: (event: MouseEvent) => event.preventDefault() }
 </script>
 
-<Nav {routes} {page} {link_props} />
+<Nav {routes} {page} {link_props} breakpoint={0} />
 ```
 
 **Features shown:** Simple string routes with auto-generated labels
@@ -42,6 +42,7 @@ Flexible, accessible navigation with dropdown support, mobile burger menu, and k
   }}
   {page}
   {link_props}
+  breakpoint={0}
 />
 ```
 
@@ -50,6 +51,8 @@ Flexible, accessible navigation with dropdown support, mobile burger menu, and k
 ## Dropdown Menus
 
 Use tuple syntax `[parent, [children...]]` for nested routes. When the parent exists in the children array, it becomes a clickable link. Otherwise, it is a non-clickable label.
+
+Submenus open on the caret, never on hover: pointing at a nav entry should not pop a panel over the page, and hover does not exist on touch. A click, tap, `Enter`, `Space` or `ArrowDown` opens one; the caret again, `Escape` or a click outside closes it.
 
 ```svelte example collapsible
 <script lang="ts">
@@ -65,7 +68,7 @@ Use tuple syntax `[parent, [children...]]` for nested routes. When the parent ex
   const link_props = { onclick: (event: MouseEvent) => event.preventDefault() }
 </script>
 
-<Nav {routes} {page} {link_props} />
+<Nav {routes} {page} {link_props} breakpoint={0} />
 ```
 
 **Features shown:**
@@ -76,7 +79,7 @@ Use tuple syntax `[parent, [children...]]` for nested routes. When the parent ex
 
 ## Keyboard Navigation
 
-- **Tab**: Follow page order; once focus enters a pinned submenu, cycle its links
+- **Tab**: Follow page order; once focus enters an open submenu, cycle its links
 - **Enter/Space**: Open dropdown or follow link
 - **Arrow Down/Up**: Navigate dropdown items
 - **Escape**: Close menus
@@ -103,7 +106,7 @@ For full control, use objects with all available properties:
   const link_props = { onclick: (event: MouseEvent) => event.preventDefault() }
 </script>
 
-<Nav {routes} {page} {link_props} />
+<Nav {routes} {page} {link_props} breakpoint={0} />
 ```
 
 **Features shown:**
@@ -149,7 +152,7 @@ Use the `link` snippet to customize how all links render:
   const routes = ['/', '/about', '/contact']
 </script>
 
-<Nav {routes} {page}>
+<Nav {routes} {page} breakpoint={0}>
   {#snippet link({ href, label, isActive })}
     <a
       {href}
@@ -173,7 +176,12 @@ Add extra content to the nav menu via `children` snippet:
   const link_props = { onclick: (event: MouseEvent) => event.preventDefault() }
 </script>
 
-<Nav {routes} {page} {link_props}>
+<Nav
+  {routes}
+  {page}
+  {link_props}
+  style="--nav-burger-position: absolute; --nav-mobile-menu-position: absolute"
+>
   {#snippet children({ is_open })}
     <button
       style="padding: 4pt 12pt; background: var(--sms-selected-bg, mediumseagreen); border: none; border-radius: 6px; color: white; cursor: pointer"
@@ -210,7 +218,7 @@ Use `item` snippet for per-item customization. The `render_default` escape hatch
   const link_props = { onclick: (event: MouseEvent) => event.preventDefault() }
 </script>
 
-<Nav {routes} {page} {link_props}>
+<Nav {routes} {page} {link_props} breakpoint={0}>
   {#snippet item({ route, render_default })}
     <span style="display: flex; align-items: center; gap: 0.3em">
       {#if route.icon}
@@ -253,6 +261,7 @@ Handle navigation events with `onnavigate`, `onopen`, and `onclose`:
   {routes}
   {page}
   {link_props}
+  style="--nav-burger-position: absolute; --nav-mobile-menu-position: absolute"
   onnavigate={({ href }) => {
     nav_message = `Navigated to ${href}`
     return false // returning false prevents navigation

--- a/src/routes/(demos)/index.ts
+++ b/src/routes/(demos)/index.ts
@@ -1,8 +1,8 @@
 import type { Pathname } from '$app/types'
 import { slug_to_title } from '$lib/utils'
 
-// Labels that slug_to_title (and the nav's capitalize fallback) can't derive, keyed by
-// unresolved route path. Shared by DemoNav's nav labels and the layout's page titles.
+// Labels slug_to_title cannot derive, keyed by unresolved route path. Shared by DemoNav's
+// nav labels and the layout's page titles.
 export const demo_labels: Record<string, string> = {
   '/multiselect': `MultiSelect`,
   '/command-menu': `CommandMenu`,
@@ -14,8 +14,8 @@ export const demo_labels: Record<string, string> = {
   '/min-max-select': `Min/Max`,
   '/allow-user-options': `User Options`,
   '/parse-labels-as-html': `HTML Labels`,
-  // attachments are named after their exports, so the nav shows the exact snake_case
-  // symbol rather than slug_to_title's "Click Outside"
+  // attachments are named after their exports, so the nav shows the snake_case symbol
+  // rather than slug_to_title's "Click Outside"
   ...Object.fromEntries(
     [
       `tooltip`,
@@ -63,12 +63,12 @@ export const demo_nav_routes = groups.map((group) => {
       if (right_route === overview_route) return 1
       return left_route.localeCompare(right_route)
     })
-  // a group holding a single page is that page, so link straight to it rather than
-  // opening a dropdown whose only entry repeats its parent
+  // a single-page group is that page, so link straight to it instead of a dropdown whose
+  // only entry repeats its parent
   return {
     href: children[0],
-    // Nav keys its labels prop on route.label when set, so a group label has to be
-    // correct here; the labels prop only reaches the dropdown children.
+    // Nav keys its labels prop on route.label when set, so a group label must be right
+    // here; the labels prop only reaches the dropdown children.
     label: demo_labels[overview_route] ?? slug_to_title(group),
     ...(children.length > 1 && { children }),
   }

--- a/src/site/Examples.md
+++ b/src/site/Examples.md
@@ -113,7 +113,9 @@ A navigation bar with dropdowns, active-route styling and a mobile burger menu.
   const link_props = { onclick: (event: MouseEvent) => event.preventDefault() }
 </script>
 
-<Nav {routes} {page} {link_props} />
+<!-- breakpoint={0} keeps this inline on phones: the mobile burger is position: fixed, so an
+embedded demo would pin a second one over the site's own nav in the same corner -->
+<Nav {routes} {page} {link_props} breakpoint={0} />
 ```
 
 ### Toc

--- a/tests/playwright/CommandMenu.test.ts
+++ b/tests/playwright/CommandMenu.test.ts
@@ -43,8 +43,8 @@ test(`backdrop still dismisses when CommandMenu disables Escape`, async ({ page 
   await page.keyboard.press(`Escape`)
   await expect(menu).toBeVisible()
 
-  // force: the host is what hit-testing reports at these coordinates, so Playwright refuses
-  // the click as intercepted — the browser still targets the input and retargets to the host
+  // force: hit-testing reports the host here so Playwright calls the click intercepted, but
+  // the browser still targets the input and retargets the event to the host
   await menu.getByRole(`combobox`).click({ force: true })
   await expect(menu).toBeVisible()
 

--- a/tests/playwright/DraggablePane.test.ts
+++ b/tests/playwright/DraggablePane.test.ts
@@ -1,8 +1,7 @@
 import type { Locator, Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 
-// Pointer events matter for touch: a touch drag never produces mousemove. happy-dom cannot
-// show that, so this lives in a real browser.
+// A touch drag never produces mousemove, which happy-dom cannot model — hence a real browser.
 
 type Point = { x: number; y: number }
 
@@ -45,9 +44,8 @@ test(`a mouse drag moves the pane`, async ({ page }) => {
   expect(Math.round(after.y - before.y)).toBe(40)
 })
 
-// The strips are absolute children, so they anchor to the padding box and only reach the
-// pane's 1px border because of their negative insets — press outside one and nothing
-// resizes. Layout is a browser fact.
+// The resize strips anchor to the padding box and reach the pane's 1px border only via their
+// negative insets — press outside one and nothing resizes.
 test(`the outermost pixel of the right edge still resizes`, async ({ page }) => {
   const { pane } = await open_pane(page)
   const before = await box_of(pane)
@@ -59,9 +57,8 @@ test(`the outermost pixel of the right edge still resizes`, async ({ page }) => 
   expect(Math.round(after.width - before.width)).toBe(-70)
 })
 
-// The pane's left/top resolve against the positioned ancestor's padding box, but it is
-// anchored from that ancestor's border-box rect, so a bordered host used to push the pane
-// off the toggle by the border width. Only a browser knows where the padding box starts.
+// The pane's insets resolve against the ancestor's padding box but were computed from its
+// border-box rect, so a bordered host used to push the pane off the toggle by the border width.
 test(`a bordered positioned ancestor keeps the pane anchored to its toggle`, async ({
   page,
 }) => {
@@ -70,7 +67,7 @@ test(`a bordered positioned ancestor keeps the pane anchored to its toggle`, asy
   const anchoring_error = async () => {
     const [pane_box, toggle_box] = await Promise.all([box_of(pane), box_of(toggle)])
     return {
-      // the default offset={ x: 5, y: 5 } hangs the pane off the toggle's bottom right
+      // default offset={ x: 5, y: 5 } hangs the pane off the toggle's bottom right
       right: pane_box.x + pane_box.width - (toggle_box.x + toggle_box.width + 5),
       top: pane_box.y - (toggle_box.y + toggle_box.height + 5),
     }
@@ -88,9 +85,8 @@ test(`a bordered positioned ancestor keeps the pane anchored to its toggle`, asy
   expect(await anchoring_error()).toEqual({ right: 0, top: 0 })
 })
 
-// toggle_props can position the toggle out of the pane's containing block, at which point
-// the toggle's offsetParent is null (viewport) while the pane's is still the host. Reading
-// the toggle's would take the document-coordinate branch and write those as host-local
+// A toggle outside the pane's containing block has offsetParent null (viewport) while the
+// pane's is still the host; reading the toggle's would write document coords as host-local
 // insets, dropping the pane by the host's offset down the page.
 test(`a fixed toggle still anchors the pane to its own offset parent`, async ({
   page,
@@ -120,9 +116,8 @@ test(`a fixed toggle still anchors the pane to its own offset parent`, async ({
   }).toEqual({ right: 0, top: 0 })
 })
 
-// Which handle a corner press lands on is a browser hit-test fact; happy-dom cannot decide
-// it. The corner has its own square handle painted over the two edge strips it overlaps, so
-// it drives BOTH axes — the edge strips still drive one axis each.
+// The corner has its own square handle painted over the two edge strips it overlaps, so it
+// drives BOTH axes; which handle a press lands on is a browser hit-test fact.
 test(`a corner drag resizes both axes`, async ({ page }) => {
   const { pane } = await open_pane(page)
   const before = await box_of(pane)
@@ -165,8 +160,8 @@ test.describe(`touch`, () => {
     expect(Math.round(after.y - before.y)).toBe(30)
   })
 
-  // A pen would pan too and is fixed by the same touch-action, but CDP's injected pen
-  // events skip the compositor gesture path, so only touch can show it here.
+  // A pen pans too and is fixed by the same touch-action, but CDP's injected pen events skip
+  // the compositor gesture path, so only touch can show it here.
   test(`a touch drag on the bottom edge resizes the pane`, async ({ page }) => {
     const { pane } = await open_pane(page)
     const before = await box_of(pane)

--- a/tests/playwright/MultiSelect.test.ts
+++ b/tests/playwright/MultiSelect.test.ts
@@ -2,14 +2,12 @@
 import { foods, languages, octicons } from '$site/options'
 import { expect, test, type Locator, type Page } from '@playwright/test'
 
-// Open the /portal demo modal and return its content locator
 async function open_portal_modal(page: Page): Promise<Locator> {
   await page.goto(`/portal`, { waitUntil: `networkidle` })
   await page.getByRole(`button`, { name: `Open Modal` }).click()
   return page.locator(`div.modal-content.modal`)
 }
 
-// Locate the visible portalled dropdown containing an option with the given label
 const portalled_options = (page: Page, label: string): Locator =>
   page.locator(`body > ul.options:not(.hidden):has(li:has-text("${label}"))`)
 
@@ -52,8 +50,8 @@ test.describe(`input`, () => {
   test(`programmatic focus opens dropdown`, async ({ page }) => {
     await page.goto(`/ui`, { waitUntil: `networkidle` })
     const dropdown = page.locator(`#foods div.multiselect > ul.options`)
-    // Raw DOM focus/blur (not locator.focus(), which skips an already-focused element
-    // and would bypass the component's .focus() override in the retry below).
+    // raw DOM focus/blur: locator.focus() skips an already-focused element and would bypass
+    // the component's .focus() override in the retry below
     const input_method = (method: `focus` | `blur`) =>
       page.evaluate((name) => {
         document.querySelector<HTMLInputElement>(`#foods input[autocomplete]`)?.[name]()
@@ -62,8 +60,7 @@ test.describe(`input`, () => {
     await expect(dropdown).toHaveClass(/hidden/u)
     await expect(dropdown).toBeHidden()
 
-    // Retry focus: it's a no-op if it fires before hydration installs the .focus()
-    // override; each retry re-invokes .focus() until the override opens the dropdown.
+    // focus is a no-op until hydration installs the .focus() override, so retry
     await expect(async () => {
       await input_method(`focus`)
       await expect(dropdown).not.toHaveClass(/hidden/u, { timeout: 1000 })
@@ -329,8 +326,8 @@ test.describe(`portal feature`, () => {
         const wrapper_rect = wrapper.getBoundingClientRect()
         const dropdown_rect = dropdown.getBoundingClientRect()
         const left_delta = Math.abs(dropdown_rect.left - wrapper_rect.left)
-        // auto placement may flip the dropdown above the trigger when space below
-        // is tight; measure the gap on whichever edge the portal chose
+        // auto placement may flip the dropdown above the trigger, so measure the gap on
+        // whichever edge the portal chose
         const top_delta =
           dropdown.dataset.placement === `top`
             ? Math.abs(wrapper_rect.top - dropdown_rect.bottom)
@@ -368,9 +365,8 @@ test.describe(`portal feature`, () => {
   })
 })
 
-// virtualList windowing needs real browser layout (happy-dom reports zero
-// heights), exercised on the internal /virtual-list test page which mounts
-// 2000 options with rows pinned to the default 30px itemHeight
+// Windowing needs real layout (happy-dom reports zero heights). The internal /virtual-list
+// page mounts 2000 options with rows pinned to the default 30px itemHeight.
 test.describe(`virtualList`, () => {
   const item_height = 30
   const total_options = 2000
@@ -382,8 +378,7 @@ test.describe(`virtualList`, () => {
   const goto_virtual_list = async (page: Page): Promise<void> => {
     await page.goto(`/virtual-list`, { waitUntil: `networkidle` })
     await expect(page.locator(`.virtual ul.options`)).toBeVisible()
-    // scroll + keyboard handlers only work once hydration installs the
-    // component's input.focus override (same readiness signal as goto_persistent)
+    // scroll + keyboard handlers only work once hydration installs the input.focus override
     await page.waitForFunction(() => {
       const input_el = document.querySelector<HTMLInputElement>(
         `.virtual input[autocomplete]`,
@@ -471,9 +466,8 @@ test.describe(`virtualList`, () => {
   })
 })
 
-// the portal's `auto` placement flips the dropdown above the input when it would
-// overflow the viewport bottom — needs real viewport geometry. Uses the /portal
-// modal: in a short viewport the lower (octicons) input has more space above.
+// `auto` placement flips the dropdown above the input when it would overflow the viewport
+// bottom. In the /portal modal's short viewport, the lower (octicons) input has more space above.
 test.describe(`portal placement auto-flip`, () => {
   const open_dropdown_at_viewport_height = async (
     page: Page,
@@ -484,8 +478,8 @@ test.describe(`portal placement auto-flip`, () => {
     await page.setViewportSize({ width: 800, height })
     const modal_content = await open_portal_modal(page)
     if (pin_modal_to_bottom) {
-      // the centered modal never leaves enough room above AND too little below;
-      // pin it to the viewport bottom so the flip geometry is deterministic
+      // the centered modal never leaves enough room above AND too little below, so pin it to
+      // the viewport bottom to make the flip geometry deterministic
       await page.evaluate(() => {
         const backdrop = document.querySelector<HTMLElement>(`.modal-backdrop`)
         if (!backdrop) throw new Error(`modal backdrop not found`)
@@ -576,14 +570,11 @@ test(`component buttons are styled correctly with border: none`, async ({ page }
   expect(border_style).toBe(`none`)
 })
 
-// Runtime regression tests for the schemeless-dark-page readability fix: the component
-// pairs a light-dark() text-color default with its light-dark() backgrounds so text can't
-// inherit a near-white page color on pages that never declare `color-scheme` (there
-// light-dark() resolves to its light branch). happy-dom strips light-dark()/var() from
-// computed styles, so this can only be verified in a real browser.
-// light-dark(#222, #eee) → #222 = rgb(34, 34, 34) under the schemeless (light) scheme.
+// The component pairs a light-dark() text-color default with its light-dark() backgrounds so
+// text can't inherit a near-white page color where `color-scheme` is never declared. happy-dom
+// strips light-dark() from computed styles. light-dark(#222, #eee) → #222 under light.
 test.describe(`schemeless-dark-page text-color readability`, () => {
-  test.use({ colorScheme: `light` }) // schemeless subtree resolves light-dark() to its light branch
+  test.use({ colorScheme: `light` }) // schemeless subtree takes light-dark()'s light branch
   const readable = `rgb(34, 34, 34)`
   const computed_color = (page: Page, selector: string) =>
     page
@@ -597,8 +588,7 @@ test.describe(`schemeless-dark-page text-color readability`, () => {
   }) => {
     await page.goto(`/ui`, { waitUntil: `networkidle` })
 
-    // simulate a dark page that never declares color-scheme: force the schemeless (normal)
-    // scheme on the widget's subtree and give its parent a distinctive inherited color.
+    // simulate a dark page that never declares color-scheme, with a distinctive parent color
     await page.evaluate(() => {
       const parent =
         document.querySelector<HTMLElement>(`#foods div.multiselect`)?.parentElement
@@ -613,8 +603,8 @@ test.describe(`schemeless-dark-page text-color readability`, () => {
     )
   })
 
-  // portalled: ul.options is moved to document.body and no longer inherits div.multiselect's
-  // color, so it needs its own default — this is the surface an in-place test can't verify.
+  // portalled ul.options moves to document.body and no longer inherits div.multiselect's
+  // color, so it needs its own default
   test(`portalled dropdown text uses the light-dark() default, not the inherited page color`, async ({
     page,
   }) => {
@@ -640,8 +630,8 @@ test.describe(`schemeless-dark-page text-color readability`, () => {
   })
 })
 
-// the /form demo previews the submitted FormData; spreading it into JSON.stringify()
-// silently dropped every field but the first (extra entries land in the replacer/space args)
+// spreading the submitted FormData into JSON.stringify() silently dropped every field but the
+// first (extra entries land in the replacer/space args)
 test(`form demo previews every submitted FormData field`, async ({ page }) => {
   await page.goto(`/form`, { waitUntil: `networkidle` })
 

--- a/tests/playwright/Nav.test.ts
+++ b/tests/playwright/Nav.test.ts
@@ -47,8 +47,8 @@ test(`generated Nav and MultiSelect ids survive hydration`, async ({ page }) => 
       hydration_warnings.push(text)
     }
   })
-  // This route renders MultiSelect directly during SSR; live-example routes mount
-  // their demo components client-side and cannot expose an SSR/client ID mismatch.
+  // This route renders MultiSelect during SSR; live-example routes mount client-side and so
+  // cannot expose an SSR/client ID mismatch.
   const response = await page.goto(`/range-select`, { waitUntil: `networkidle` })
   const server_html = await response?.text()
   if (!server_html) throw new Error(`Missing SSR response body for /range-select`)
@@ -140,15 +140,14 @@ test.describe(`Nav dropdown`, () => {
   })
 })
 
-// The pill is painted on `.menu > span`, but the link inside it is `flex: 1`, which fills
-// only the content box. Without the link stretching back over the span's padding, that
-// padding is a dead band inside the visible row. Only a browser resolves these boxes.
+// The pill is painted on `.menu > span` but its `flex: 1` link fills only the content box, so
+// without the link stretching over the span's padding that padding is a dead band.
 test(`the whole painted mobile row is part of its link's hit area`, async ({ page }) => {
   await page.setViewportSize({ width: 420, height: 800 })
   await page.goto(`/nav`, { waitUntil: `networkidle` })
 
-  // .click() here races a decorative overlay for the press; the burger's own hit area is
-  // not what this test is about, so open the menu directly
+  // .click() races a decorative overlay for the press, and the burger's hit area is not what
+  // this test is about
   await page
     .locator(`nav.mobile button.burger`)
     .first()
@@ -176,9 +175,9 @@ test(`the whole painted mobile row is part of its link's hit area`, async ({ pag
   }
 })
 
-// The submenu inherits its line-height from the host page, which once made every child row
-// taller than the parent it hangs under. Its guide line is one border on the wrapper, and the
-// active link recolours a segment of it by sitting exactly on top. Layout-only, so: a browser.
+// The submenu inherits line-height from the host page, which once made every child row taller
+// than its parent. Its guide line is one border on the wrapper, recoloured in part by the
+// active link sitting exactly on top.
 test(`expanded submenu rows are compact and share one continuous guide line`, async ({
   page,
 }) => {
@@ -193,7 +192,7 @@ test(`expanded submenu rows are compact and share one continuous guide line`, as
   const parent_row = dropdown.locator(`> div:first-child`)
   const caret = parent_row.locator(`> button`)
   // the caret is the only way to open a section, so it claims the row's full height and runs
-  // out to the painted trailing edge rather than stopping inside the row's padding
+  // out to the painted trailing edge
   const [caret_box, row_box] = await Promise.all([
     caret.boundingBox(),
     parent_row.boundingBox(),
@@ -208,8 +207,7 @@ test(`expanded submenu rows are compact and share one continuous guide line`, as
   await caret.evaluate((el: HTMLElement) => el.click())
   const links = dropdown.locator(`> div:last-child a`)
   await expect(links.first()).toBeVisible()
-  // the section opens over 0.25s; measuring mid-transition reads a wrapper still shorter
-  // than the links it clips
+  // the section opens over 0.25s; mid-transition the wrapper is still shorter than its links
   const wrapper_locator = dropdown.locator(`.submenu-inner`)
   await expect
     .poll(async () => (await wrapper_locator.boundingBox())?.height ?? 0)

--- a/tests/playwright/Nav.test.ts
+++ b/tests/playwright/Nav.test.ts
@@ -274,4 +274,37 @@ test(`expanded submenu rows are compact and share one continuous guide line`, as
   const last = link_boxes[link_boxes.length - 1]
   expect(wrapper.y).toBeLessThanOrEqual(link_boxes[0].y)
   expect(wrapper.bottom).toBeGreaterThanOrEqual(last.bottom - 0.5)
+
+  // The desktop panel hugs its content and its links never wrap, which suits a box floating
+  // free of the page. Inline in the phone column both leaked: a long label pushed the menu
+  // wider than the viewport, so its tail sat outside the panel and had to be scrolled to.
+  const long_label = await links.first().evaluate((link) => {
+    link.textContent = `Extremely Long Submenu Label That Cannot Possibly Fit`
+    const menu = link.closest(`.menu`)
+    if (!menu) throw new Error(`Missing mobile menu panel`)
+    const box = link.getBoundingClientRect()
+    return {
+      menu_overflow: menu.scrollWidth - menu.clientWidth,
+      // the far end of the label, and what is painted there
+      tail: document.elementFromPoint(box.right - 4, box.top + box.height / 2)?.tagName,
+      wrapped: box.height,
+      row_height: menu.querySelector(`.dropdown > div:first-child`)?.clientHeight ?? 0,
+    }
+  })
+  expect(long_label.menu_overflow, `phone menu scrolls sideways`).toBe(0)
+  expect(long_label.tail, `label tail is outside the panel`).toBe(`A`)
+  expect(long_label.wrapped, `label did not wrap onto more rows`).toBeGreaterThan(
+    long_label.row_height,
+  )
+
+  // the panel's other desktop sizing knob is a floor wide enough to clear the trigger, which
+  // on a narrow phone is wider than the whole column
+  await page.setViewportSize({ width: 320, height: 800 })
+  const floored = await links.first().evaluate((link) => {
+    document.documentElement.style.setProperty(`--nav-dropdown-min-width`, `20em`)
+    const menu = link.closest(`.menu`)
+    if (!menu) throw new Error(`Missing mobile menu panel`)
+    return menu.scrollWidth - menu.clientWidth
+  })
+  expect(floored, `--nav-dropdown-min-width leaks into the phone column`).toBe(0)
 })

--- a/tests/playwright/Nav.test.ts
+++ b/tests/playwright/Nav.test.ts
@@ -92,6 +92,42 @@ test.describe(`Nav dropdown`, () => {
     await expect(menu.locator(`a`).first()).toBeVisible()
   })
 
+  // the caret only faded 0.6 -> 1 on hover, which reads as the whole row lighting up rather
+  // than the arrow being its own target
+  for (const mobile of [false, true]) {
+    test(`the ${mobile ? `mobile ` : ``}caret recolors under the pointer`, async ({
+      page,
+    }) => {
+      if (mobile) await page.setViewportSize({ width: 420, height: 800 })
+      await page.goto(`/nav`, { waitUntil: `networkidle` })
+      if (mobile) {
+        await page
+          .locator(`nav.mobile button.burger`)
+          .first()
+          .evaluate((element: HTMLElement) => element.click())
+      }
+
+      const caret = page
+        .locator(`${mobile ? `nav.mobile ` : ``}.dropdown [data-dropdown-toggle]`)
+        .first()
+      const read = () =>
+        caret.evaluate((node) => {
+          const style = getComputedStyle(node)
+          return { color: style.color, opacity: style.opacity }
+        })
+
+      const idle = await read()
+      await caret.hover()
+      // both halves matter: opacity is what the mobile rule's specificity used to eat, and
+      // colour is what tells the user this glyph is the control
+      await expect.poll(async () => (await read()).opacity).toBe(`1`)
+      expect(Number(idle.opacity)).toBeLessThan(1)
+      expect((await read()).color, `caret colour is unchanged on hover`).not.toBe(
+        idle.color,
+      )
+    })
+  }
+
   test(`click opens the dropdown until outside, Escape, or the toggle closes it`, async ({
     page,
   }) => {

--- a/tests/playwright/Nav.test.ts
+++ b/tests/playwright/Nav.test.ts
@@ -1,4 +1,3 @@
-import type { Locator, Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 
 // oxlint-disable-next-line vitest/prefer-each -- Playwright test has no each API
@@ -79,34 +78,21 @@ test(`generated Nav and MultiSelect ids survive hydration`, async ({ page }) => 
 })
 
 test.describe(`Nav dropdown`, () => {
-  const hover_open = async (
-    page: Page,
-    dropdown: Locator,
-    menu: Locator,
-  ): Promise<void> => {
-    const trigger = dropdown.locator(`:scope > div`).first()
-    await expect(trigger).toBeVisible()
-    await expect(async () => {
-      await page.mouse.move(0, 0)
-      await trigger.hover()
-      await expect(menu).toHaveCSS(`display`, `flex`, { timeout: 500 })
-    }).toPass({ timeout: 10_000 })
-  }
-
-  test(`opens on hover and closes on mouse leave`, async ({ page }) => {
+  test(`hover leaves the dropdown shut; only a click opens it`, async ({ page }) => {
     await page.goto(`/nav`, { waitUntil: `networkidle` })
 
     const dropdown = page.locator(`.dropdown`).first()
     const menu = dropdown.locator(`[data-submenu]`)
 
     await expect(menu).toHaveCSS(`display`, `none`)
-    await hover_open(page, dropdown, menu)
-    await expect(menu.locator(`a`).first()).toBeVisible()
-    await page.mouse.move(0, 0)
+    await dropdown.locator(`:scope > div`).first().hover()
     await expect(menu).toHaveCSS(`display`, `none`)
+
+    await dropdown.locator(`[data-dropdown-toggle]`).click()
+    await expect(menu.locator(`a`).first()).toBeVisible()
   })
 
-  test(`click pins dropdown until outside, Escape, or toggle closes it`, async ({
+  test(`click opens the dropdown until outside, Escape, or the toggle closes it`, async ({
     page,
   }) => {
     await page.goto(`/nav`, { waitUntil: `networkidle` })
@@ -188,4 +174,70 @@ test(`the whole painted mobile row is part of its link's hit area`, async ({ pag
       `${edge} of the pill is outside the link`,
     ).toBeLessThanOrEqual(0.5)
   }
+})
+
+// The submenu inherits its line-height from the host page, which once made every child row
+// taller than the parent it hangs under. Its guide line is one border on the wrapper, and the
+// active link recolours a segment of it by sitting exactly on top. Layout-only, so: a browser.
+test(`expanded submenu rows are compact and share one continuous guide line`, async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 420, height: 800 })
+  await page.goto(`/nav`, { waitUntil: `networkidle` })
+  await page
+    .locator(`nav.mobile button.burger`)
+    .first()
+    .evaluate((element: HTMLElement) => element.click())
+
+  const dropdown = page.locator(`nav.mobile .dropdown`).first()
+  const parent_row = dropdown.locator(`> div:first-child`)
+  const caret = parent_row.locator(`> button`)
+  // the caret is the only way to open a section, so it claims the row's full height and runs
+  // out to the painted trailing edge rather than stopping inside the row's padding
+  const [caret_box, row_box] = await Promise.all([
+    caret.boundingBox(),
+    parent_row.boundingBox(),
+  ])
+  if (!caret_box || !row_box) throw new Error(`Missing mobile dropdown caret geometry`)
+  expect(caret_box.height).toBeCloseTo(row_box.height, 0)
+  expect(row_box.x + row_box.width - (caret_box.x + caret_box.width)).toBeLessThanOrEqual(
+    0.5,
+  )
+  expect(caret_box.width).toBeGreaterThan(caret_box.height)
+
+  await caret.evaluate((el: HTMLElement) => el.click())
+  const links = dropdown.locator(`> div:last-child a`)
+  await expect(links.first()).toBeVisible()
+  // the section opens over 0.25s; measuring mid-transition reads a wrapper still shorter
+  // than the links it clips
+  const wrapper_locator = dropdown.locator(`.submenu-inner`)
+  await expect
+    .poll(async () => (await wrapper_locator.boundingBox())?.height ?? 0)
+    .toBeGreaterThan(0)
+  await dropdown
+    .locator(`> div:last-child`)
+    .evaluate((el) =>
+      Promise.all(el.getAnimations({ subtree: true }).map((anim) => anim.finished)),
+    )
+
+  const parent_box = await parent_row.boundingBox()
+  const link_boxes = await links.evaluateAll((els) =>
+    els.map((el) => el.getBoundingClientRect().toJSON()),
+  )
+  const wrapper = await dropdown
+    .locator(`.submenu-inner`)
+    .evaluate((el) => el.getBoundingClientRect().toJSON())
+  if (!parent_box) throw new Error(`Missing mobile dropdown row geometry`)
+
+  for (const box of link_boxes) {
+    expect(box.height, `child row is taller than its parent`).toBeLessThanOrEqual(
+      parent_box.height,
+    )
+    // each link's own (transparent, or accent when current) border sits on the wrapper's line
+    expect(Math.abs(box.x - wrapper.x)).toBeLessThanOrEqual(0.5)
+  }
+  // one unbroken line: the wrapper spans from above the first row to below the last
+  const last = link_boxes[link_boxes.length - 1]
+  expect(wrapper.y).toBeLessThanOrEqual(link_boxes[0].y)
+  expect(wrapper.bottom).toBeGreaterThanOrEqual(last.bottom - 0.5)
 })

--- a/tests/playwright/SettingsSearch.test.ts
+++ b/tests/playwright/SettingsSearch.test.ts
@@ -1,15 +1,13 @@
 import type { Locator, Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 
-// The corner trigger and the filtered-row override are pure CSS, and happy-dom applies
-// neither Svelte's scoped styles nor layout, so both only mean anything in a real browser.
-// Every locator is scoped to this demo: other examples on the page repeat these classes.
+// The corner trigger and the filtered-row override are pure CSS, which happy-dom applies no
+// layout for. Every locator is scoped to this demo: other examples repeat these classes.
 
 const open_demo = async (page: Page) => {
   await page.goto(`/settings`, { waitUntil: `networkidle` })
   const demo = page.locator(`#settings-search`).first()
-  // `networkidle` lands before mdsvex has compiled the live examples on a cold dev server,
-  // so the first test to arrive would otherwise scroll to an element that is not there yet
+  // `networkidle` lands before mdsvex compiles the live examples on a cold dev server
   await expect(demo).toBeVisible()
   await demo.scrollIntoViewIfNeeded()
   return {
@@ -36,7 +34,7 @@ test(`the corner trigger expands into the content flow`, async ({ page }) => {
   const trigger_box = await box_of(trigger)
   const group_before = await box_of(group)
 
-  // collapsed: flush with the pane's top-right corner, and out of flow — the first group
+  // collapsed: flush with the pane's top-right corner and out of flow, so the first group
   // starts at the pane's top edge rather than below the icon
   expect(trigger_box.x + trigger_box.width).toBeCloseTo(pane_box.x + pane_box.width, 0)
   expect(trigger_box.y).toBeCloseTo(pane_box.y, 0)
@@ -57,13 +55,12 @@ test(`filtering paints rows away and matches on group titles`, async ({ page }) 
 
   await field.fill(`radius`)
 
-  // `data-search-hidden` alone loses to the `display: grid` a grid section puts on its rows,
-  // so this only passes if the component's own override is in the stylesheet
+  // `data-search-hidden` alone loses to the `display: grid` a grid section puts on its rows
   await expect(color_row).toBeHidden()
   await expect(radius_row).toBeVisible()
   await expect(camera).toBeHidden() // the group holding no match goes with it
 
-  // no row says "camera"; the group heading above them does, and matching it opens the group
+  // no row says "camera"; only the group heading does, and matching it opens the group
   await field.fill(`camera`)
 
   await expect(camera).toBeVisible()

--- a/tests/playwright/attachments.test.ts
+++ b/tests/playwright/attachments.test.ts
@@ -18,7 +18,7 @@ type TooltipMetrics = {
   content_scrolls: boolean
 }
 
-// Measure final tooltip geometry. The tooltip uses border-box sizing.
+// the tooltip uses border-box sizing
 const measure_tooltip = (tooltip_el: Locator): Promise<TooltipMetrics> =>
   tooltip_el.evaluate((el) => {
     const rect = el.getBoundingClientRect()
@@ -52,7 +52,7 @@ const measure_tooltip = (tooltip_el: Locator): Promise<TooltipMetrics> =>
     }
   })
 
-// Hover until hydration has attached the delegated pointer listeners.
+// retry until hydration has attached the delegated pointer listeners
 const hover_tooltip = async (
   page: Page,
   button_name: string,
@@ -172,9 +172,8 @@ test.describe(`tooltip layout and lifecycle`, () => {
     expect(cross_axis_error).toBeLessThanOrEqual(3)
   })
 
-  // The arrow's absolute insets resolve against the padding box while its geometry is
-  // measured in border-box space, so both axes have to add the surface's border back.
-  // A transparent border still occupies layout, hence the second case.
+  // The arrow's insets resolve against the padding box while its geometry is measured in
+  // border-box space, so both axes must add the border back — transparent ones included.
   for (const border of [`unset`, `4px solid transparent`]) {
     test(`arrow tip clears and centers on the trigger on every side (border: ${border})`, async ({
       page,
@@ -206,8 +205,8 @@ test.describe(`tooltip layout and lifecycle`, () => {
         if (!button_box || !arrow_box || !surface_box) {
           throw new Error(`Missing ${placement} arrow geometry`)
         }
-        // A square rotated 45° has a bounding box centred on its tip, so the box's cross
-        // axis gives the tip's position and its leading edge gives the tip itself.
+        // a square rotated 45° has a bounding box centred on its tip, so the box's cross axis
+        // gives the tip's position and its leading edge the tip itself
         const vertical = placement === `top` || placement === `bottom`
         const cross = (box: typeof arrow_box) =>
           vertical ? box.x + box.width / 2 : box.y + box.height / 2
@@ -215,7 +214,7 @@ test.describe(`tooltip layout and lifecycle`, () => {
           Math.abs(cross(arrow_box) - cross(button_box)),
           `${placement} arrow off the trigger's center`,
         ).toBeLessThanOrEqual(0.5)
-        // The tip stands the default 6px --tooltip-arrow-size clear of the surface.
+        // the tip stands the default 6px --tooltip-arrow-size clear of the surface
         const protrusion = {
           top: arrow_box.y + arrow_box.height - surface_box.y - surface_box.height,
           bottom: surface_box.y - arrow_box.y,
@@ -227,9 +226,8 @@ test.describe(`tooltip layout and lifecycle`, () => {
     })
   }
 
-  // The arrow continues the edge it hangs off, so it copies that side's border and keeps
-  // clear of that side's corners. Every --tooltip-* shorthand sets all four alike, so only
-  // a consumer stylesheet can tell a fixed side apart from the right one.
+  // The arrow copies the border and clears the corners of the side it hangs off. Every
+  // --tooltip-* shorthand sets all four alike, so only a consumer stylesheet can tell them apart.
   test(`the arrow follows the side it hangs off, not the top`, async ({ page }) => {
     const radius = 80
     await page.addStyleTag({
@@ -260,8 +258,8 @@ test.describe(`tooltip layout and lifecycle`, () => {
       arrow_box.x + arrow_box.width / 2 - box.x,
       `tip inside the corner`,
     ).toBeGreaterThanOrEqual(radius)
-    // Still 6px proud. Unlike the colour, this survives reading the wrong border, so it is
-    // the one guard that the arrow's size and its inset come off the SAME side.
+    // still 6px proud: unlike the colour this survives reading the wrong border, so it is the
+    // one guard that the arrow's size and inset come off the SAME side
     expect(arrow_box.y + arrow_box.height - box.y - box.height).toBeCloseTo(6, 0)
   })
 

--- a/tests/playwright/extras.test.ts
+++ b/tests/playwright/extras.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(({ page }) => page.goto(`/extras`, { waitUntil: `networkidle` }))
+
+// CopyButton is white-space: nowrap and ActionButton is width: fit-content, so a card
+// holding a long CamelCase icon name used to outgrow its track and paint over its neighbor.
+test(`icon catalog cards and labels stay inside their grid track`, async ({ page }) => {
+  const demo = page.locator(`#icon-demo`)
+  await demo.getByRole(`searchbox`).fill(`chart`) // ChartBellCurveCumulative et al
+
+  const layout = await demo.locator(`div:has(> button)`).evaluate((grid) => {
+    const grid_right = grid.getBoundingClientRect().right
+    const cards = Array.from(grid.children, (card) => {
+      const box = card.getBoundingClientRect()
+      const label = card.querySelector(`code`)?.getBoundingClientRect()
+      return { name: card.querySelector(`code`)?.textContent ?? ``, box, label }
+    })
+    return {
+      spilling_grid: cards
+        .filter((it) => it.box.right > grid_right + 0.5)
+        .map((it) => it.name),
+      spilling_card: cards
+        .filter((it) => it.label && it.label.right > it.box.right + 0.5)
+        .map((it) => it.name),
+      distinct_widths: new Set(cards.map((it) => Math.round(it.box.width))).size,
+    }
+  })
+
+  expect(layout.spilling_grid).toEqual([])
+  expect(layout.spilling_card).toEqual([])
+  expect(layout.distinct_widths).toBe(1) // fit-content would size each card to its name
+})
+
+test(`copy feedback covers the icon name instead of squeezing it`, async ({ page }) => {
+  const demo = page.locator(`#icon-demo`)
+  await demo.getByRole(`searchbox`).fill(`ChartBellCurveCumulative`)
+  const card = demo.getByRole(`button`).first()
+
+  // the width sizer only overlays the label while the button keeps ActionButton's grid
+  await expect(card).toHaveCSS(`display`, `grid`)
+  const label_width = async () => (await card.locator(`code`).boundingBox())?.width ?? 0
+  const before = await label_width()
+  expect(before).toBeGreaterThan(0)
+
+  await card.click()
+  await expect(card.locator(`small`)).toBeVisible()
+  expect(await label_width()).toBe(before)
+})

--- a/tests/playwright/source-links.test.ts
+++ b/tests/playwright/source-links.test.ts
@@ -18,7 +18,7 @@ test(`inline code mentions of components link to their source, on load and after
   expect(await page.locator(`pre code a`).count()).toBe(0)
   expect(await page.locator(`a code a`).count()).toBe(0)
 
-  // client-side navigation swaps the page inside the same wrapper: new mentions link too
+  // client-side nav swaps the page inside the same wrapper: new mentions link too
   await page.goto(`/popover`)
   await expect(
     page.locator(`code > a[href$="/src/lib/Popover.svelte"]`).first(),

--- a/tests/playwright/toc.test.ts
+++ b/tests/playwright/toc.test.ts
@@ -69,10 +69,18 @@ test(`active ToC row keeps its accent under the pointer`, async ({ page }) => {
 
   const read_color = () => active.evaluate((li) => getComputedStyle(li).color)
   const idle = await read_color()
-  const box = await active.boundingBox()
-  await page.mouse.move((box?.x ?? 0) + 20, (box?.y ?? 0) + (box?.height ?? 0) / 2)
-  expect(await active.evaluate((li) => li.matches(`:hover`))).toBe(true)
-  expect(await read_color()).toBe(idle)
+  const list_color = await page
+    .locator(`aside.toc.mobile > nav > ol`)
+    .evaluate((ol) => getComputedStyle(ol).color)
+  expect(idle, `active row carries no accent to lose`).not.toBe(list_color)
+
+  // hover inside the poll: activeHeading can still move to another row just after the scroll,
+  // which leaves the pointer over the previous one and the locator pointing at a third
+  await expect(async () => {
+    await active.hover()
+    expect(await active.evaluate((li) => li.matches(`:hover`))).toBe(true)
+    expect(await read_color()).toBe(idle)
+  }).toPass()
 })
 
 // on_keydown listens on the window and preventDefaults to drive the ToC's own list, which

--- a/tests/playwright/toc.test.ts
+++ b/tests/playwright/toc.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from '@playwright/test'
 
 test.use({ viewport: { width: 390, height: 780 } })
+test.beforeEach(({ page }) => page.goto(`/extras`, { waitUntil: `networkidle` }))
 
 // The title's rule cancels the panel's inline padding, a custom property that substitutes as
 // text: in `em` it resolved against the h2's larger font-size and overhung the panel.
 test(`mobile ToC title rule spans the panel without overflowing it`, async ({ page }) => {
-  await page.goto(`/extras`, { waitUntil: `networkidle` })
   await page.locator(`aside.toc.mobile > button`).first().click()
   const panel = page.locator(`aside.toc.mobile > nav`).first()
   await expect(panel.locator(`.toc-title`)).toBeVisible()
@@ -37,7 +37,6 @@ test(`mobile ToC title rule spans the panel without overflowing it`, async ({ pa
 // background still swallows the taps aimed at the page under it. The docs site zeroes the
 // token, so set it back to the library default here or the test proves nothing.
 test(`closed mobile toggle hugs its own box`, async ({ page }) => {
-  await page.goto(`/extras`, { waitUntil: `networkidle` })
   await page.evaluate(() =>
     document
       .querySelector<HTMLElement>(`.docs-body`)
@@ -62,7 +61,6 @@ test(`closed mobile toggle hugs its own box`, async ({ page }) => {
 // --toc-li-hover-color makes `color` invalid at computed-value time, which resolves to the
 // inherited text colour instead of dropping out and wipes the accent off that row.
 test(`active ToC row keeps its accent under the pointer`, async ({ page }) => {
-  await page.goto(`/extras`, { waitUntil: `networkidle` })
   await page.locator(`aside.toc.mobile > button`).first().click()
   // scroll rather than click an entry: clicking closes the panel
   await page.evaluate(() => globalThis.scrollTo({ top: 2500, behavior: `instant` }))
@@ -73,15 +71,14 @@ test(`active ToC row keeps its accent under the pointer`, async ({ page }) => {
   const idle = await read_color()
   const box = await active.boundingBox()
   await page.mouse.move((box?.x ?? 0) + 20, (box?.y ?? 0) + (box?.height ?? 0) / 2)
-  await expect(async () => expect(await read_color()).toBe(idle)).toPass()
   expect(await active.evaluate((li) => li.matches(`:hover`))).toBe(true)
+  expect(await read_color()).toBe(idle)
 })
 
 // on_keydown listens on the window and preventDefaults to drive the ToC's own list, which
 // cancelled the activation of whatever else had focus. The toggle is the visible case; every
 // button on the page went dead the same way while the panel was open.
 test(`Enter on the mobile toggle closes the panel`, async ({ page }) => {
-  await page.goto(`/extras`, { waitUntil: `networkidle` })
   const toggle = page.locator(`aside.toc.mobile > button`).first()
   await toggle.click()
   const panel = page.locator(`aside.toc.mobile > nav`)
@@ -99,13 +96,11 @@ test(`Enter on the mobile toggle closes the panel`, async ({ page }) => {
 })
 
 test(`the ToC leaves keys to whatever else has focus`, async ({ page }) => {
-  await page.goto(`/extras`, { waitUntil: `networkidle` })
   await page.locator(`aside.toc.mobile > button`).first().click()
   await expect(page.locator(`aside.toc.mobile > nav`)).toBeVisible()
 
   // a copy button on the page behind the open panel still activates on Enter
   const card = page.locator(`#icon-demo button`).first()
-  await card.scrollIntoViewIfNeeded()
   await card.focus()
   await page.keyboard.press(`Enter`)
   await expect(card.locator(`small`)).toBeVisible() // its copied/failed overlay

--- a/tests/playwright/toc.test.ts
+++ b/tests/playwright/toc.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from '@playwright/test'
+
+test.use({ viewport: { width: 390, height: 780 } })
+
+// The title's rule cancels the panel's inline padding, a custom property that substitutes as
+// text: in `em` it resolved against the h2's larger font-size and overhung the panel.
+test(`mobile ToC title rule spans the panel without overflowing it`, async ({ page }) => {
+  await page.goto(`/extras`, { waitUntil: `networkidle` })
+  await page.locator(`aside.toc.mobile > button`).first().click()
+  const panel = page.locator(`aside.toc.mobile > nav`).first()
+  await expect(panel.locator(`.toc-title`)).toBeVisible()
+
+  const geometry = await panel.evaluate((nav) => {
+    const heading = nav.querySelector(`.toc-title`)
+    const item = nav.querySelector(`ol > li`)
+    if (!heading || !item) throw new Error(`ToC panel is missing its title or entries`)
+    const border = Number(getComputedStyle(nav).borderLeftWidth.replace(`px`, ``))
+    return {
+      overflow: nav.scrollWidth - nav.clientWidth,
+      border,
+      nav: nav.getBoundingClientRect().toJSON(),
+      title: heading.getBoundingClientRect().toJSON(),
+      gap: item.getBoundingClientRect().top - heading.getBoundingClientRect().bottom,
+    }
+  })
+
+  expect(geometry.overflow, `title rule scrolls the panel sideways`).toBe(0)
+  // flush to the panel's padding box: inside its border, but past its inline padding
+  expect(geometry.title.left - geometry.nav.left).toBeCloseTo(geometry.border, 1)
+  expect(geometry.nav.right - geometry.title.right).toBeCloseTo(geometry.border, 1)
+  // the title is a header here, not a paragraph with a desktop-sized gap under it
+  expect(geometry.gap).toBeLessThanOrEqual(10)
+})
+
+// The base rule floors the aside at --toc-min-width (15em by default). A closed toggle then
+// towed a transparent 15em box around the corner of the screen, and a fixed box with no
+// background still swallows the taps aimed at the page under it. The docs site zeroes the
+// token, so set it back to the library default here or the test proves nothing.
+test(`closed mobile toggle hugs its own box`, async ({ page }) => {
+  await page.goto(`/extras`, { waitUntil: `networkidle` })
+  await page.evaluate(() =>
+    document
+      .querySelector<HTMLElement>(`.docs-body`)
+      ?.style.setProperty(`--toc-min-width`, `15em`),
+  )
+  const aside = page.locator(`aside.toc.mobile`).first()
+
+  const corner = await aside.evaluate((node) => {
+    const box = node.getBoundingClientRect()
+    const button = node.querySelector(`button`)?.getBoundingClientRect()
+    if (!button) throw new Error(`mobile ToC has no toggle`)
+    // just inside the aside's left edge, level with the middle of the toggle
+    const hit = document.elementFromPoint(box.left + 2, button.top + button.height / 2)
+    return { slack: box.width - button.width, hit_is_toc: node.contains(hit) }
+  })
+
+  expect(corner.slack, `dead strip beside the toggle`).toBeLessThanOrEqual(1)
+  expect(corner.hit_is_toc).toBe(true) // the only pixels the aside claims are the toggle's own
+})
+
+// li:hover sits after li.active so the active row still lights up, but an unset
+// --toc-li-hover-color makes `color` invalid at computed-value time, which resolves to the
+// inherited text colour instead of dropping out and wipes the accent off that row.
+test(`active ToC row keeps its accent under the pointer`, async ({ page }) => {
+  await page.goto(`/extras`, { waitUntil: `networkidle` })
+  await page.locator(`aside.toc.mobile > button`).first().click()
+  // scroll rather than click an entry: clicking closes the panel
+  await page.evaluate(() => globalThis.scrollTo({ top: 2500, behavior: `instant` }))
+  const active = page.locator(`aside.toc.mobile > nav > ol > li.active`).first()
+  await expect(active).toBeVisible()
+
+  const read_color = () => active.evaluate((li) => getComputedStyle(li).color)
+  const idle = await read_color()
+  const box = await active.boundingBox()
+  await page.mouse.move((box?.x ?? 0) + 20, (box?.y ?? 0) + (box?.height ?? 0) / 2)
+  await expect(async () => expect(await read_color()).toBe(idle)).toPass()
+  expect(await active.evaluate((li) => li.matches(`:hover`))).toBe(true)
+})
+
+// on_keydown listens on the window and preventDefaults to drive the ToC's own list, which
+// cancelled the activation of whatever else had focus. The toggle is the visible case; every
+// button on the page went dead the same way while the panel was open.
+test(`Enter on the mobile toggle closes the panel`, async ({ page }) => {
+  await page.goto(`/extras`, { waitUntil: `networkidle` })
+  const toggle = page.locator(`aside.toc.mobile > button`).first()
+  await toggle.click()
+  const panel = page.locator(`aside.toc.mobile > nav`)
+  await expect(panel).toBeVisible()
+
+  await toggle.focus()
+  await page.keyboard.press(`Enter`)
+  await expect(panel).toHaveCount(0)
+  expect(await page.evaluate(() => globalThis.scrollY)).toBe(0) // no heading was activated
+
+  await page.keyboard.press(`Enter`) // and it reopens, rather than only closing
+  await expect(panel).toBeVisible()
+  await page.keyboard.press(`Escape`) // Escape still reaches the window handler
+  await expect(panel).toHaveCount(0)
+})
+
+test(`the ToC leaves keys to whatever else has focus`, async ({ page }) => {
+  await page.goto(`/extras`, { waitUntil: `networkidle` })
+  await page.locator(`aside.toc.mobile > button`).first().click()
+  await expect(page.locator(`aside.toc.mobile > nav`)).toBeVisible()
+
+  // a copy button on the page behind the open panel still activates on Enter
+  const card = page.locator(`#icon-demo button`).first()
+  await card.scrollIntoViewIfNeeded()
+  await card.focus()
+  await page.keyboard.press(`Enter`)
+  await expect(card.locator(`small`)).toBeVisible() // its copied/failed overlay
+
+  // and arrow keys still move the caret in a text field rather than the ToC's selection
+  const search = page.locator(`#icon-demo input[type=search]`)
+  await search.fill(`chart`)
+  await page.keyboard.press(`ArrowUp`)
+  const caret = await search.evaluate((node: HTMLInputElement) => node.selectionStart)
+  expect(caret).toBe(0) // ArrowUp in a single-line input jumps to the start
+})

--- a/tests/vitest/ActionMenu.svelte.test.ts
+++ b/tests/vitest/ActionMenu.svelte.test.ts
@@ -16,8 +16,7 @@ describe(`ActionMenu`, () => {
     { label: `Copy`, action: vi.fn(), shortcut: `mod+c` },
     { label: `Delete`, action: vi.fn(), disabled: true },
   ]
-  // svelte:body listeners outlive document.body.innerHTML = '', so unmount for real
-  // or a previous test's menu keeps answering right-clicks
+  // svelte:body listeners outlive innerHTML = '', so unmount or old menus keep answering
   const mounted: Record<string, unknown>[] = []
   afterEach(() => mounted.splice(0).forEach((app) => void unmount(app)))
   // returns the reactive props, so a test can drive `at` the way a consumer would
@@ -42,7 +41,7 @@ describe(`ActionMenu`, () => {
     })
     await tick()
   }
-  // mounts a menu and right-clicks the page to open it, returning the contextmenu event
+  // opens a menu by right-clicking the page, returning the contextmenu event
   const open_menu = async (
     actions: MenuEntries = make_actions(),
     extra: MenuProps = {},
@@ -86,8 +85,7 @@ describe(`ActionMenu`, () => {
       `Actions`,
       -1,
     ])
-    // .action-menu comes after the {...rest} spread, so a consumer class adds to the
-    // styling hook instead of replacing it
+    // .action-menu comes after {...rest}, so a consumer class adds instead of replacing
     expect(surface.classList.contains(`action-menu`)).toBe(true)
     expect(surface.classList.contains(`consumer-class`)).toBe(true)
   })
@@ -97,8 +95,7 @@ describe(`ActionMenu`, () => {
     expect(doc_query<HTMLMenuElement>(`menu[role="menu"]`).tabIndex).toBe(0)
   })
 
-  // with a region, svelte:body's handler is dropped, so the rest of the page keeps
-  // the browser's own menu
+  // with a region, svelte:body's handler is dropped: the page keeps its native menu
   test(`a children region scopes the right-click to itself`, async () => {
     mount_menu(make_actions(), { children: region })
 
@@ -112,8 +109,7 @@ describe(`ActionMenu`, () => {
     expect(menu()).not.toBeNull()
   })
 
-  // for a consumer whose triggers must record *which* of their targets was
-  // right-clicked: neither the document nor a wrapper can, so it drives `at` itself
+  // for consumers that must record which target was right-clicked and drive `at` themselves
   test.each([
     [`no region`, {}, () => document.body],
     [`a region`, { children: region }, () => doc_query(`[data-testid="region"]`)],
@@ -181,8 +177,8 @@ describe(`ActionMenu`, () => {
     expect(document.activeElement).toBe(trigger)
   })
 
-  // reachable by clicking menu chrome rather than an item: focus leaves the list, and
-  // every key used to enter at the first item regardless of which end it pointed at
+  // clicking menu chrome takes focus out of the list, where every key used to enter at
+  // the first item regardless of which end it pointed at
   test.each([
     [`End`, 2],
     [`ArrowUp`, 2],
@@ -224,8 +220,8 @@ describe(`ActionMenu`, () => {
     expect(menu()).toBeNull()
   })
 
-  // Custom dismissal can opt into press timing or leave Escape to the page. Native
-  // light-dismiss is exercised in Playwright rather than emulated in happy-dom.
+  // custom dismissal can opt into press timing or leave Escape to the page; native
+  // light-dismiss is covered in Playwright rather than emulated in happy-dom
   const outside_press = () => new PointerEvent(`pointerdown`, { bubbles: true })
   const outside_click = () => new MouseEvent(`click`, { bubbles: true })
   const release: MenuProps = { dismiss: { dismiss_on: `release`, escape: false } }
@@ -279,8 +275,8 @@ describe(`ActionMenu`, () => {
       { title: `Other`, actions: [{ label: `Reset`, action: vi.fn() }] },
     ]
 
-    // Unique ids stay stable across reorder; duplicate tags append position so
-    // they cannot each_key_duplicate.
+    // unique ids stay stable across reorder; duplicates append position to avoid
+    // each_key_duplicate
     test(`ids, labels, and duplicates stay distinct keys`, async () => {
       await open_menu([
         { id: 1, label: `Numeric id`, action: vi.fn() },
@@ -321,8 +317,8 @@ describe(`ActionMenu`, () => {
       expect(items()).toEqual([second, first])
     })
 
-    // A section has no id, so its title is a heading rather than an identity. Keyed on
-    // title alone these two collided, and each_key_duplicate took down the whole menu.
+    // a section title is a heading, not an identity: keyed on title alone these collided
+    // and each_key_duplicate took down the whole menu
     test(`two sections may share a title`, async () => {
       await open_menu([
         { title: `Tools`, actions: [{ label: `First`, action: vi.fn() }] },
@@ -440,8 +436,7 @@ describe(`ActionMenu`, () => {
       expect(document.querySelector(`kbd`)).toBeNull() // default shortcut markup is gone
     })
 
-    // CmdAction allows arbitrary extra keys, so one carrying `actions` or `title` must
-    // not be mistaken for a section
+    // CmdAction allows extra keys, so `actions`/`title` must not make one read as a section
     test(`a flat action with section-shaped extras stays flat`, async () => {
       await open_menu([
         { label: `Copy`, action: vi.fn(), actions: [`audit`], title: `tooltip` },

--- a/tests/vitest/ButtonGroup.test.ts
+++ b/tests/vitest/ButtonGroup.test.ts
@@ -8,8 +8,8 @@ import { doc_query, hover as dispatch_hover } from './index'
 
 describe(`ButtonGroup`, () => {
   type Props = Partial<ComponentProps<typeof ButtonGroup>>
-  // the option object arm of the `options` union, i.e. ButtonGroupOption. Spelled out
-  // rather than imported: only svelte-check reads types out of a .svelte module script
+  // ButtonGroupOption, spelled out rather than imported: only svelte-check reads types
+  // out of a .svelte module script
   type Option = {
     value: string
     label?: string
@@ -44,9 +44,8 @@ describe(`ButtonGroup`, () => {
     )
 
   const letters = { alpha: `Alpha`, beta: `Beta`, gamma: `Gamma` }
-  // happy-dom drops nested CSS rules, so the mounted stylesheet reports `.button-group
-  // {}` as empty and computed styles say nothing. The styling assertions below read the
-  // source instead; the values they produce were checked in a real browser.
+  // happy-dom drops nested CSS rules, so computed styles say nothing; the styling
+  // assertions read the source instead (values verified in a real browser).
   const styles = button_group_source.slice(button_group_source.indexOf(`<style>`))
   // an info link, the affordance matbench-discovery had nested inside its buttons
   const remove_button = createRawSnippet<[{ option: { value: string } }]>(
@@ -103,8 +102,7 @@ describe(`ButtonGroup`, () => {
       null,
       `aria-pressed`,
       `aria-checked`,
-      // `selected` is bindable and reassigned by the component, so it must stay mutable
-      // even though `as const` freezes the rest of the row
+      // `selected` is bindable and reassigned, so it must stay mutable under `as const`
       { multiple: true, selected: [`beta`] as string[] },
     ],
   ] as const)(
@@ -260,7 +258,7 @@ describe(`ButtonGroup`, () => {
   })
 
   // multi select is a plain group, not a radiogroup, so it keeps every native tab stop
-  // rather than roving a single one. Joined so a row is one line: `` is an absent attr.
+  // instead of roving one. Expectations are joined; `` means the attribute is absent.
   test.each([
     [`the checked option`, { selected: `gamma` }, `-1,-1,0`],
     [`the first option when nothing is selected`, {}, `0,-1,-1`],
@@ -296,9 +294,8 @@ describe(`ButtonGroup`, () => {
     })
 
     const arrow = doc_query<HTMLButtonElement>(`.sort-order`)
-    // the label states the direction and what activating does. No aria-pressed: APG is
-    // explicit that a toggle's label must not change with its state, and this one does,
-    // so "Sorted ascending, not pressed" would read as the sort not being applied
+    // no aria-pressed: APG forbids a toggle label that changes with state, and this one
+    // does, so "Sorted ascending, not pressed" would read as the sort not being applied
     const arrow_state = () => [
       arrow.textContent?.trim(),
       arrow.getAttribute(`aria-label`),
@@ -334,8 +331,8 @@ describe(`ButtonGroup`, () => {
 
     expect(buttons[0].querySelector(`svg`)).not.toBeNull()
     expect(buttons[1].querySelector(`svg`)).toBeNull()
-    // Loading-capable options keep the spinner's width reserved while it is hidden. The
-    // spinner itself is decoration either way — `aria-busy` is what carries the state.
+    // loading-capable options reserve the spinner's width while hidden; the spinner is
+    // decoration, `aria-busy` carries the state
     expect(buttons[1].querySelector(`div`)?.style.width).toBe(`0.8em`)
     expect(buttons[1].querySelector(`div`)?.style.visibility).toBe(`visible`)
     expect(buttons[2].querySelector(`div`)?.style.visibility).toBe(`hidden`)
@@ -356,8 +353,7 @@ describe(`ButtonGroup`, () => {
   })
 
   test(`an option snippet replaces the default button content`, () => {
-    // wider than the component's own param type, which is how a snippet stays
-    // assignable to it (parameters are contravariant)
+    // wider than the component's param type: parameters are contravariant
     const option = createRawSnippet<[{ option: { label?: string }; selected: boolean }]>(
       (get_params) => ({
         render: () => {
@@ -375,9 +371,8 @@ describe(`ButtonGroup`, () => {
     ])
   })
 
-  // Escaping is the default because tooltip content is often user data; `tooltip_options`
-  // is the opt out, and without that pass-through no consumer with rich tooltips can
-  // migrate. Each row also pins that an option carrying no tooltip stays silent.
+  // tooltip content is often user data, so escaping is the default and `tooltip_options`
+  // the opt out; each row also pins that an option without a tooltip stays silent
   test.each([
     [`escapes markup by default`, undefined, `&lt;b&gt;bold&lt;/b&gt;`],
     [`renders it under allow_html`, { allow_html: true }, `<b>bold</b>`],
@@ -400,8 +395,8 @@ describe(`ButtonGroup`, () => {
     }
   })
 
-  // `as` exists so a group can sit in a heading or paragraph, where a div is invalid.
-  // The inner options wrapper has to follow, or the root is legal and its child isn't.
+  // `as` lets a group sit in a heading or paragraph where a div is invalid; the inner
+  // options wrapper must follow, or the root is legal and its child isn't
   test.each([
     [`div`, undefined],
     [`span`, `span` as const],
@@ -412,23 +407,19 @@ describe(`ButtonGroup`, () => {
     expect(doc_query(`.options`).tagName.toLowerCase()).toBe(`span`)
   })
 
-  // The `font` shorthand would also set weight and style, and since `.button-group
-  // button` outranks a consumer's own `button {}` rule it silently overrode their
-  // global button typography.
+  // the `font` shorthand also sets weight and style, and `.button-group button` outranks
+  // a consumer's own `button {}` rule, so it silently overrode their global typography
   test(`leaves font-weight and font-style to the consumer`, () => {
     expect(styles).toMatch(/font-family:\s*var\(--btn-group-btn-font-family/u)
-    // any `font:` shorthand, not just `font: inherit` — `font: var(--x, inherit)` sets
-    // weight and style just the same, and is the form a reintroduction would take
+    // any `font:` shorthand, since `font: var(--x, inherit)` sets weight and style too
     expect(styles).not.toMatch(/[^-]font:/u)
-    // a hook for either would have to be a declaration on the button, which is what
-    // reintroduces the override, so neither property is set anywhere
+    // a var hook would itself be a declaration on the button, reintroducing the override
     expect(styles).not.toMatch(/font-(?:weight|style):/u)
   })
 
-  // matbench-discovery's SelectToggle put an info link inside the button, which is an
-  // invalid content model. The `option` snippet renders inside the button and so cannot
-  // fix it; this one is a sibling, which is the whole point.
-  // Opt-in: wrappers break consumers' `.segmented > button` selectors.
+  // matbench-discovery's SelectToggle nested an info link inside the button (invalid
+  // content model); `option` renders inside the button, `option_suffix` is a sibling.
+  // Opt-in because wrappers break consumers' `.segmented > button` selectors.
   test.each([
     [`options`, `nothing is slotted`, undefined, 0],
     [`option`, `a suffix is slotted`, info_link, 3],
@@ -455,10 +446,9 @@ describe(`ButtonGroup`, () => {
     ).toEqual([`/docs/alpha:false`, `/docs/beta:true`, `/docs/gamma:false`])
   })
 
-  // A suffix rendering its own button is the second reason this prop exists, and it is
-  // what makes handle_keydown's query ambiguous: a bare `button` selector collects the
-  // suffixes too, so focus lands on one while the selection jumps an option ahead. An
-  // `<a>` suffix cannot catch that, since the selector never matched it either way.
+  // a suffix that renders its own button makes handle_keydown's query ambiguous: a bare
+  // `button` selector collects suffixes too, so focus lands on one while the selection
+  // jumps an option ahead. An `<a>` suffix can't catch that, the selector never matched it.
   test.each([
     [`a link`, info_link],
     [`a button`, remove_button],
@@ -503,9 +493,8 @@ describe(`ButtonGroup`, () => {
     expect(arrow.getAttribute(`aria-label`)).toBe(`Absteigend sortiert`)
   })
 
-  // The whole themable surface, not a handful of existence rows: this way a rename, a
-  // deletion and an undocumented new knob all fail. `justify-content`, `btn-cursor`,
-  // `btn-hover-transform` and `btn-transition` are here because each was a `:global`
+  // exhaustive so a rename, deletion or undocumented new knob all fail. `justify-content`,
+  // `btn-cursor`, `btn-hover-transform` and `btn-transition` each replaced a `:global`
   // escape hatch a downstream repo needed.
   test(`exposes exactly the documented custom properties`, () => {
     const matches = styles.matchAll(/var\(\s*--btn-group-(?<name>[\w-]+)/gu)

--- a/tests/vitest/CommandMenu.svelte.test.ts
+++ b/tests/vitest/CommandMenu.svelte.test.ts
@@ -11,9 +11,8 @@ const mock_actions = [
 
 const menu_input = () => doc_query<HTMLInputElement>(`dialog input[autocomplete]`)
 
-// Fades are off unless a test is about them, so the dialog opens and closes synchronously.
-// Filled in on the caller's own object rather than a merged copy: several tests mount a
-// $state proxy and then mutate it, and spreading into a fresh object would sever that.
+// fades off unless a test is about them, so the dialog opens and closes synchronously.
+// Set on the caller's object: tests mutate the mounted $state proxy, which copying severs
 const mount_menu = (props: ComponentProps<typeof CommandMenu>) => {
   props.fade_duration_ms ??= 0
   return mount(CommandMenu, { target: document.body, props })
@@ -264,7 +263,6 @@ test(`handles action selection and execution`, async () => {
 
   const input_el = menu_input()
 
-  // Navigate to second action and select it
   input_el.dispatchEvent(
     new KeyboardEvent(`keydown`, { key: `ArrowDown`, bubbles: true }),
   )
@@ -300,8 +298,7 @@ test(`ignores user-created options without action handlers`, async () => {
   expect(props.open).toBe(true)
 })
 
-// open=false must call dialog.close() before `{#if open}` unmounts, including while
-// an outro keeps the closed element mounted.
+// open=false must call dialog.close() before `{#if open}` unmounts, outro included
 test.each([0, 50])(
   `controlled close fires native onclose once (fade_duration_ms=%i)`,
   async (fade_duration_ms) => {
@@ -452,7 +449,6 @@ test(`remains open when trigger keys are pressed while already open`, async () =
 
   expect(props.open).toBe(true)
 
-  // Trigger key should not change state when already open
   globalThis.dispatchEvent(new KeyboardEvent(`keydown`, { key: `k`, metaKey: true }))
   await tick()
 
@@ -1273,9 +1269,9 @@ test(`global shortcuts ignore events consumed by editable controls`, () => {
   expect(action).not.toHaveBeenCalled()
 })
 
-// Shift counts as typing, not as a chord, so neither may run nor steal the keystroke
-// inside an editable target. The plain div keeps the guard honest: without it,
-// suppressing these shortcuts everywhere would still pass.
+// Shift counts as typing, not a chord, so neither may run or steal a keystroke inside an
+// editable target. The plain div keeps the guard honest: suppressing them everywhere
+// would otherwise pass too.
 test.each([`n`, `shift+n`])(
   `global shortcut %s fires only outside editable targets`,
   (shortcut) => {
@@ -1354,7 +1350,7 @@ test(`recent_actions_key ranks, persists, and reloads recently triggered actions
   await tick()
 
   expect(actions[2].action).toHaveBeenCalledExactlyOnceWith(`gamma`)
-  expect(props.open).toBe(false) // menu closed after trigger
+  expect(props.open).toBe(false)
   expect(JSON.parse(localStorage.getItem(storage_key) ?? `[]`)).toEqual([`gamma`])
 
   // reopen: gamma now ranks first, rest keep original order
@@ -1403,8 +1399,8 @@ test.each([
     [`beta`, `alpha`, `gamma`],
     1,
   ],
-  // stale persisted ids (actions since removed/renamed) must not occupy low ranks,
-  // else a real recent (rank 4 here) sorts after non-recents (default rank 3)
+  // stale persisted ids must not occupy low ranks, else a real recent (rank 4 here)
+  // sorts after non-recents (default rank 3)
   [
     `stale ids are ignored so real recents still rank first`,
     JSON.stringify([`removed-1`, `removed-2`, `removed-3`, `removed-4`, `gamma`]),
@@ -1442,8 +1438,8 @@ test.each([
   },
 )
 
-// global shortcut presses (while closed) persist the triggered action to recents
-// (that the action also fires is covered by `global action shortcuts: fires when closed`)
+// a global shortcut press while closed must persist the action to recents (that it fires
+// is covered by `global action shortcuts: fires when closed`)
 test.each([
   {
     desc: `records the triggered action`,

--- a/tests/vitest/ConfirmDialog.svelte.test.ts
+++ b/tests/vitest/ConfirmDialog.svelte.test.ts
@@ -6,11 +6,9 @@ import { render } from 'svelte/server'
 import { afterEach, expect, test, vi } from 'vite-plus/test'
 import { create_element, doc_query, track } from './index'
 
-// happy-dom implements <dialog>: showModal(), .open, close() and the close event all
-// behave, so nothing about the dialog is stubbed here. What it does not implement is
-// Escape closing a modal dialog or a real ::backdrop, so those paths are driven the way
-// the browser drives them: Escape by close(), a backdrop press by a click whose target
-// is the dialog element itself.
+// happy-dom implements <dialog> (showModal, .open, close, close event) but not Escape
+// closing a modal nor a real ::backdrop, so those two are driven as the browser does:
+// close() for Escape, a click targeting the dialog element itself for the backdrop
 
 const mounted: Record<string, unknown>[] = []
 afterEach(async () => {
@@ -194,8 +192,8 @@ test(`dismissing a prompt returns null`, async () => {
   expect([answer.settled, answer.value]).toEqual([true, null])
 })
 
-// The reason the queue exists. Two prompts racing in one modal would leave the second
-// answered by a click meant for the first, and a double-click is how that happens.
+// why the queue exists: a double-click's second half would otherwise answer the prompt
+// that replaced the first
 test(`one click cannot answer two racing requests`, async () => {
   const dialog = await mount_dialog()
   const first = ask(`Delete node_modules?`, `First`)
@@ -211,9 +209,8 @@ test(`one click cannot answer two racing requests`, async () => {
   expect(second.settled).toBe(false)
   expect(doc_query(`dialog h2`).textContent).toBe(`Second`) // dialog stayed up
 
-  // The second question offers the same choice ids, so without the {#key request} block
-  // Svelte reuses these DOM nodes and the second half of a double-click lands on the
-  // button that now answers a question nobody read.
+  // the second question reuses the same choice ids, so without {#key request} Svelte
+  // keep these DOM nodes and the stale click would answer a question nobody read
   const fresh_write_button = buttons()[1]
   expect(fresh_write_button).not.toBe(stale_write_button)
   expect(stale_write_button.isConnected).toBe(false)
@@ -229,8 +226,7 @@ test(`one click cannot answer two racing requests`, async () => {
   expect(dialog.open).toBe(false)
 })
 
-// Dismissing is not consent: both paths have to answer with dismiss_id, never with the
-// accented choice a stray key would otherwise reach.
+// dismissing is not consent: both paths must answer dismiss_id, never the accented choice
 test.each([
   [`Escape`, (dialog: HTMLDialogElement) => dialog.close()],
   [`a backdrop click`, press_backdrop],
@@ -246,8 +242,8 @@ test.each([
   expect(dialog.open).toBe(false)
 })
 
-// Answering removes the button that had focus. Without a hand-off the next question
-// comes up with the keyboard on <body>, outside the trap.
+// answering removes the focused button, so without a hand-off the next question comes up
+// with the keyboard on <body>, outside the trap
 test(`focus enters each question and returns to the opener`, async () => {
   const trigger = create_element(`button`)
   const dialog = await mount_dialog()

--- a/tests/vitest/CopyButton.test.ts
+++ b/tests/vitest/CopyButton.test.ts
@@ -66,8 +66,7 @@ const mount_global = async (props: Partial<ComponentProps<typeof CopyButton>>) =
   return component
 }
 
-// The initial scan is synchronous, but later ones ride the MutationObserver, which
-// coalesces them into one animation frame instead of rescanning on every render flush.
+// only the initial scan is sync; later ones ride the MutationObserver, coalesced per frame
 const flush_rescan = async () => {
   await tick()
   await new Promise(requestAnimationFrame)
@@ -261,13 +260,12 @@ test(`unmount clears outstanding reset timer`, async () => {
   const reset_timer_id = set_timeout_spy.mock.results[reset_idx].value
 
   void unmount(copy_button_component)
-  // that exact timer, not merely some clearTimeout call. toContain compares by
-  // identity; toHaveBeenCalledWith's deep equality matches any Timeout object
+  // identity match: toHaveBeenCalledWith's deep equality would accept any Timeout object
   expect(clear_timeout_spy.mock.calls.map((call) => call[0])).toContain(reset_timer_id)
 })
 
-// two-way binding tests: this file isn't compiled by the Svelte plugin so $state is
-// unavailable - a getter/setter pair backed by fromStore mimics a parent bind:state
+// $state is unavailable here (file isn't Svelte-compiled), so a fromStore getter/setter
+// pair stands in for a parent's bind:state
 type CopyState = `ready` | `success` | `error`
 
 const mount_bound_copy_button = () => {
@@ -303,7 +301,7 @@ test.each([
 
     const { copy_button, state_store } = mount_bound_copy_button()
     await click_copy_button(copy_button)
-    expect(get(state_store)).toBe(expected_state) // internal change reached the binding
+    expect(get(state_store)).toBe(expected_state)
     expect(icon_path(copy_button)).toBe(icon.d)
 
     // external write back to idle flows into the component and restores the Copy icon
@@ -489,8 +487,7 @@ test(`global mode as=a does not remount when the observer re-enters`, async () =
   void unmount(component)
 })
 
-// CopyButton was the one wired component whose defaults lived in a local const, so callers
-// could not import its record or derive its type the way the others allow.
+// these defaults used to live in a local const callers could neither import nor type off
 test(`COPY_BUTTON_LABELS is the exported default record, and partials merge over it`, () => {
   expect(COPY_BUTTON_LABELS).toEqual({ ready: ``, success: ``, error: `` })
 

--- a/tests/vitest/DemoNav.test.ts
+++ b/tests/vitest/DemoNav.test.ts
@@ -1,4 +1,3 @@
-// Test that DemoNav stays in sync with actual demo pages
 import { DemoNav } from '$site'
 import { mount } from 'svelte'
 import { expect, test, vi } from 'vite-plus/test'
@@ -13,7 +12,7 @@ vi.mock(`$app/state`, () => ({ page: { url: { pathname: `/docs/` } } }))
 test(`DemoNav contains all base-prefixed demo pages`, () => {
   mount(DemoNav, { target: document.body })
 
-  // Extract all hrefs from the rendered nav (excluding group headers like #basics)
+  // group headers like #basics are anchors, not pages
   const hrefs = Array.from(document.querySelectorAll(`nav a`)).flatMap((link) => {
     const href = link.getAttribute(`href`)
     return href && !href.startsWith(`#`) ? [href] : []
@@ -26,9 +25,8 @@ test(`DemoNav contains all base-prefixed demo pages`, () => {
   )
   expect(new Set(hrefs)).toEqual(new Set(expected))
 
-  // Nav resolves custom labels from route.label for top-level items but from the href for
-  // dropdown children, so a group label taken from the wrong source silently regresses to
-  // slug casing (`Multiselect`, `Command Menu`)
+  // Nav takes labels from route.label for top-level items but from the href for dropdown
+  // children, so the wrong source silently regresses to slug casing (`Multiselect`)
   const link_text = new Set(
     Array.from(document.querySelectorAll(`nav a`), (link) => link.textContent?.trim()),
   )

--- a/tests/vitest/DraggablePane.test.ts
+++ b/tests/vitest/DraggablePane.test.ts
@@ -18,8 +18,7 @@ const mock_pane_rect = (pane: HTMLElement, left = 0, top = 0) =>
   mock_rect(pane, { left, top, width: 450, height: 300 })
 
 describe(`DraggablePane`, () => {
-  // click_outside registers document listeners that outlive innerHTML = '', and
-  // stubbed globals must not leak into the next case
+  // click_outside registers document listeners that outlive innerHTML = ''
   const mounted: Record<string, unknown>[] = []
   const cleanups: (() => void)[] = []
   afterEach(() => {
@@ -28,8 +27,8 @@ describe(`DraggablePane`, () => {
     vi.useRealTimers()
   })
 
-  // raw snippets render once, so this captures the payload rather than tracking it;
-  // the reactive half of the pane state is asserted through the DOM below
+  // raw snippets render once, so this captures the payload; the reactive half is
+  // asserted through the DOM below
   let last_pane_state: Record<string, unknown> = {}
   const children = createRawSnippet<[Record<string, unknown>]>((state) => ({
     render: () => {
@@ -45,13 +44,12 @@ describe(`DraggablePane`, () => {
     )
     await tick()
     const pane = doc_query<HTMLDivElement>(`.draggable-pane`)
-    // happy-dom does not apply the component stylesheet; mirror its border-box rule so
-    // resizable's box-model conversion matches the browser.
+    // happy-dom skips the component stylesheet; mirror border-box so resizable's
+    // box-model conversion matches the browser
     pane.style.boxSizing = `border-box`
     return {
       toggle: doc_query<HTMLButtonElement>(`button.pane-toggle`),
-      // by class, not [role="dialog"]: the role is itself under test, and finding the
-      // pane by it would make those assertions tautological
+      // by class, not [role="dialog"]: the role is itself under test
       pane,
     }
   }
@@ -82,12 +80,11 @@ describe(`DraggablePane`, () => {
   // pointer_event sets isPrimary; a bare PointerEvent reads as a second finger
   const press = (target: EventTarget) =>
     target.dispatchEvent(pointer_event(`pointerdown`, 0, 0))
-  // The pane dismisses on release, so a gesture meant to dismiss needs both halves.
-  // Kept apart from `press` because a lone pointerdown is what several tests assert on.
+  // dismissal happens on release, so a dismissing gesture needs both halves; kept apart
+  // from `press` because several tests assert on a lone pointerdown
   const press_release = (target: EventTarget) => {
     press(target)
-    // detail: 1 is a real pointer click; 0 is keyboard/programmatic and skips the
-    // press-started-inside exemption
+    // detail: 1 is a real pointer click; 0 skips the press-started-inside exemption
     return target.dispatchEvent(new MouseEvent(`click`, { bubbles: true, detail: 1 }))
   }
   const release_pointer = () =>
@@ -98,8 +95,7 @@ describe(`DraggablePane`, () => {
   const escape = () => document.dispatchEvent(escape_key())
   const is_open = (pane: HTMLElement) => pane.style.display === `grid`
 
-  // the press-move-release both attachments listen for, on the pane (resize) or on
-  // its handle (drag)
+  // the press-move-release both attachments listen for: the pane (resize) or handle (drag)
   const drag = (
     target: EventTarget,
     [start_x, start_y]: readonly number[],
@@ -111,8 +107,8 @@ describe(`DraggablePane`, () => {
   }
   const drag_by = (dx: number, dy: number) =>
     drag(doc_query(`.drag-handle`), [0, 0], [dx, dy])
-  // resizable hit-tests nothing itself: each edge gets a strip, and pressing one is the
-  // only way in. happy-dom paints nothing, so the corner's precedence lives in playwright.
+  // resizable hit-tests nothing: pressing an edge strip is the only way in. happy-dom
+  // paints nothing, so the corner's precedence is covered in playwright.
   const handle_of = (pane: HTMLElement, attribute: string, value: string) => {
     const handle = pane.querySelector<HTMLElement>(`[${attribute}="${value}"]`)
     if (!handle) throw new Error(`pane has no ${value} ${attribute}`)
@@ -173,10 +169,8 @@ describe(`DraggablePane`, () => {
     }
   }
 
-  // The main reason for the `release` default. Dismissing on the press lets Svelte's flush
-  // write checked=false to the DOM before the click, whose pre-click activation flips it back
-  // for the bind to commit — reopening the pane, leaving it uncloseable from that checkbox.
-  // On the click, dismissal lands after that activation instead.
+  // why `release` is the default: dismissing on the press writes checked=false before the
+  // click, whose activation flips it back and reopens the pane, uncloseable from that checkbox
   test.each([
     [`press`, true, `press`],
     [`release`, false, `release`],
@@ -224,7 +218,7 @@ describe(`DraggablePane`, () => {
     },
   )
 
-  // and the fix for it, when the trigger is one the consumer holds a reference to
+  // `inside` spares a consumer-held trigger from both its press and its click
   test.each([`press`, `release`] as const)(
     `inside spares an outside control's press and click, dismiss_on=%s`,
     async (dismiss_on) => {
@@ -304,9 +298,8 @@ describe(`DraggablePane`, () => {
     expect(pane.style.getPropertyValue(`--pane-viewport-clamp`)).toBe(clamp)
   })
 
-  // Stubbed on the pane, not the toggle: the pane's own containing block is what its
-  // left/top resolve against, and the two only coincide while nothing repositions the
-  // toggle out of it.
+  // stubbed on the pane, not the toggle: left/top resolve against the pane's own
+  // containing block, and the two only coincide while nothing repositions the toggle
   test(`absolute positioning measures against the pane's offsetParent`, async () => {
     const ancestor = document.createElement(`div`)
     document.body.append(ancestor)
@@ -524,9 +517,8 @@ describe(`DraggablePane`, () => {
     drag(corner_of(pane), [550, 350], [900, 900])
     await tick()
 
-    // Width is capped so 8px on the far edge stays visible: 700 - left 100 - margin 8 = 592.
-    // Height takes the full drag: it is already bounded by the CSS `max-height`, and a second
-    // JS cap there only fought the gesture (it could even shrink a pane being dragged larger).
+    // width caps at 700 - left 100 - margin 8 = 592 so the far edge stays visible; height
+    // takes the full drag, since CSS `max-height` bounds it and a JS cap fought the gesture
     expect(pane.style.width).toBe(`592px`)
     expect(pane.style.height).toBe(`850px`)
     expect(pane.style.maxWidth).toBe(`calc(100vw - 16px)`)
@@ -581,9 +573,8 @@ describe(`DraggablePane`, () => {
     release_pointer()
   })
 
-  // The pane dismisses on the click, which browsers (and Playwright) synthesize even after
-  // a resize that ends outside it — click_outside exempts it because the pointerdown was
-  // inside, so matterviz's 200 ms post-resize guard is unnecessary here.
+  // browsers synthesize a click even after a resize ending outside the pane; click_outside
+  // exempts it because the pointerdown was inside, so no post-resize guard is needed
   test(`a resize released outside the pane does not dismiss it`, async () => {
     const on_close = vi.fn()
     const { pane } = await open_pane({ resize: `both`, on_close })
@@ -651,27 +642,23 @@ describe(`DraggablePane`, () => {
       'aria-label': `Structure controls`,
     }
     const toggle_props = { class: `consumer-toggle`, title: `Options`, onclick }
-    // Omit'd from the prop types; set reflectively to prove the runtime ordering holds
-    // for JS consumers too
+    // Omit'd from the prop types; set reflectively to cover untyped JS consumers
     Reflect.set(pane_props, `role`, `region`)
     Reflect.set(pane_props, `aria-modal`, `true`)
     Reflect.set(toggle_props, `type`, `submit`)
     const { toggle, pane } = await setup({ pane_props, toggle_props })
 
     expect(pane.id).toBe(`my-pane`)
-    // role, aria-modal, data-resize and type sit after the spread, so a consumer cannot
-    // clobber them: a `region` pane loses its dialog semantics, an `aria-modal` one traps
-    // screen readers inside non-modal chrome, a `submit` toggle posts the form
+    // role, aria-modal, data-resize and type sit after the spread so a consumer cannot
+    // clobber them into broken semantics (lost dialog role, trapped SRs, form-posting toggle)
     expect([pane.getAttribute(`role`), pane.dataset.resize]).toEqual([`dialog`, `none`])
     expect(pane.getAttribute(`aria-modal`)).toBe(`false`)
     expect(toggle.getAttribute(`type`)).toBe(`button`)
-    // the other side of the ordering: aria-label sits before the spread, so a page with
-    // several panes can rename them apart rather than reading three "Draggable pane"s
+    // aria-label sits before the spread, so a page with several panes can rename them apart
     expect(pane.getAttribute(`aria-label`)).toBe(`Structure controls`)
     expect(pane.classList.contains(`draggable-pane`)).toBe(true)
     expect(pane.classList.contains(`consumer-pane`)).toBe(true)
-    // Toc skips headings whose closest() match is excluded, so pane content (floating
-    // chrome, not page structure) stays out of a page's contents
+    // Toc skips excluded subtrees, so pane chrome stays out of a page's contents
     expect(pane.classList.contains(`toc-exclude`)).toBe(true)
     expect(toggle.classList.contains(`pane-toggle`)).toBe(true)
     expect(toggle.classList.contains(`consumer-toggle`)).toBe(true)
@@ -683,8 +670,8 @@ describe(`DraggablePane`, () => {
     expect(pane.style.display).toBe(`grid`) // our own handler still opened it
   })
 
-  // the demo page's Styling section is the only list of these, so a var added to the
-  // component without a mention there is a knob nobody can find
+  // the demo page's Styling section is the only list of these, so an unmentioned var is
+  // a knob nobody can find
   test(`every --pane-* custom property the styles read is documented`, () => {
     const declared = new Set(
       [...pane_source.matchAll(/var\(\s*(?<prop>--pane-[\w-]+)/gu)].map(

--- a/tests/vitest/FileDetails.svelte.test.ts
+++ b/tests/vitest/FileDetails.svelte.test.ts
@@ -19,11 +19,11 @@ test.each<[string, string, string, string?]>([
   [`styles.css`, `.a{}`, `css`],
   [`script.py`, `x = 1`, `python`],
   [`config.yml`, `key: val`, `yaml`],
-  // HTML-wrapped title — extension extracted after stripping tags
+  // extension extracted after stripping tags
   [`<code>options.ts</code>`, `export const x = 1`, `typescript`],
   // explicit language overrides title inference
   [`data.json`, `{}`, `javascript`, `javascript`],
-  // unknown extension uses extension directly as language flag
+  // unknown extension used as the language flag
   [`readme.xyz`, `hello`, `xyz`],
   // no extension falls back to default_lang
   [`Makefile`, `all:`, `svelte`],
@@ -36,8 +36,8 @@ test.each<[string, string, string, string?]>([
 
 test(`lang-label is positioned out of flow so it can't indent code`, () => {
   mount_files({ files: [{ title: `util.ts`, content: `const x = 1` }] })
-  // pre is white-space: pre, so an in-flow label shifts the first code line right.
-  // absolute positioning takes it out of flow (regression guard, see FileDetails.svelte)
+  // pre is white-space: pre, so an in-flow label indents the first code line
+  // (regression guard, see FileDetails.svelte)
   expect(getComputedStyle(doc_query(`.lang-label`)).position).toBe(`absolute`)
 })
 
@@ -60,7 +60,6 @@ test(`unsupported language falls back to escaped raw content`, async () => {
   mount_files({
     files: [{ title: `file.xyz`, content, language: `nonexistent-lang-xyz` }],
   })
-  // wait for highlight attempt to complete and fall back
   await vi.waitFor(() => expect(doc_query(`pre code`).innerHTML).toContain(`&lt;`), {
     timeout: 5000,
   })
@@ -134,7 +133,7 @@ test(`toggle all button opens/closes all, tracks label, and handles partial/nati
   expect(getComputedStyle(btn).whiteSpace).toBe(`nowrap`)
   const open_states = () => details.map((el) => el.open)
 
-  expect(open_states()).toEqual([false, false, false]) // initially closed
+  expect(open_states()).toEqual([false, false, false])
   expect(button_label()).toBe(`Open all`)
 
   btn.click()
@@ -147,8 +146,7 @@ test(`toggle all button opens/closes all, tracks label, and handles partial/nati
   expect(open_states()).toEqual([false, false, false])
   expect(button_label()).toBe(`Open all`)
 
-  // user opens a single <details> directly - the DOM open property is not
-  // reactive, so the label must update via the native toggle event
+  // the DOM open property is not reactive, so the label must follow the native toggle
   details[0].open = true
   details[0].dispatchEvent(new Event(`toggle`))
   flushSync()
@@ -167,8 +165,7 @@ test(`toggle all label reflects pre-opened details on mount`, async () => {
     { title: `file1`, content: `content1` },
     { title: `file2`, content: `content2` },
   ]
-  // details render open from the start - the toggle event never fires on mount,
-  // so the label must be initialized from detail_elements in the sync $effect
+  // the toggle event never fires on mount, so the label must init from detail_elements
   mount_files({ files, details_props: { open: true } })
   await tick()
 
@@ -211,8 +208,7 @@ test(`detail element refs are trimmed when files are removed to prevent memory l
   await tick()
 
   const details_nodes = () => [...document.querySelectorAll(`details`)]
-  // by identity, not structural toEqual: [0, 1, ...] means every file points at its
-  // own <details>, -1 means the ref is null or stale
+  // by identity: [0, 1, ...] means each file points at its own <details>, -1 means stale
   const ref_positions = (nodes: (HTMLDetailsElement | null | undefined)[]) =>
     nodes.map((node) => (node ? details_nodes().indexOf(node) : -1))
   const file_nodes = () => reactive_files.map((file) => file.node)
@@ -220,10 +216,8 @@ test(`detail element refs are trimmed when files are removed to prevent memory l
   expect(details_nodes()).toHaveLength(3)
   expect(ref_positions(file_nodes())).toEqual([0, 1, 2])
 
-  // Store references to the old nodes before removal
   const old_nodes = file_nodes()
 
-  // Remove the last file
   flushSync(() => {
     reactive_files.pop()
   })
@@ -235,7 +229,6 @@ test(`detail element refs are trimmed when files are removed to prevent memory l
   expect(ref_positions(file_nodes())).toEqual([0, 1])
   expect(ref_positions(old_nodes.slice(0, 2))).toEqual([0, 1])
 
-  // The removed file's node should no longer be in the DOM
   expect(old_nodes[2]?.isConnected).toBe(false)
 })
 

--- a/tests/vitest/FindBar.svelte.test.ts
+++ b/tests/vitest/FindBar.svelte.test.ts
@@ -220,8 +220,8 @@ describe(`create_find_state`, () => {
     expect(find.status).toBe(`1 of 2`)
   })
 
-  // The status is the only text create_find_state renders, and it reaches an aria-live
-  // region, so both branches have to be reachable without forking the state module.
+  // status is the only text create_find_state renders and it feeds an aria-live region,
+  // so both branches are exercised at the state level
   test(`labels reword both status branches, falling back per key`, () => {
     const { root, find } = setup(`<p>alpha</p><p>alpha</p>`, {
       labels: { match_position: (position, total) => `${position} von ${total}` },
@@ -338,7 +338,6 @@ describe(`create_find_state`, () => {
     await unmount_bar()
     await tick()
     expect(disconnect).toHaveBeenCalled()
-    // Unmount must drop the highlight owner.
     expect(registry.has(`find-match`)).toBe(false)
     expect(root.isConnected).toBe(true) // the searched subtree is left alone
   })

--- a/tests/vitest/Footer.test.ts
+++ b/tests/vitest/Footer.test.ts
@@ -72,9 +72,8 @@ describe(`Footer`, () => {
     expect(document.querySelector(`footer nav`)).toBeNull()
   })
 
-  // FooterLink has no id and href is not an identity: two links may point at the same
-  // page under different labels. A key that collided would throw each_key_duplicate and
-  // take down the whole nav rather than just the repeat.
+  // href is no identity: two links may point at one page under different labels, and a
+  // colliding each key would throw each_key_duplicate, taking down the whole nav
   test(`renders links sharing an href`, () => {
     mount_footer({
       links: [

--- a/tests/vitest/Icon.test.ts
+++ b/tests/vitest/Icon.test.ts
@@ -17,16 +17,15 @@ test.each([
   expect(escape_template_literal(input)).toBe(expected)
 })
 
-// The manifest is edited by hand and merged across branches, so both invariants drift easily.
-// The generator rejects duplicate ids and custom.ts clashes; ordering has no other guard.
+// the hand-edited manifest drifts across merges; the generator catches duplicate ids and
+// custom.ts clashes, but ordering has no other guard
 describe(`icons-manifest`, () => {
   const source = readFileSync(
     `${import.meta.dirname}/../../scripts/icons-manifest.ts`,
     `utf8`,
   )
-  // A section header is a bare lowercase tag. Explanatory notes sit at the same indent, so
-  // anything wordier continues the current section instead of opening a new one — treating
-  // one as a header would silently restart the ordering run and hide entries after it.
+  // a section header is a bare lowercase tag; wordier notes at the same indent continue
+  // the section — reading one as a header would restart the run and hide later entries
   const sections: string[][] = []
   for (const line of source.split(`\n`)) {
     if (/^ {2}\/\/ [a-z][a-z\d &:]*$/u.test(line)) sections.push([])
@@ -40,8 +39,8 @@ describe(`icons-manifest`, () => {
   const names = sections.flat()
 
   test(`finds icon names in the manifest`, () => {
-    // Both checks below are satisfied by an empty parse, so a manifest reformat that broke
-    // either regex would quietly retire them rather than fail.
+    // an empty parse satisfies both checks below, so a reformat breaking either regex
+    // would quietly retire them rather than fail
     expect(names.length).toBeGreaterThan(0)
   })
 
@@ -63,9 +62,8 @@ describe(`icons-manifest`, () => {
 })
 
 describe(`Icon`, () => {
-  // Every entry, not a sample: the set is merged from another repo, and markup holding
-  // several shapes rather than one `d` renders as nothing unless Icon spots the markup.
-  // Offenders are collected so a bad merge names every icon it broke, not just the first.
+  // every entry, not a sample: the set is merged from another repo and multi-shape markup
+  // renders as nothing unless Icon spots it; offenders collected so a bad merge names all
   test(`every icon renders its viewBox, fill, stroke and shape`, () => {
     const offenders: string[] = []
     // annotated because the inferred literal types drop the optional keys entirely

--- a/tests/vitest/LiteYouTubeEmbed.svelte.test.ts
+++ b/tests/vitest/LiteYouTubeEmbed.svelte.test.ts
@@ -3,8 +3,8 @@ import { type ComponentProps, mount, tick } from 'svelte'
 import { afterAll, describe, expect, test, vi } from 'vite-plus/test'
 import { doc_query } from './index'
 
-// happy-dom navigates an iframe's src for real, which would put youtube.com requests in
-// the test run; serve every request locally instead and record what was asked for.
+// happy-dom navigates an iframe's src for real, so intercept every request locally
+// instead of hitting youtube.com, recording what was asked for
 const { settings } = (
   globalThis as unknown as {
     happyDOM: { settings: { fetch: Record<string, unknown> } }
@@ -72,8 +72,7 @@ describe(`LiteYouTubeEmbed`, () => {
 
     click(`button.play-btn`)
     await tick()
-    // a supplied title, not the default: asserting the default cannot tell a wired prop
-    // from a hardcoded attribute
+    // a supplied title: the default cannot tell a wired prop from a hardcoded attribute
     expect(doc_query(`iframe`).getAttribute(`title`)).toBe(`Talk player`)
 
     // the poster URLs get the same encoding the iframe src above is checked for
@@ -139,8 +138,8 @@ describe(`LiteYouTubeEmbed`, () => {
     await tick()
 
     expect(iframes()).toHaveLength(0)
-    // teardown has to be synchronous: leaving the iframe up for even one render lets the
-    // browser start loading the new video, the exact cost this component exists to avoid
+    // teardown must be synchronous: one render with the old iframe up already starts
+    // loading the new video, the exact cost this component exists to avoid
     expect(fetched).toEqual([])
   })
 

--- a/tests/vitest/MultiSelect.a11y.svelte.test.ts
+++ b/tests/vitest/MultiSelect.a11y.svelte.test.ts
@@ -230,10 +230,10 @@ test(`clearing searchText while create-option message is active drops aria-activ
   expect(doc_query(`ul.options > li.user-msg`).classList.contains(`active`)).toBe(true)
   expect(input.getAttribute(`aria-activedescendant`)).toContain(`user-msg`)
 
-  // clearing the search removes the message li — active state must not go stale
+  // clearing the search removes the message li; aria-activedescendant used to keep
+  // pointing at it (dangling ARIA reference)
   await type_search_text(``, input)
   expect(document.querySelector(`ul.options > li.user-msg`)).toBeNull()
-  // previously kept pointing at the removed user-msg li (dangling ARIA reference)
   expect(input.getAttribute(`aria-activedescendant`)).toBeNull()
 })
 
@@ -254,9 +254,8 @@ describe(`ARIA correctness`, () => {
       `true`,
     )
 
-    // at max capacity the row is disabled but must NOT be announced as selected:
-    // aria-selected tracks only whether all selectable options are selected
-    // (option 3 is not) — not the maxSelect capacity limit
+    // at max capacity the row is disabled but must NOT announce as selected: aria-selected
+    // tracks whether all selectable options are selected (option 3 is not), not maxSelect
     await unmount_component(first)
     mount_multiselect({
       options: [1, 2, 3],
@@ -281,7 +280,6 @@ describe(`ARIA correctness`, () => {
     expect(document.querySelector(`ul.options`)).toBeNull()
     expect(input.getAttribute(`aria-controls`)).toBeNull()
 
-    // once options exist, aria-controls references the actual listbox id
     props.options = [1, 2]
     await tick()
     const listbox = doc_query(`ul.options`)

--- a/tests/vitest/MultiSelect.async.svelte.test.ts
+++ b/tests/vitest/MultiSelect.async.svelte.test.ts
@@ -179,7 +179,7 @@ describe(`loadOptions feature`, () => {
     await tick()
     expect(load_options).toHaveBeenCalledTimes(1)
 
-    // Mock a rendered but non-overflowing list
+    // a rendered list that does not overflow
     const ul = doc_query(`ul.options`)
     vi.spyOn(ul, `clientHeight`, `get`).mockReturnValue(400)
     vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(100)
@@ -209,8 +209,7 @@ describe(`loadOptions feature`, () => {
     expect(load_options).toHaveBeenCalledTimes(1)
   })
 
-  // The unmount abort lives in a teardown-returning $effect, whose shape is easy to
-  // misread as a missing call. This pins the behavior so a "fix" can't silently undo it.
+  // the unmount abort lives in a teardown-returning $effect that reads like a missing call
   test(`unmounting aborts the in-flight fetch`, async () => {
     const { fn: load_options } = deferred_load()
     const component = mount_multiselect({ loadOptions: load_options, open: true })
@@ -261,9 +260,8 @@ describe(`loadOptions feature`, () => {
     expect(load_options.mock.calls[1][0].signal?.aborted).toBe(true)
   })
 
-  // A server can report hasMore alongside an empty batch. Refetching the same offset
-  // can't make progress, and a non-reset load at offset 0 would break the documented
-  // cursor-pagination pattern that treats offset 0 as "reset your cursor".
+  // a server can report hasMore with an empty batch; refetching the same offset makes no
+  // progress, and offset 0 means "reset your cursor" in the documented pagination pattern
   test(`auto-fill stops on an empty batch and never reuses offset 0`, async () => {
     const offsets: number[] = []
     const load_options = vi.fn(async ({ offset }: LoadOptionsParams) => {
@@ -285,7 +283,6 @@ describe(`loadOptions feature`, () => {
     const { fn: load_options, resolvers } = await mount_deferred_open()
     expect(load_options).toHaveBeenCalledTimes(1)
 
-    // Type new search while first fetch is pending
     const input = get_input()
     await type_search_text(`xyz`, input)
     await vi.runAllTimersAsync()
@@ -299,14 +296,13 @@ describe(`loadOptions feature`, () => {
       signal: expect.any(AbortSignal),
     })
 
-    // Resolve the STALE first request after the new one was initiated
+    // resolve the stale first request
     resolvers[0]({ options: [`Stale Result`], hasMore: false })
     await vi.runAllTimersAsync()
 
     const ul = doc_query(`ul.options`)
     expect(ul.textContent).not.toContain(`Stale Result`)
 
-    // Resolve the current request
     resolvers[1]({ options: [`Fresh Result`], hasMore: false })
     await vi.runAllTimersAsync()
     expect(ul.textContent).toContain(`Fresh Result`)
@@ -353,20 +349,18 @@ describe(`loadOptions feature`, () => {
     const input = get_input()
     expect(input.getAttribute(`aria-busy`)).toBe(`true`)
 
-    // Close dropdown via Escape while fetch is still pending
+    // close while the fetch is still pending
     input.dispatchEvent(fresh_key(`Escape`))
     await tick()
 
-    // aria-busy should clear immediately on close
     expect(input.getAttribute(`aria-busy`)).toBeNull()
     expect(load_options.mock.calls[0][0].signal?.aborted).toBe(true)
 
-    // Stale fetch resolves after close — should not corrupt state
+    // a stale resolve after close must not corrupt state
     resolvers[0]({ options: [`Result`], hasMore: false })
     await tick()
     expect(input.getAttribute(`aria-busy`)).toBeNull()
 
-    // Reopen — should trigger fresh load, not be stuck
     reopen()
     await tick()
     expect(load_options).toHaveBeenCalledTimes(2)
@@ -394,15 +388,14 @@ describe(`loadOptions feature`, () => {
     await flush_ticks()
     expect(load_options).toHaveBeenCalledTimes(capped_count)
 
-    // Simulate user scroll — should reset counter and allow more loading
+    // a user scroll resets the auto-fill counter
     vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(500)
     vi.spyOn(ul, `scrollTop`, `get`).mockReturnValue(250)
     ul.dispatchEvent(new Event(`scroll`))
     await tick()
     expect(load_options).toHaveBeenCalledTimes(capped_count + 1)
 
-    // After scroll-triggered load resolves, auto-fill should resume
-    // (list still doesn't overflow), verifying that the counter was reset.
+    // auto-fill resumes once the scroll-triggered load resolves, proving the counter reset
     vi.spyOn(ul, `scrollHeight`, `get`).mockReturnValue(100)
     resolvers[capped_count]({ options: [`Post-scroll`], hasMore: true })
     await flush_ticks()
@@ -417,24 +410,23 @@ describe(`loadOptions feature`, () => {
 
     const input = get_input()
 
-    // Close while first fetch is still pending (NOT resolved)
+    // close while the first fetch is still pending
     input.dispatchEvent(fresh_key(`Escape`))
     await tick()
     expect(input.getAttribute(`aria-busy`)).toBeNull()
 
-    // Reopen BEFORE old fetch resolves — this is the critical timing
+    // reopen before the old fetch resolves — the critical timing
     reopen()
     await tick()
     expect(load_options).toHaveBeenCalledTimes(2)
     expect(input.getAttribute(`aria-busy`)).toBe(`true`)
 
-    // Old fetch resolves late — must be discarded, not corrupt new session
+    // the late resolve must be discarded, not corrupt the new session
     resolvers[0]({ options: [`Stale`], hasMore: false })
     await tick()
     expect(input.getAttribute(`aria-busy`)).toBe(`true`)
     expect(doc_query(`ul.options`).textContent).not.toContain(`Stale`)
 
-    // New fetch resolves — applied normally
     resolvers[1]({ options: [`Fresh`], hasMore: false })
     await tick()
     expect(doc_query(`ul.options`).textContent).toContain(`Fresh`)
@@ -446,24 +438,24 @@ describe(`loadOptions feature`, () => {
     const { fn: load_options, resolvers, rejectors } = await mount_deferred_open()
     expect(load_options).toHaveBeenCalledTimes(1)
 
-    // Type to trigger a new search while first fetch is pending
+    // new search while the first fetch is pending
     const input = get_input()
     await type_search_text(`test`, input)
     await vi.runAllTimersAsync()
     expect(load_options).toHaveBeenCalledTimes(2)
 
-    // New fetch succeeds FIRST with hasMore=true
+    // the new fetch succeeds first, with hasMore=true
     resolvers[1]({ options: [`Result A`], hasMore: true })
     await vi.runAllTimersAsync()
 
     const ul = doc_query(`ul.options`)
     expect(ul.textContent).toContain(`Result A`)
 
-    // Old (stale) fetch ERRORS AFTER success — must not corrupt hasMore
+    // the stale fetch errors after that success and must not corrupt hasMore
     rejectors[0](new Error(`Stale network error`))
     await vi.runAllTimersAsync()
 
-    // Scroll should trigger pagination (hasMore was NOT corrupted by stale error)
+    // pagination still fires, so hasMore survived the stale error
     mock_scroll_near_bottom(ul)
     await vi.runAllTimersAsync()
     expect(load_options).toHaveBeenCalledTimes(3)
@@ -473,13 +465,13 @@ describe(`loadOptions feature`, () => {
     mock_console_error()
     const { fn: load_options, resolvers, rejectors } = deferred_load()
     vi.useFakeTimers()
-    // Use onOpen=false so retry requires typing, exposing has_more via pending
+    // onOpen=false so retry requires typing, exposing has_more via pending
     mount_multiselect({
       loadOptions: { fetch: load_options, onOpen: false, debounceMs: 10 },
       open: true,
     })
 
-    // Type to trigger initial load (onOpen=false requires user input)
+    // with onOpen=false, typing is what triggers the initial load
     const input = get_input()
     await type_search_text(`q`, input)
     await vi.runAllTimersAsync()
@@ -488,15 +480,13 @@ describe(`loadOptions feature`, () => {
     rejectors[0](new Error(`Server down`))
     await vi.runAllTimersAsync()
 
-    // Close and reopen
     input.dispatchEvent(fresh_key(`Escape`))
     await vi.runAllTimersAsync()
     reopen()
     await vi.runAllTimersAsync()
 
-    // Type to trigger load again (onOpen=false)
     await type_search_text(`q`, input)
-    // During debounce: aria-busy must be true (has_more was reset on close)
+    // has_more was reset on close, so aria-busy is true during the debounce
     await tick()
     expect(input.getAttribute(`aria-busy`)).toBe(`true`)
 
@@ -518,12 +508,11 @@ describe(`loadOptions feature`, () => {
       open: true,
     })
     await vi.runAllTimersAsync()
-    // Initial load succeeds
     resolvers[0]({ options: [`Apple`], hasMore: false })
     await vi.runAllTimersAsync()
     expect(load_options).toHaveBeenCalledTimes(1)
 
-    // Search "x" triggers load, which fails
+    // this search fails
     const input = get_input()
     await type_search_text(`x`, input)
     await vi.runAllTimersAsync()
@@ -531,7 +520,7 @@ describe(`loadOptions feature`, () => {
     rejectors[1](new Error(`fail`))
     await vi.runAllTimersAsync()
 
-    // Clear and retype the same search to trigger a fresh request.
+    // clearing and retyping the same search must refetch
     await type_search_text(``, input)
     await vi.runAllTimersAsync()
     await type_search_text(`x`, input)
@@ -623,9 +612,8 @@ describe(`load_options_pending`, () => {
     await tick()
     expect(fetch_fn).toHaveBeenCalledTimes(1) // immediate open load, still in-flight
 
-    // type two chars while the first fetch is still awaiting (load_options_last_search
-    // is null until it resolves). Pre-fix, each keystroke re-entered the first-load branch
-    // and fired another immediate load_dynamic_options(true); the fix routes them to debounce.
+    // typing while the first fetch is still awaiting: pre-fix each keystroke re-entered the
+    // first-load branch and fired another immediate load, instead of routing to the debounce
     const input = get_input()
     for (const value of [`a`, `ab`]) {
       await type_search_text(value, input)
@@ -668,13 +656,11 @@ describe(`load_options_pending`, () => {
 
       expect(input.getAttribute(`aria-busy`)).toBe(`true`)
 
-      // Enter during debounce window should NOT create an option
       input.dispatchEvent(fresh_key(`Enter`))
       await tick()
       expect(oncreate_spy).not.toHaveBeenCalled()
       expect(document.querySelector(`.user-msg`)).toBeNull()
 
-      // Let debounce fire and fetch complete
       await vi.runAllTimersAsync()
       fetch_resolvers.at(-1)?.({ options: [], hasMore: false })
       await vi.runAllTimersAsync()
@@ -684,7 +670,6 @@ describe(`load_options_pending`, () => {
         `Create this option`,
       )
 
-      // Now Enter should create the option
       input.dispatchEvent(fresh_key(`Enter`))
       await tick()
       expect(oncreate_spy).toHaveBeenCalledTimes(1)
@@ -738,15 +723,14 @@ describe(`load_options_pending`, () => {
     await vi.runAllTimersAsync()
     expect(fetch_fn).toHaveBeenCalledTimes(2)
 
-    // Close dropdown while fetch is in-flight
     input.dispatchEvent(fresh_key(`Escape`))
     await tick()
 
-    // Late fetch resolves after close — stale results must be discarded
+    // the late resolve after close must be discarded
     fetch_resolvers[1]({ options: [`Rust Lang`], hasMore: false })
     await vi.runAllTimersAsync()
 
-    // Reopen — should trigger fresh load immediately (is_first_load path)
+    // reopen takes the is_first_load path, loading immediately
     reopen()
     await tick()
     // Fresh load fires immediately; stale path would debounce (not yet called)

--- a/tests/vitest/MultiSelect.grouping.svelte.test.ts
+++ b/tests/vitest/MultiSelect.grouping.svelte.test.ts
@@ -106,8 +106,7 @@ describe(`option grouping feature`, () => {
 
     const input = await focus_input()
 
-    // arrows land on real options only: the second press steps over the Genre header
-    // sitting between the ungrouped option and Rock
+    // the second press steps over the Genre header between the ungrouped option and Rock
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
     expect(doc_query(`ul.options > li.active`).textContent?.trim()).toBe(
@@ -126,8 +125,7 @@ describe(`option grouping feature`, () => {
       (header: HTMLElement) => header.click(),
     ],
     [
-      // The collapse control is a real <button> now, so Enter and Space activate it
-      // natively instead of going through a hand-rolled keydown handler on the <li>.
+      // a real <button> now, so Enter/Space activate it natively (no keydown handler)
       `keyboard activation of the toggle button`,
       (header: HTMLElement) =>
         header.querySelector<HTMLButtonElement>(`button.group-collapse-toggle`)?.click(),
@@ -359,11 +357,9 @@ describe(`option grouping feature`, () => {
     expect(onselectAll_spy.mock.calls[0][0].options).toEqual(genre_options)
   })
 
-  // A listbox may only own `option` and `group` elements. The header row is therefore
-  // presentational, which conflict resolution would undo if the <li> were focusable or
-  // carried any global ARIA attribute — so `aria-label`, `tabindex` and `role="button"`
-  // all had to come off it, and the group name reaches assistive tech through each
-  // option's `aria-describedby` instead.
+  // a listbox may only own `option`/`group` children, so the header row is presentational:
+  // focusability or a global ARIA attribute on the <li> would demote it to listitem, hence
+  // no aria-label/tabindex/role=button and the group name rides option aria-describedby
   test.each([true, false] as const)(
     `group headers stay presentational when collapsibleGroups=%s`,
     async (collapsibleGroups) => {
@@ -488,8 +484,8 @@ describe(`option grouping feature`, () => {
 
   test.each([
     [`expands the matching group`, `Rock`, { group: `Genre`, collapsed: false }],
-    // "C Major"/"D Minor" contain spaces, so a bare space fuzzy-matches them. The
-    // has_search_text guard must stop the Key group expanding on whitespace-only input.
+    // a bare space fuzzy-matches "C Major"/"D Minor", so the has_search_text guard must
+    // keep the Key group collapsed
     [`ignores whitespace-only input`, ` `, null],
   ])(`searchExpandsCollapsedGroups %s`, async (_name, search, expected_toggle) => {
     const ongroupToggle_spy = vi.fn()
@@ -683,7 +679,6 @@ test(`searchExpandsCollapsedGroups: manually collapsed group stays collapsed unt
     collapsedGroups: new Set([`Fruits`]),
   })
   const input = get_input()
-  // typing auto-expands the collapsed group with matches
   await type_search_text(`a`, input)
   expect(group_expanded(`Fruits`)).toBe(`true`)
 

--- a/tests/vitest/MultiSelect.history.svelte.test.ts
+++ b/tests/vitest/MultiSelect.history.svelte.test.ts
@@ -23,8 +23,8 @@ describe(`history / undo-redo`, () => {
   }
 
   test(`undo/redo bound by default, canUndo/canRedo initially false`, async () => {
-    // keys must exist on the $state props for the bindables to write back;
-    // canUndo/canRedo start true to verify the component resets them to false
+    // keys must exist on the $state props for the bindables to write back; canUndo/redo
+    // start true so the reset to false is observable
     const props = await mount_history({
       history: undefined,
       canUndo: true,
@@ -39,8 +39,7 @@ describe(`history / undo-redo`, () => {
     expect(props.redo?.()).toBe(false) // nothing to redo
   })
 
-  // an empty stack already returns false, so these build real history first - otherwise
-  // move_history bails on next_index < 0 and never reaches the guard under test
+  // build real history first, else move_history bails on next_index < 0 before the guard
   test.each([`undo`, `redo`] as const)(`%s is a no-op while disabled`, async (method) => {
     const props = await mount_history()
     props.selected = [1]
@@ -60,8 +59,7 @@ describe(`history / undo-redo`, () => {
     expect(props.canRedo).toBe(false)
   })
 
-  // false and 0 hit different branches of the max_history derivation; enabled values
-  // (true, positive integers) are covered by the undo/redo behavior tests below
+  // false and 0 hit different branches of the max_history derivation
   test.each([false, 0] as const)(
     `history=%s records nothing, leaving undo bound but inert`,
     async (history_val) => {
@@ -134,8 +132,7 @@ describe(`history / undo-redo`, () => {
   ])(`compatible with %s`, async (_desc, options, extra) => {
     const props = await mount_history({ options, ...extra })
 
-    // Select first selectable option (skip group headers)
-    // A missing row is a failure, not a reason to silently skip a compatibility case.
+    // a missing row is a failure, not a reason to silently skip a compatibility case
     doc_query(`ul.options > li:not(.group-header)`).click()
     await tick()
     expect(props.selected?.length).toBeGreaterThan(0)
@@ -203,10 +200,9 @@ describe(`history / undo-redo`, () => {
     expect(props.canUndo).toBe(false)
     expect(props.canRedo).toBe(true)
 
-    // Calling undo again when nothing to undo should return false and not change state
     expect(props.undo?.()).toBe(false)
     await tick()
-    expect(props.selected).toEqual([]) // state unchanged
+    expect(props.selected).toEqual([])
 
     expect(props.redo?.()).toBe(true)
     await tick()
@@ -252,11 +248,10 @@ describe(`history / undo-redo`, () => {
   })
 
   test(`preselected values are correctly tracked as initial state`, async () => {
-    // Regression: prev_selected must sync to initial selected on mount,
-    // otherwise undo after deselect restores [] instead of preselected state
+    // regression: prev_selected must sync to the initial selected on mount, else undo
+    // after a deselect restores [] instead of [1, 2]
     const props = await mount_history({ selected: [1, 2] })
 
-    // Remove one item, then undo - should restore [1, 2], not []
     doc_query(`ul.selected li button.remove`).click()
     await tick()
     expect(props.selected).toEqual([2])

--- a/tests/vitest/MultiSelect.keyboard.svelte.test.ts
+++ b/tests/vitest/MultiSelect.keyboard.svelte.test.ts
@@ -133,7 +133,6 @@ test(`closes dropdown on tab out and blur to external element`, async () => {
   mount_multiselect({ options: [1, 2, 3], onclose })
   expect(doc_query(`ul.options.hidden`)).toBeInstanceOf(HTMLUListElement)
 
-  // opens dropdown on focus
   const input = await focus_input()
   expect(document.querySelector(`ul.options.hidden`)).toBeNull()
 
@@ -210,13 +209,11 @@ test(`backspace does not remove items when minSelect would be violated`, async (
 
   mount_multiselect({ options, selected, minSelect })
 
-  // Try to remove the only selected item with backspace
   const backspace = fresh_key(`Backspace`)
   const input = get_input()
   input.dispatchEvent(backspace)
   await tick()
 
-  // The item should still be selected since minSelect=1
   expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`Red`)
 })
 
@@ -261,7 +258,7 @@ describe(`arrow key navigation between selected items`, () => {
     expect(selected_items()).toHaveLength(2)
     expect(selected_items()[0]?.textContent).toContain(`Red`)
     expect(selected_items()[1]?.textContent).toContain(`Blue`)
-    // highlight should stay at idx 1 (Blue), not jump to idx 0 (Red)
+    // idx 1 is Blue now, not Red
     expect(is_highlighted(1)).toBe(true)
     expect(is_highlighted(0)).toBe(false)
   })
@@ -321,7 +318,7 @@ describe(`arrow key navigation between selected items`, () => {
     input.dispatchEvent(press(`ArrowLeft`))
     await tick()
     expect(is_highlighted(1)).toBe(true)
-    // click X on last item (Blue) — selected becomes [Red, Green], stale idx 1 still valid
+    // remove Blue: selected becomes [Red, Green], so the stale idx 1 is still valid
     ;[...document.querySelectorAll<HTMLElement>(`ul.selected li button.remove`)]
       .at(-1)
       ?.click()
@@ -332,7 +329,7 @@ describe(`arrow key navigation between selected items`, () => {
   test(`remove-all button clears highlight`, async () => {
     // minSelect=1 so one item survives remove-all, exposing stale highlighted_idx
     const input = setup([`Red`, `Green`, `Blue`], { minSelect: 1 })
-    // highlight idx 0 (Red) — this item will survive remove-all
+    // highlight idx 0 (Red), the item that survives remove-all
     for (let step = 0; step < 3; step++) input.dispatchEvent(press(`ArrowLeft`))
     await tick()
     expect(is_highlighted(0)).toBe(true)
@@ -360,14 +357,12 @@ describe(`arrow key navigation between selected items`, () => {
   })
 
   test(`Backspace with duplicates removes correct occurrence`, async () => {
-    // with duplicates=true, selected can have repeated values
-    // backspace on highlighted idx 2 (second "Red") must remove idx 2, not idx 0
+    // backspace on highlighted idx 2 (the second Red) must remove idx 2, not idx 0
     const input = setup([`Red`, `Blue`, `Red`], { duplicates: true })
     input.dispatchEvent(press(`ArrowLeft`)) // idx 2 (second Red)
     input.dispatchEvent(press(`Backspace`))
     await tick()
     expect(selected_items()).toHaveLength(2)
-    // first Red (idx 0) should survive, Blue (idx 1) should survive
     expect(selected_items()[0]?.textContent).toContain(`Red`)
     expect(selected_items()[1]?.textContent).toContain(`Blue`)
   })
@@ -403,8 +398,7 @@ describe(`arrow key navigation between selected items`, () => {
   })
 
   test.each<[name: string, next_selected: string[], expected_idx: number | null]>([
-    // externally shrinking past the highlighted idx should clamp to the last valid index;
-    // clearing should drop the highlight entirely (expected_idx null)
+    // shrinking past the highlighted idx clamps to the last valid one, clearing drops it
     [`shrink clamps highlighted_idx`, [`Red`, `Green`], 1],
     [`clear nullifies highlighted_idx`, [], null],
   ])(`external selected %s`, async (_name, next_selected, expected_idx) => {
@@ -447,8 +441,8 @@ describe(`arrow key navigation between selected items`, () => {
 })
 
 describe(`keyboard shortcuts`, () => {
-  // Mount with shortcut props, focus the input, dispatch one keydown, and return the
-  // bound props plus the (cancelable) event so callers can assert selection + defaultPrevented.
+  // mounts, focuses the input and dispatches one keydown, returning the bound props and
+  // the cancelable event so callers can assert selection and defaultPrevented
   async function test_shortcut(
     shortcut_props: Partial<MultiSelectProps>,
     key_event: {
@@ -512,14 +506,13 @@ describe(`keyboard shortcuts`, () => {
   )
 
   test(`custom shortcuts override defaults`, async () => {
-    // Default ctrl+a should NOT work with a custom select_all binding
+    // the default ctrl+a must stop working once select_all is rebound
     const { props, input } = await test_shortcut(
       { selectAllOption: true, shortcuts: { select_all: `ctrl+e` } },
       { key: `a`, ctrlKey: true },
     )
     expect(props.selected).toEqual([])
 
-    // Custom ctrl+e SHOULD work
     input.dispatchEvent(
       new KeyboardEvent(`keydown`, { key: `e`, ctrlKey: true, bubbles: true }),
     )
@@ -584,7 +577,6 @@ describe(`keyboard shortcuts`, () => {
       { selectAllOption: false, shortcuts: { select_all: `ctrl+a` } },
       { key: `a`, ctrlKey: true },
     )
-    // Should NOT select all since selectAllOption is false
     expect(props.selected).toEqual([])
   })
 
@@ -627,7 +619,6 @@ describe(`keyboard shortcuts`, () => {
       { selectAllOption: true, shortcuts: { select_all: `ctrl+a` }, disabled: true },
       { key: `a`, ctrlKey: true },
     )
-    // Shortcuts should not work when component is disabled
     expect(props.selected).toEqual([])
   })
 
@@ -679,7 +670,6 @@ describe(`keyboard shortcuts`, () => {
     },
   )
 
-  // Tests for shortcut override behavior - custom shortcuts take precedence over built-in keys
   test.each([
     // [description, shortcuts, extra_props, key, expected_open, expected_selected]
     [
@@ -787,7 +777,7 @@ test(`IME composition guard: Enter during composition is ignored`, async () => {
   await tick()
   expect(doc_query(`ul.options > li.active`).textContent?.trim()).toBe(`foo`)
 
-  // Enter mid-composition (e.g. confirming CJK text) must not select the active option
+  // Enter mid-composition (confirming CJK text) must not select the active option
   const composing_enter = fresh_key(`Enter`)
   Object.defineProperty(composing_enter, `isComposing`, { value: true })
   input.dispatchEvent(composing_enter)
@@ -800,7 +790,7 @@ test(`IME composition guard: Enter during composition is ignored`, async () => {
   expect(props.selected).toEqual([`foo`])
 })
 
-// The remove button is unmounted by the removal it just ran, so focus fell to <body>.
+// the remove button is unmounted by the removal it just ran, so focus fell to <body>
 test.each([
   [`a single chip's remove button`, `ul.selected button.remove`],
   [`the remove-all button`, `button.remove-all`],

--- a/tests/vitest/MultiSelect.paste.svelte.test.ts
+++ b/tests/vitest/MultiSelect.paste.svelte.test.ts
@@ -30,8 +30,7 @@ async function paste_into(extra_props: Partial<MultiSelectProps>, paste_text: st
   const input = get_input()
   const event = make_paste_event(paste_text)
   input.dispatchEvent(event)
-  // No macrotask wait: sync-oncreate paste must complete synchronously. handle_paste
-  // only awaits add() when an async oncreate suspends.
+  // no macrotask wait: handle_paste only awaits add() when an async oncreate suspends
   await tick()
   return { ...spies, props, event }
 }
@@ -48,9 +47,8 @@ describe(`parse_paste`, () => {
     expect(onadd).toHaveBeenCalledWith(expect.objectContaining({ option: `beta` }))
   })
 
-  // `text.split(',')` on a trailing comma yields an empty entry. `add` throws on those, and
-  // the throw used to reject handle_paste: the loop stopped, later entries vanished and
-  // onparsed_paste never fired, leaving an unhandled rejection behind.
+  // an empty parsed entry makes `add` throw; that throw used to reject handle_paste, so
+  // the loop stopped, later entries vanished and onparsed_paste never fired
   test.each([`alpha,beta,`, `alpha,,beta`])(
     `an empty parsed entry is rejected without aborting the paste (%j)`,
     async (paste_text) => {

--- a/tests/vitest/MultiSelect.portal.svelte.test.ts
+++ b/tests/vitest/MultiSelect.portal.svelte.test.ts
@@ -7,8 +7,7 @@ import { mount_multiselect, unmount_component } from './MultiSelect.test-utils'
 describe(`portal placement`, () => {
   afterEach(() => vi.unstubAllGlobals()) // don't leak innerHeight overrides to other tests
 
-  // happy-dom has no real layout engine, so stub getBoundingClientRect on the
-  // outer div, offsetHeight on the portalled dropdown, and the viewport height
+  // happy-dom has no layout engine: stub trigger rect, dropdown offsetHeight, viewport
   function stub_layout({
     trigger_rect,
     dropdown_height,
@@ -49,8 +48,7 @@ describe(`portal placement`, () => {
     await tick()
   }
 
-  // `top` positions the dropdown's margin edge, so the action subtracts the
-  // computed margin-top when placing above — mirror that in expected values
+  // `top` positions the margin edge, so the action subtracts margin-top when above
   function expected_top_style(
     expected_placement: `top` | `bottom`,
     trigger_rect: { top: number; bottom: number },
@@ -105,8 +103,7 @@ describe(`portal placement`, () => {
       desc: `unmeasured dropdown (offsetHeight 0) falls back to bottom`,
     },
     {
-      // omitted placement must default to auto: same tight-space-below setup as
-      // the auto row above, so a flip to top proves the default contract
+      // same tight-space-below setup as the auto row above, so a flip proves the default
       placement: undefined,
       trigger_rect: { top: 600, bottom: 630 },
       dropdown_height: 200,
@@ -175,7 +172,7 @@ describe(`portal placement`, () => {
     expect(dropdown.dataset.placement).toBe(`bottom`)
     expect(dropdown.style.top).toBe(`130px`)
 
-    // trigger moves near viewport bottom → auto placement flips above on next scroll
+    // trigger near viewport bottom → auto flips above on next scroll
     stub_layout({
       trigger_rect: { top: 600, bottom: 630 },
       dropdown_height: 200,
@@ -219,9 +216,8 @@ test(`toggling portal.active at runtime portals and un-portals the dropdown`, as
   expect(back_inside.dataset.placement).toBeUndefined()
 })
 
-// The click_outside attachment receives `inside: [options_list_el]`, which is undefined
-// until bind:this lands. Attachments re-run on reactive reads, so the portalled list
-// must count as inside once bound — otherwise pressing it would close the dropdown.
+// click_outside gets `inside: [options_list_el]`, undefined until bind:this lands — the
+// attachment must re-run on that reactive read or pressing the list would close it
 test(`press on the portalled dropdown does not close it`, async () => {
   const props = $state<MultiSelectProps>({
     options: [1, 2, 3],

--- a/tests/vitest/MultiSelect.range.test.ts
+++ b/tests/vitest/MultiSelect.range.test.ts
@@ -65,8 +65,8 @@ test(`backward range selects upward from the anchor`, async () => {
   })
 })
 
-// the row hint indexes the dropdown while the lookup runs against a superset that also
-// holds already-selected rows, so a naive first match lands on the wrong duplicate
+// the row hint indexes the dropdown but the lookup runs against a superset including
+// already-selected rows, so a naive first match lands on the wrong duplicate
 test.each([
   // Sel leaves the dropdown once selected, so the second Dup moves up to index 1
   [`distinct labels between them`, dup_options, {}, 1],
@@ -216,8 +216,8 @@ test(`an invalidated anchor falls back to one ordinary add`, async () => {
   })
 })
 
-// Two equal-sized ranges in a row yield the same text. With a plain string the live
-// region's DOM would be untouched and a screen reader would stay silent on the repeat.
+// two equal-sized ranges yield identical text; a plain string would leave the live
+// region's DOM untouched and screen readers silent on the repeat
 test(`an identical repeat announcement still replaces the live region node`, async () => {
   mount_range({ options: [`A`, `B`, `C`, `D`, `E`], open: true })
   const live = doc_query(`.sr-only[aria-live="polite"]`)

--- a/tests/vitest/MultiSelect.svelte.test.ts
+++ b/tests/vitest/MultiSelect.svelte.test.ts
@@ -31,7 +31,7 @@ test(`2-way binding preserves a valid initial auto-active index`, async () => {
   await tick()
   expect(props.activeIndex).toBe(1)
 
-  // test internal changes to activeIndex bind outward
+  // internal changes bind outward
   for (const idx of [1, 2]) {
     const li = doc_query(`ul.options li:nth-child(${idx})`)
     li.dispatchEvent(fresh_mouseover())
@@ -39,7 +39,7 @@ test(`2-way binding preserves a valid initial auto-active index`, async () => {
     expect(props.activeIndex).toEqual(idx - 1)
   }
 
-  // test external changes to activeIndex bind inward
+  // external changes bind inward
   props.activeIndex = 2
   await tick()
 
@@ -64,7 +64,7 @@ test(`clears active state when replacement identity is ambiguous`, async () => {
 })
 
 test(`1-way binding of activeOption and hovering an option makes it active`, async () => {
-  // test internal change to activeOption binds outward
+  // internal changes bind outward
   let activeOption: Option | null | undefined = 0
   const cb = vi.fn()
 
@@ -132,7 +132,6 @@ test(`applies DOM attributes to input node`, () => {
   const input = get_input()
   const form_input = doc_query<HTMLInputElement>(`input.form-control`)
 
-  // make sure the search text filtered the dropdown options
   expect(lis).toHaveLength(1)
 
   expect(input?.value).toBe(searchText)
@@ -181,7 +180,7 @@ test(`applies custom classes for styling through CSS frameworks`, async () => {
 
   mount_multiselect({ options: [1, 2, 3], ...css_classes, selected: [1], maxSelect: 2 })
 
-  // make an option active hovering it so it gets the active class
+  // hover to make an option active
   document.querySelector(`ul.options > li`)?.dispatchEvent(fresh_mouseover())
   await tick()
 
@@ -287,7 +286,6 @@ test.each([
   expect(select.selected).toEqual([falsy_val])
 })
 
-// Bug: value/selected should update when maxSelect changes at runtime
 test.each([
   {
     initial: null,
@@ -817,7 +815,7 @@ test.each([
   [[{ label: `a` }, { label: `b` }, { label: `c` }]],
 ])(`passes selected options=%j to form submission handlers`, async (options) => {
   const form = document.createElement(`form`)
-  // actual form submission not supported in nodejs, would throw without preventing default behavior
+  // nodejs cannot really submit a form, so prevent the default
   form.addEventListener(`submit`, (event) => event.preventDefault())
   document.body.append(form)
 
@@ -880,7 +878,6 @@ test(`toggling required after invalid form submission allows submitting`, async 
   const props = $state({ options: [1, 2, 3], required: true })
   mount_multiselect(props, form)
 
-  // form should not be submittable due to missing required input
   expect(form.checkValidity()).toBe(false)
 
   props.required = false
@@ -897,7 +894,6 @@ test(`invalid=true gives top-level div class 'invalid' and input attribute of 'a
   const multiselect = doc_query(`div.multiselect`)
   expect(multiselect.classList.contains(`invalid`)).toBe(true)
 
-  // assert aria-invalid attribute is removed on selecting a new option
   const option_li = doc_query<HTMLLIElement>(`ul.options > li`)
   option_li.click()
   await tick()
@@ -982,7 +978,6 @@ test(`option snippet receives selected, active, and disabled booleans`, async ()
   expect(option_spans[1].dataset.disabled).toBe(`true`)
   expect(option_spans[1].dataset.active).toBe(`false`)
 
-  // hover first option to activate it
   doc_query(`ul.options > li`).dispatchEvent(
     new MouseEvent(`mouseover`, { bubbles: true }),
   )
@@ -1187,9 +1182,8 @@ test(`autoScroll=false skips scrolling active options into view`, async () => {
 test.each([
   [`highlightMatches=false suppresses highlighting`, { highlightMatches: false }, false],
   [`typed search text is highlighted`, {}, true],
-  // after committing, searchText is "Alpha" but it is no longer an active filter, so
-  // highlighting must stay off — pins that the dropdown highlights the *effective*
-  // filter text rather than the raw searchText
+  // after committing, searchText is "Alpha" but no longer an active filter: highlighting
+  // follows the effective filter text, not the raw searchText
   [
     `committed selectedDisplay=input text is not highlighted`,
     { maxSelect: 1, selectedDisplay: `input`, closeDropdownOnSelect: false },
@@ -1291,7 +1285,7 @@ test.each([
 test(`remove all button removes all selected options and is visible only if more than 1 option is selected`, async () => {
   const remove_all_btn_selector = `button[title='Remove all']`
 
-  // Scenario 1: Multiple items selected, button is visible, click removes all
+  // several selected: the button is visible and clicking it removes all
   mount_multiselect({ options: [1, 2, 3], selected: [1, 2, 3] })
   expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`1 2 3`)
 
@@ -1300,7 +1294,7 @@ test(`remove all button removes all selected options and is visible only if more
   expect(doc_query(`ul.selected`).textContent?.trim()).toBe(``)
   document.body.innerHTML = `` // Clean up for next mount
 
-  // Scenario 2: Select 2 items, button becomes visible only after 2nd selection
+  // the button appears only on the 2nd selection
   mount_multiselect({ options: [1, 2, 3], selected: [] })
 
   const option_lis = document.querySelectorAll<HTMLLIElement>(`ul.options > li`)
@@ -1449,7 +1443,7 @@ describe.each([
 
       const input = get_input()
 
-      // Type the selected value to trigger duplicate/create check
+      // typing the selected value triggers the duplicate/create check
       await type_search_text(`${selected[0]}`, input)
 
       const dropdown = doc_query(`ul.options`)
@@ -1540,7 +1534,7 @@ test(`2-way binding of selected`, async () => {
 
   mount(Test2WayBind, { target: document.body, props })
 
-  // test internal changes to selected bind outward
+  // internal changes bind outward
   for (const _ of Array.from({ length: 2 })) {
     const li = doc_query(`ul.options li`)
     li.click()
@@ -1549,7 +1543,7 @@ test(`2-way binding of selected`, async () => {
 
   expect(selected).toEqual([1, 2])
 
-  // test external changes to selected bind inward
+  // external changes bind inward
   props.selected = [3]
   await tick()
 
@@ -1575,7 +1569,7 @@ test.each([
       },
     })
 
-    // test internal changes bind outward
+    // internal changes bind outward
     for (const _ of [1, 2]) {
       const li = doc_query(`ul.options li`)
       li.click()
@@ -1607,11 +1601,10 @@ test(`disabled multiselect disables input, removal controls, and shows disabled 
 })
 
 test(`can remove user-created selected option which is not in dropdown list`, async () => {
-  // i.e. allowUserOptions=true, not 'append', meaning user options are only selected but
-  // aren't added to dropdown list yet remove() should still be able to delete them
+  // allowUserOptions=true (not 'append'): user options are selected without joining the
+  // dropdown list, and remove() must still delete them
   mount_multiselect({ options: [`1`, `2`, `3`], allowUserOptions: true })
 
-  // add a new option created from user text input
   const input = get_input()
   await type_search_text(`foo`, input)
 
@@ -1620,7 +1613,6 @@ test(`can remove user-created selected option which is not in dropdown list`, as
   await tick()
   expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`foo`)
 
-  // remove the new option
   const li_selected = doc_query(`ul.selected li button[title*='Remove']`)
   li_selected.click()
   await tick()
@@ -1731,7 +1723,7 @@ test(`remove all button does not remove items when minSelect constraint would be
   doc_query(`button.remove-all`).click()
   await tick()
 
-  // The first item should still be selected since minSelect=1
+  // minSelect=1 keeps the first item
   expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`Red`)
 })
 
@@ -1844,8 +1836,7 @@ test(`rejects empty options without an empty-state mode`, () => {
 test(`throws synchronously when adding an empty option`, () => {
   mount_multiselect({ options: [``] })
   const empty_option = doc_query<HTMLLIElement>(`ul.options > li`)
-  // Invoke Svelte's delegated handler directly so a rejected promise cannot masquerade
-  // as a synchronous exception.
+  // invoke Svelte's delegated handler directly so a rejected promise can't look synchronous
   const event_symbol = Object.getOwnPropertySymbols(empty_option).find(
     (symbol) => symbol.description === `events`,
   )
@@ -2110,7 +2101,7 @@ test(`onopen fires once with FocusEvent, not again when already open`, async () 
   expect(open_spy).toHaveBeenCalledOnce()
   expect(open_spy.mock.calls[0][0].event).toBeInstanceOf(FocusEvent)
 
-  // clicking the input again while already open should NOT fire onopen again
+  // already open, so a second click must not re-fire
   input.dispatchEvent(new MouseEvent(`mouseup`, { bubbles: true }))
   await tick()
   expect(open_spy).toHaveBeenCalledOnce()
@@ -2120,19 +2111,18 @@ test(`onclose fires once with KeyboardEvent, not again when already closed`, asy
   const close_spy = vi.fn()
   mount_multiselect({ options: [1, 2, 3], onclose: close_spy })
 
-  // dropdown starts closed — clicking outside should NOT fire onclose
+  // still closed, so an outside click must not fire
   document.body.click()
   await tick()
   expect(close_spy).not.toHaveBeenCalled()
 
-  // open then close — should fire exactly once with KeyboardEvent
   const input = await focus_input()
   input.dispatchEvent(fresh_key(`Escape`))
   await tick()
   expect(close_spy).toHaveBeenCalledOnce()
   expect(close_spy.mock.calls[0][0].event).toBeInstanceOf(KeyboardEvent)
 
-  // clicking outside again while already closed — still no extra fire
+  // closed again, so no extra fire
   document.body.click()
   await tick()
   expect(close_spy).toHaveBeenCalledOnce()
@@ -2208,9 +2198,8 @@ describe(`keepSelectedInDropdown feature`, () => {
     },
   )
 
-  // The box is one-way bound to `view.selected` with no change handler, so a native click
-  // flipped it before the <li> ran the real toggle. When that toggle was refused the
-  // selection never changed, Svelte saw no new value to write, and the box stayed wrong.
+  // the box is one-way bound with no change handler, so a native click flipped it before the
+  // <li> toggle ran; on a refusal Svelte saw no new value to write and the box stayed wrong
   test.each([
     // maxSelect 1 replaces rather than refuses, so a real refusal needs a full multi-select
     [
@@ -2270,7 +2259,6 @@ describe(`keepSelectedInDropdown feature`, () => {
 
       await focus_input()
 
-      // Toggle Apple off (selected → unselected)
       const apple_option = option_by_label(`Apple`)
       click_keep_selected_option(apple_option, mode)
       await tick()
@@ -2278,7 +2266,6 @@ describe(`keepSelectedInDropdown feature`, () => {
       expect(onChange_spy).toHaveBeenCalledWith({ option: `Apple`, type: `remove` })
       expect(apple_option?.classList.contains(`selected`)).toBe(false)
 
-      // Toggle Banana on (unselected → selected)
       const banana_option = option_by_label(`Banana`)
       click_keep_selected_option(banana_option, mode)
       await tick()
@@ -2291,8 +2278,7 @@ describe(`keepSelectedInDropdown feature`, () => {
   test.each(keep_selected_modes)(
     `keeps all options visible and styled selected when everything is selected in %s mode`,
     async (mode) => {
-      // the partially-selected case, where unselected rows must stay unstyled, is
-      // covered where only Apple is selected
+      // the partially-selected case is covered where only Apple is selected
       mount_multiselect({ options, selected: options, keepSelectedInDropdown: mode })
 
       await focus_input()
@@ -2322,14 +2308,14 @@ describe(`keepSelectedInDropdown feature`, () => {
 
       await focus_input()
 
-      // Remove Apple (should work as we'll still have Banana)
+      // removing Apple is allowed, Banana remains
       const apple_option = option_by_label(`Apple`)
       click_keep_selected_option(apple_option, mode)
       await tick()
 
       expect(apple_option?.classList.contains(`selected`)).toBe(false)
 
-      // Try to remove Banana as well – should be blocked by minSelect=1
+      // removing Banana too is blocked by minSelect=1
       const banana_option = option_by_label(`Banana`)
       click_keep_selected_option(banana_option, mode)
       await tick()
@@ -2423,7 +2409,7 @@ test.each(
     }
     mount_multiselect(props)
 
-    // create a state where no options match the search text
+    // no option matches this search text
     await type_search_text(`bar`)
 
     if (allowUserOptions && createOptionMsg) {
@@ -2497,9 +2483,8 @@ test.each([[true], [-1], [3.5], [`foo`], [{}]])(
   },
 )
 
-// A key outside 'selected' | 'option' used to appear here as two more rows, but the body
-// queries one list per key and so asserted nothing for them — same mount as the `option`
-// row, no expectation reached.
+// rows for a key outside 'selected' | 'option' asserted nothing: the body queries one list
+// per key, so they re-ran the `option` mount and reached no expectation
 test.each<[OptionStyle, `selected` | `option`, string]>([
   // String style cases
   [`color: red;`, `selected`, `color: red;`],
@@ -2787,7 +2772,7 @@ test(`Escape and Tab still blur input even with closeDropdownOnSelect='retain-fo
   input_el.focus()
   await tick()
 
-  // Escape should blur input (retain-focus only applies to selection, not keyboard closing)
+  // retain-focus applies to selection, not keyboard closing, so Escape blurs
   input_el.dispatchEvent(fresh_key(`Escape`))
 
   expect(document.activeElement).not.toBe(input_el)
@@ -3213,10 +3198,8 @@ describe(`selectAllOption feature`, () => {
   })
 })
 
-// value initializes selected for single (maxSelect=1) and multi-select (maxSelect=null)
-// alike, over string, number and object options. Each row carries its own maxSelect: a
-// shared describe.each over both crossed with every value shape spent half its runs
-// returning at a validity guard, reporting six passing tests that asserted nothing.
+// rows carry their own maxSelect: crossing a shared describe.each over both maxSelect modes
+// with every value shape spent half its runs returning at a validity guard, asserting nothing
 test.each<[1 | null, Option | Option[], Option[], string]>([
   [1, `Red`, [`Red`, `Green`, `Blue`], `Red`],
   [1, 1, [1, 2, 3], `1`],
@@ -3287,8 +3270,7 @@ describe(`binding update event count`, () => {
     },
   )
 
-  // This test catches the regression where value gets synced from null to []
-  // The bug: values_equal(null, []) returned false, causing value = [] assignment
+  // regression: values_equal(null, []) returned false, so value was synced from null to []
   test.each([null, 1])(
     `value binding with maxSelect=%s: no extra sync from null to [] on init`,
     async (maxSelect) => {
@@ -3368,10 +3350,8 @@ describe(`CSS static analysis`, () => {
     expect(options_block).toMatch(/--sms-options-bg,\s*light-dark\(#fcfcfc/u)
   })
 
-  // Guards the schemeless-dark-page readability fix: the primary text-bearing surfaces
-  // (root, input, dropdown) must pair their light-dark() background with a light-dark()
-  // text default, so the widget can't render white-on-white when the page never declares
-  // color-scheme (light-dark() → light).
+  // every text-bearing surface must pair its light-dark() background with a light-dark() text
+  // default, else a page that never declares color-scheme renders white-on-white
   test.each([
     [`div.multiselect root`, /:where\(div\.multiselect\)\s*\{(?<block>[\s\S]*?)\}/u],
     [
@@ -3417,10 +3397,9 @@ describe(`onsearch event`, () => {
 
     await type_search_text(`1`, input)
 
-    // Should not fire immediately due to debounce
     expect(onsearch_spy).not.toHaveBeenCalled()
 
-    // Advance timers past debounce (150ms)
+    // past the 150ms debounce
     await vi.advanceTimersByTimeAsync(200)
 
     expect(onsearch_spy).toHaveBeenCalledTimes(1)
@@ -3429,7 +3408,7 @@ describe(`onsearch event`, () => {
       matchingOptions: [1, 10],
     })
 
-    // Clear the search - should also fire
+    // clearing the search fires too
     await type_search_text(``, input)
     await vi.advanceTimersByTimeAsync(200)
 
@@ -3447,7 +3426,6 @@ describe(`onsearch event`, () => {
 
     await tick()
 
-    // Advance timers past the debounce period
     await vi.advanceTimersByTimeAsync(200)
 
     expect(onsearch_spy).not.toHaveBeenCalled()
@@ -3465,12 +3443,11 @@ describe(`onsearch event`, () => {
     // only part of the 150ms debounce, so nothing has fired yet
     await vi.advanceTimersByTimeAsync(100)
 
-    // Type another character before debounce completes
+    // another character before the debounce completes
     await type_search_text(`ap`, input)
 
     await vi.advanceTimersByTimeAsync(200)
 
-    // Should only fire once with final value
     expect(onsearch_spy).toHaveBeenCalledTimes(1)
     expect(onsearch_spy).toHaveBeenCalledWith({
       searchText: `ap`,
@@ -3525,8 +3502,7 @@ describe(`onmaxreached event`, () => {
       })
       const input = await focus_input()
 
-      // try to add a 3rd option when maxSelect is 2, via click or keyboard
-      // Fresh events avoid cross-test pollution from retained event flags.
+      // add a 3rd option past maxSelect=2; fresh events avoid retained defaultPrevented flags
       if (trigger === `keyboard`) {
         input.dispatchEvent(fresh_key(`ArrowDown`))
         input.dispatchEvent(fresh_key(`Enter`))
@@ -3587,9 +3563,8 @@ describe(`onduplicate event`, () => {
     expect(onduplicate_spy).not.toHaveBeenCalled()
   })
 
-  // Tests duplicate detection via allowUserOptions for both string and object options
-  // For object options, label-based detection fires even when keys differ (e.g., typing "Apple"
-  // when {label: "Apple", value: 1} is selected) - prevents confusing UX
+  // detection is label-based, so typing "Apple" hits a selected {label: "Apple", value: 1}
+  // even though the keys differ — otherwise the UX is confusing
   test.each<{
     desc: string
     options: Option[]
@@ -3640,8 +3615,7 @@ describe(`onduplicate event`, () => {
 
       await type_search_text(typed_value, input)
 
-      // Fresh Enter event per case: defaultPrevented persists across re-dispatch
-      // and would suppress later iterations.
+      // fresh Enter per case: defaultPrevented persists across re-dispatch
       input.dispatchEvent(fresh_key(`Enter`))
       await tick()
 
@@ -3665,12 +3639,11 @@ describe(`onduplicate event`, () => {
 
     const input = await focus_input()
 
-    // Type "1" which is a duplicate AND maxSelect is reached
+    // "1" is a duplicate and maxSelect is already reached
     await type_search_text(`1`, input)
     input.dispatchEvent(fresh_key(`Enter`))
     await tick()
 
-    // Both events should fire
     expect(onmaxreached_spy).toHaveBeenCalledTimes(1)
     expect(onduplicate_spy).toHaveBeenCalledTimes(1)
   })
@@ -3727,7 +3700,6 @@ describe(`onactivate event`, () => {
 
     const input = await focus_input()
 
-    // Navigate to last option
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
     input.dispatchEvent(fresh_key(`ArrowDown`))
@@ -3735,7 +3707,6 @@ describe(`onactivate event`, () => {
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
 
-    // One more ArrowDown should wrap to first
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
 
@@ -3745,9 +3716,8 @@ describe(`onactivate event`, () => {
   })
 
   test(`does not fire when toggling user message with no matching options`, async () => {
-    // When there are no matching options and only the user message is shown,
-    // arrow navigation toggles the user message active state but doesn't fire onactivate
-    // because the function returns early before reaching the onactivate call
+    // with only the user message shown, arrow navigation toggles its active state but returns
+    // early, before the onactivate call
     const onactivate_spy = vi.fn()
 
     mount_multiselect({
@@ -3760,7 +3730,6 @@ describe(`onactivate event`, () => {
 
     const input = await focus_input()
 
-    // Type something to show the user message
     await type_search_text(`new option`, input)
 
     input.dispatchEvent(fresh_key(`ArrowDown`))
@@ -3782,26 +3751,23 @@ describe(`onactivate event`, () => {
 
     const input = await focus_input()
 
-    // Navigate to first option (sets activeIndex = 0)
+    // sets activeIndex = 0
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
     expect(onactivate_spy).toHaveBeenCalledTimes(1)
     expect(onactivate_spy).toHaveBeenCalledWith({ option: 1, index: 0 })
 
-    // Type something that filters all options away
+    // filters every option away
     await type_search_text(`xyz`, input)
 
-    // Press ArrowDown again - should be a no-op since nothing to navigate
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
 
-    // Should only have 1 call (from first ArrowDown), not 2
     expect(onactivate_spy).toHaveBeenCalledTimes(1)
   })
 })
 
-// Regression test for issue #391: case-variant labels should not crash
-// https://github.com/janosh/svelte-widgets/issues/391
+// case-variant labels used to crash: https://github.com/janosh/svelte-widgets/issues/391
 describe(`case-variant labels (issue #391)`, () => {
   const object_options = [
     { label: `pd`, value: `uuid-1` },
@@ -3895,8 +3861,7 @@ describe(`duplicates prop variants`, () => {
   })
 
   test(`same-label dropdown options respect duplicate rules`, async () => {
-    // Issue: label check was blocking dropdown options even when values differ
-    // The is_from_options check should skip label-based duplicate detection for dropdown items
+    // the label check blocked dropdown options with differing values; is_from_options skips
     const options = [1, 2, 3].map((value) => ({
       label: `apple`,
       selectedTitle: `Already selected`,
@@ -3965,8 +3930,7 @@ test.each([
   [`empty string`, ``],
   [`out-of-range numeric prefix`, `42 items`],
   [`negative index`, `-1`],
-  // numeric page text passes parseInt — must still be rejected since no
-  // dragstart fired on this instance (foreign drag source)
+  // passes parseInt but no dragstart fired on this instance, so it is a foreign source
   [`valid-looking numeric text without dragstart`, `0`],
 ])(`drop with foreign/invalid drag data (%s) is a no-op`, async (_desc, drag_data) => {
   const onreorder_spy = vi.fn()

--- a/tests/vitest/MultiSelect.virtualList.svelte.test.ts
+++ b/tests/vitest/MultiSelect.virtualList.svelte.test.ts
@@ -106,7 +106,6 @@ describe(`virtualList`, () => {
     expect(doc_query(`ul.options li.active`).textContent?.trim()).toBe(
       `option ${n_presses - 1}`,
     )
-    // the window scrolled down: option 0 is no longer rendered
     expect(get_rendered_options()[0]?.textContent?.trim()).not.toBe(`option 0`)
     expect(get_rendered_options().length).toBeLessThan(50)
   })
@@ -157,16 +156,14 @@ describe(`virtualList`, () => {
     expect(top_spacer.style.height).toBe(`${15 * item_height}px`) // 15 rows above window
     expect(bottom_spacer.style.height).toBe(`${(55 - 39) * item_height}px`) // 16 below
 
-    // keyboard: first ArrowDown activates flat idx 0, whose ROW is 1 (the group 0
-    // header occupies row 0) — auto-scroll must clamp to the row offset, not the
-    // flat option index (which would scroll to 0)
+    // first ArrowDown activates flat idx 0, whose ROW is 1 (group 0's header is row 0) —
+    // auto-scroll must use the row offset, not the flat index (which would scroll to 0)
     const input = get_input()
     input.dispatchEvent(fresh_key(`ArrowDown`))
     await tick()
     expect(ul_options.scrollTop).toBe(item_height) // row 1 (header row 0 above it)
 
-    // 11 more presses reach flat idx 11 (group 1's 2nd option = "option 6", row 13),
-    // still inside the viewport window — active li must be rendered
+    // 11 more presses reach flat idx 11 ("option 6", row 13), still inside the window
     for (let press = 0; press < 11; press++) {
       input.dispatchEvent(fresh_key(`ArrowDown`))
       await tick()

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -59,7 +59,6 @@ describe(`Nav`, () => {
     assert(dropdown_menu !== null, `No dropdown menu found`)
     return { dropdown, dropdown_menu }
   }
-  // mounts a nav with a single dropdown and hands back the parts most tests need
   const mount_dropdown = (props: Partial<ComponentProps<typeof Nav>> = {}) => {
     mount_nav({ routes: single_dropdown_route, ...props })
     const { dropdown, dropdown_menu } = query_dropdown_elements()
@@ -67,7 +66,6 @@ describe(`Nav`, () => {
     assert(toggle !== null, `No dropdown toggle found`)
     return { dropdown, dropdown_menu, toggle }
   }
-  // all dropdowns with their submenus (for multi-dropdown tests)
   const query_all_dropdowns = () =>
     [...document.querySelectorAll(`.dropdown`)].map((dropdown) => {
       const menu = dropdown.querySelector<HTMLElement>(`[data-submenu]`)
@@ -228,8 +226,7 @@ describe(`Nav`, () => {
       add_listener.mock.calls.filter(([type]) => type === `pointerdown`).length
     const { dropdown_menu, toggle } = mount_dropdown()
     const burger_button = doc_query(`.burger`)
-    // with nothing open there is nothing to dismiss, so the document stays clean — that
-    // handler does a layout read (the scrollbar guard) for every press on the page
+    // nothing open means no listener: it does a layout read on every press on the page
     expect(press_listeners()).toBe(0)
 
     await click(burger_button)
@@ -247,8 +244,7 @@ describe(`Nav`, () => {
     expect(burger_button.getAttribute(`aria-expanded`)).toBe(`false`)
     expect(is_visible(dropdown_menu)).toBe(false)
 
-    // an open dropdown arms the listener on its own, with the burger menu shut: it is the
-    // only thing an outside click has to dismiss
+    // an open dropdown arms the listener on its own, with the burger menu shut
     const listeners_before = press_listeners()
     await click(toggle)
     expect(is_visible(dropdown_menu)).toBe(true)
@@ -287,7 +283,7 @@ describe(`Nav`, () => {
     mount_nav({ routes: [route], route_labels })
     const link = doc_query(`a[href="${route}"]`)
     expect(link.textContent?.trim()).toBe(expected)
-    // Test inline style since format_label intentionally sets text-transform
+    // format_label deliberately sets text-transform, but only for derived labels
     expect(link.getAttribute(`style`)).toBe(
       route_labels ? `` : `text-transform: capitalize;`,
     )
@@ -616,8 +612,7 @@ describe(`Nav`, () => {
       ]
       mount_nav({ routes })
       const dropdown = doc_query(`.dropdown`)
-      // `:scope` so these only match the dropdown's own row/submenu, not a nested wrapper
-      // that happens to be a first/last child too
+      // `:scope` so these match the dropdown's own row/submenu, not a nested wrapper
       const parent_span = dropdown.querySelector(
         `:scope > div:first-child > span.disabled`,
       )
@@ -787,9 +782,7 @@ describe(`Nav`, () => {
       expect(on_close).toHaveBeenCalledTimes(1)
     })
 
-    // No per-cause onclose test: the callback fires from one $effect watching is_open go
-    // true->false, which the burger case above covers, and `closes on Escape or link
-    // click` already pins those two causes reaching that transition.
+    // No per-cause onclose test: one $effect watches is_open go true->false, covered above.
   })
 
   describe(`breakpoint prop`, () => {
@@ -868,8 +861,7 @@ describe(`Nav`, () => {
       expect(is_visible(dropdown_menu)).toBe(false)
 
       await click(toggle)
-      // ...and moving off it used to close it again, so the synthetic mouseleave a tap
-      // emits could undo the tap
+      // ...and moving off used to close it, so a tap's synthetic mouseleave undid the tap
       mouse_leave(dropdown)
       await vi.advanceTimersByTimeAsync(500)
       expect(is_visible(dropdown_menu)).toBe(true)
@@ -923,8 +915,7 @@ describe(`Nav`, () => {
       await click(toggle)
       expect(is_visible(dropdown_menu)).toBe(true)
 
-      // ArrowDown navigates within the dropdown instead of closing it. toggle_dropdown
-      // focuses the first item in a setTimeout(..., 0), so flush a macrotask.
+      // ArrowDown navigates instead of closing; the focus move is in a setTimeout(.., 0)
       keydown(`ArrowDown`, toggle)
       await next_task()
       expect(is_visible(dropdown_menu)).toBe(true)
@@ -964,8 +955,7 @@ describe(`Nav`, () => {
       await click(doc_query(`[data-dropdown-toggle]`))
       expect(is_visible(dropdown_menu)).toBe(true)
 
-      // stays open whether focus moves inside the dropdown or out of it entirely
-      // (dropdowns close via click outside / Escape, not focusout)
+      // focus moving inside or fully out: dropdowns close on click-outside/Escape only
       for (const related of [
         dropdown_menu.querySelector(`a`),
         document.createElement(`button`),

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -18,8 +18,7 @@ describe(`Nav`, () => {
   // two submenu links, so Tab/ArrowDown have somewhere to move
   const two_child_route: NavRoute[] = [[`/p`, [`/p`, `/p/child1`, `/p/child2`]]]
   const one_child_route: NavRoute[] = [[`/p`, [`/p`, `/p/1`]]]
-  // no hover cooldown, so a menu still open afterward is open because it was pinned
-  const pinned_props = { routes: two_child_route, dropdown_cooldown_ms: 0 }
+  const two_child_props = { routes: two_child_route }
   const mount_nav = (props: ComponentProps<typeof Nav>) =>
     mount(Nav, { target: document.body, props })
   const click = (el?: Element | null) => {
@@ -227,7 +226,7 @@ describe(`Nav`, () => {
     const add_listener = vi.spyOn(document, `addEventListener`)
     const press_listeners = () =>
       add_listener.mock.calls.filter(([type]) => type === `pointerdown`).length
-    const { dropdown, dropdown_menu, toggle } = mount_dropdown()
+    const { dropdown_menu, toggle } = mount_dropdown()
     const burger_button = doc_query(`.burger`)
     // with nothing open there is nothing to dismiss, so the document stays clean — that
     // handler does a layout read (the scrollbar guard) for every press on the page
@@ -248,13 +247,12 @@ describe(`Nav`, () => {
     expect(burger_button.getAttribute(`aria-expanded`)).toBe(`false`)
     expect(is_visible(dropdown_menu)).toBe(false)
 
-    // a dropdown left open by hover alone must arm the listener too — on a touch device
-    // that state has nothing to close it
-    const listeners_before_hover = press_listeners()
-    mouse_enter(dropdown)
-    await tick()
+    // an open dropdown arms the listener on its own, with the burger menu shut: it is the
+    // only thing an outside click has to dismiss
+    const listeners_before = press_listeners()
+    await click(toggle)
     expect(is_visible(dropdown_menu)).toBe(true)
-    expect(press_listeners()).toBe(listeners_before_hover + 1)
+    expect(press_listeners()).toBe(listeners_before + 1)
     await click_outside()
     expect(is_visible(dropdown_menu)).toBe(false)
   })
@@ -407,18 +405,26 @@ describe(`Nav`, () => {
     expect(link_props.onkeydown).toHaveBeenCalledTimes(5)
   })
 
-  test(`dropdown focus behavior`, async () => {
-    const { dropdown, dropdown_menu: menu } = mount_dropdown({ routes: one_child_route })
+  test(`focus alone neither opens nor closes a dropdown`, async () => {
+    const {
+      dropdown,
+      dropdown_menu: menu,
+      toggle,
+    } = mount_dropdown({
+      routes: one_child_route,
+    })
 
-    focus_in(dropdown)
+    focus_in(dropdown) // tabbing through the nav must not pop panels open
     await tick()
-    expect(is_visible(menu)).toBe(true)
+    expect(is_visible(menu)).toBe(false)
 
+    await click(toggle)
     const external = document.createElement(`button`)
     document.body.append(external)
     focus_out(dropdown, external)
     await tick()
-    expect(is_visible(menu)).toBe(false)
+    // what a click opened, only a click (on the toggle or outside) or Escape closes
+    expect(is_visible(menu)).toBe(true)
     external.remove()
   })
 
@@ -610,12 +616,16 @@ describe(`Nav`, () => {
       ]
       mount_nav({ routes })
       const dropdown = doc_query(`.dropdown`)
-      const parent_span = dropdown.querySelector(`div:first-child > span.disabled`)
+      // `:scope` so these only match the dropdown's own row/submenu, not a nested wrapper
+      // that happens to be a first/last child too
+      const parent_span = dropdown.querySelector(
+        `:scope > div:first-child > span.disabled`,
+      )
       expect(parent_span?.getAttribute(`aria-disabled`)).toBe(`true`)
-      expect(dropdown.querySelector(`div:first-child > a`)).toBeNull() // no parent link
+      expect(dropdown.querySelector(`:scope > div:first-child > a`)).toBeNull() // no parent link
       // dropdown children stay accessible
       expect(
-        dropdown.querySelector(`div:last-child`)?.querySelectorAll(`a`),
+        dropdown.querySelector(`:scope > div:last-child`)?.querySelectorAll(`a`),
       ).toHaveLength(1)
     })
   })
@@ -832,108 +842,38 @@ describe(`Nav`, () => {
     expect(document.querySelectorAll(`.dropdown`)).toHaveLength(1)
   })
 
-  describe(`pinned dropdown feature`, () => {
-    test(`click toggles pinned state and aria-expanded`, async () => {
-      // cooldown 0 so an unpinned dropdown would hide within one macrotask
-      const { dropdown, dropdown_menu, toggle } = mount_dropdown({
-        dropdown_cooldown_ms: 0,
-      })
+  describe(`dropdowns open on click, never on hover`, () => {
+    test(`click toggles the dropdown and aria-expanded`, async () => {
+      const { dropdown_menu, toggle } = mount_dropdown()
 
       expect(is_visible(dropdown_menu)).toBe(false)
       expect(toggle.getAttribute(`aria-expanded`)).toBe(`false`)
 
-      await click(toggle) // pin open
+      await click(toggle)
       expect(is_visible(dropdown_menu)).toBe(true)
       expect(toggle.getAttribute(`aria-expanded`)).toBe(`true`)
 
-      mouse_leave(dropdown) // stays open when pinned
-      await next_task()
-      expect(is_visible(dropdown_menu)).toBe(true)
-      expect(toggle.getAttribute(`aria-expanded`)).toBe(`true`)
-
-      await click(toggle) // unpin
+      await click(toggle)
       expect(is_visible(dropdown_menu)).toBe(false)
       expect(toggle.getAttribute(`aria-expanded`)).toBe(`false`)
     })
 
-    describe(`dropdown_cooldown_ms`, () => {
-      beforeEach(() => vi.useFakeTimers())
-      afterEach(() => vi.useRealTimers())
+    test(`hover neither opens nor closes a dropdown`, async () => {
+      vi.useFakeTimers()
+      const { dropdown, dropdown_menu, toggle } = mount_dropdown()
 
-      test(`cooldown closes only after the full timeout`, async () => {
-        const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown_ms: 100 })
+      // pointing at a nav entry used to pop its panel open over the page
+      mouse_enter(dropdown)
+      await vi.advanceTimersByTimeAsync(500)
+      expect(is_visible(dropdown_menu)).toBe(false)
 
-        mouse_enter(dropdown)
-        await tick()
-        expect(is_visible(dropdown_menu)).toBe(true)
-
-        mouse_leave(dropdown)
-        await vi.advanceTimersByTimeAsync(99)
-        expect(is_visible(dropdown_menu)).toBe(true)
-        await vi.advanceTimersByTimeAsync(1)
-        expect(is_visible(dropdown_menu)).toBe(false)
-      })
-
-      test(`multiple rapid enter/leave cycles reset cooldown each time`, async () => {
-        const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown_ms: 100 })
-
-        for (let idx = 0; idx < 3; idx++) {
-          mouse_enter(dropdown)
-          // deno-lint-ignore no-await-in-loop
-          await tick()
-          mouse_leave(dropdown)
-          // deno-lint-ignore no-await-in-loop
-          await vi.advanceTimersByTimeAsync(50)
-          expect(is_visible(dropdown_menu)).toBe(true)
-        }
-        await vi.advanceTimersByTimeAsync(51)
-        expect(is_visible(dropdown_menu)).toBe(false)
-      })
-
-      test.each([
-        [`re-entering menu`, (_dropdown: Element, menu: Element) => mouse_enter(menu)],
-        [`keyboard focus`, (dropdown: Element) => focus_in(dropdown)],
-      ])(`%s during cooldown cancels hide`, async (_desc, reinteract) => {
-        const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown_ms: 150 })
-
-        mouse_enter(dropdown)
-        await tick()
-        mouse_leave(dropdown)
-        await vi.advanceTimersByTimeAsync(50)
-
-        reinteract(dropdown, dropdown_menu)
-        await vi.advanceTimersByTimeAsync(200)
-        expect(is_visible(dropdown_menu)).toBe(true)
-      })
-
-      test(`switching between multiple dropdowns respects cooldown`, async () => {
-        mount_nav({ routes: two_dropdown_routes, dropdown_cooldown_ms: 100 })
-        const [
-          { dropdown: dropdown1, menu: menu1 },
-          { dropdown: dropdown2, menu: menu2 },
-        ] = query_all_dropdowns()
-
-        mouse_enter(dropdown1)
-        await tick()
-        expect(is_visible(menu1)).toBe(true)
-
-        mouse_leave(dropdown1)
-        await vi.advanceTimersByTimeAsync(30)
-        mouse_enter(dropdown2)
-        await tick()
-
-        expect([is_visible(menu2), is_visible(menu1)]).toEqual([true, false]) // switches at once
-
-        // dropdown1's pending hide must not take dropdown2 down with it
-        await vi.advanceTimersByTimeAsync(100)
-        expect([is_visible(menu2), is_visible(menu1)]).toEqual([true, false])
-
-        mouse_leave(dropdown2) // leaving starts a fresh full cooldown
-        await vi.advanceTimersByTimeAsync(99)
-        expect(is_visible(menu2)).toBe(true)
-        await vi.advanceTimersByTimeAsync(1)
-        expect(is_visible(menu2)).toBe(false)
-      })
+      await click(toggle)
+      // ...and moving off it used to close it again, so the synthetic mouseleave a tap
+      // emits could undo the tap
+      mouse_leave(dropdown)
+      await vi.advanceTimersByTimeAsync(500)
+      expect(is_visible(dropdown_menu)).toBe(true)
+      vi.useRealTimers()
     })
 
     test.each([
@@ -945,7 +885,7 @@ describe(`Nav`, () => {
         },
       ],
       [`Escape key`, escape],
-    ])(`pinned dropdown closes on %s`, async (_trigger, close_action) => {
+    ])(`an open dropdown closes on %s`, async (_trigger, close_action) => {
       const { dropdown_menu, toggle } = mount_dropdown()
       await click(toggle)
       expect(is_visible(dropdown_menu)).toBe(true)
@@ -953,14 +893,8 @@ describe(`Nav`, () => {
       expect(is_visible(dropdown_menu)).toBe(false)
     })
 
-    // hover → open_dropdown; click → toggle_dropdown — both clear the other pin
-    test.each([
-      [`hover`, (dropdown: Element) => mouse_enter(dropdown)],
-      [
-        `click toggle`,
-        (dropdown: Element) => click(dropdown.querySelector(`[data-dropdown-toggle]`)),
-      ],
-    ])(`%s on different dropdown closes pinned dropdown`, async (_method, activate) => {
+    // one dropdown at a time: opening the second has to close the first
+    test(`opening a second dropdown closes the first`, async () => {
       mount_nav({ routes: two_dropdown_routes })
       const [{ dropdown: dropdown1, menu: menu1 }, { dropdown: dropdown2, menu: menu2 }] =
         query_all_dropdowns()
@@ -968,35 +902,25 @@ describe(`Nav`, () => {
       await click(dropdown1.querySelector(`[data-dropdown-toggle]`))
       expect(is_visible(menu1)).toBe(true)
 
-      await activate(dropdown2)
-      await tick()
+      await click(dropdown2.querySelector(`[data-dropdown-toggle]`))
       expect(is_visible(menu1)).toBe(false)
       expect(is_visible(menu2)).toBe(true)
     })
 
     // Enter/Space share one branch; ArrowDown opens when closed via another
-    test.each([`Enter`, `ArrowDown`])(`keyboard %s pins dropdown open`, async (key) => {
-      const { dropdown, dropdown_menu, toggle } = mount_dropdown({
-        dropdown_cooldown_ms: 0,
-      })
+    test.each([`Enter`, `ArrowDown`])(`keyboard %s opens the dropdown`, async (key) => {
+      const { dropdown_menu, toggle } = mount_dropdown()
 
       keydown(key, toggle)
       await next_task()
       expect(is_visible(dropdown_menu)).toBe(true)
       expect(toggle.getAttribute(`aria-expanded`)).toBe(`true`)
-
-      mouse_leave(dropdown)
-      await next_task()
-      expect(is_visible(dropdown_menu)).toBe(true)
     })
 
-    test(`ArrowDown navigates within pinned dropdown after mouse leave`, async () => {
-      const { dropdown, dropdown_menu, toggle } = mount_dropdown(pinned_props)
+    test(`ArrowDown on the toggle of an open dropdown navigates into it`, async () => {
+      const { dropdown_menu, toggle } = mount_dropdown(two_child_props)
 
-      await click(toggle) // pin open, then leave with the mouse
-      expect(is_visible(dropdown_menu)).toBe(true)
-      mouse_leave(dropdown)
-      await next_task()
+      await click(toggle)
       expect(is_visible(dropdown_menu)).toBe(true)
 
       // ArrowDown navigates within the dropdown instead of closing it. toggle_dropdown
@@ -1008,7 +932,7 @@ describe(`Nav`, () => {
     })
 
     test(`Escape on a submenu link closes it for good and restores focus`, async () => {
-      const { dropdown_menu, toggle } = mount_dropdown(pinned_props)
+      const { dropdown_menu, toggle } = mount_dropdown(two_child_props)
 
       await click(toggle)
       const first_link = doc_query<HTMLAnchorElement>(`[data-submenu] a`)
@@ -1017,12 +941,11 @@ describe(`Nav`, () => {
       await next_task()
 
       expect(document.activeElement).toBe(toggle)
-      // handing focus back lands on the toggle, whose focusin must not reopen it
       expect(is_visible(dropdown_menu)).toBe(false)
     })
 
-    test(`Tab cycles within a pinned submenu instead of leaving it`, async () => {
-      const { dropdown_menu } = mount_dropdown(pinned_props)
+    test(`Tab cycles within an open submenu instead of leaving it`, async () => {
+      const { dropdown_menu } = mount_dropdown(two_child_props)
 
       await click(doc_query(`[data-dropdown-toggle]`))
       const links = [...dropdown_menu.querySelectorAll(`a`)]
@@ -1035,14 +958,14 @@ describe(`Nav`, () => {
       expect(document.activeElement).toBe(links[0])
     })
 
-    test(`pinned dropdown stays open on focus out`, async () => {
+    test(`an open dropdown stays open on focus out`, async () => {
       const { dropdown, dropdown_menu } = mount_dropdown({ routes: two_child_route })
 
       await click(doc_query(`[data-dropdown-toggle]`))
       expect(is_visible(dropdown_menu)).toBe(true)
 
       // stays open whether focus moves inside the dropdown or out of it entirely
-      // (pinned dropdowns close via click outside / Escape, not focusout)
+      // (dropdowns close via click outside / Escape, not focusout)
       for (const related of [
         dropdown_menu.querySelector(`a`),
         document.createElement(`button`),
@@ -1054,7 +977,7 @@ describe(`Nav`, () => {
       }
     })
 
-    test(`pinned state clears when burger menu closes`, async () => {
+    test(`open dropdown clears when burger menu closes`, async () => {
       set_window_width(500)
       const { dropdown_menu, toggle } = mount_dropdown({ breakpoint: 767 })
       await tick()
@@ -1085,62 +1008,6 @@ describe(`Nav`, () => {
       expect(
         [...document.querySelectorAll(`a`)].map((link) => link.getAttribute(`href`)),
       ).toEqual(routes.map((route) => route.href))
-    })
-  })
-
-  // Regression: dropdown panel mouseleave should not close when mouse moves to trigger
-  describe(`dropdown panel mouseleave relatedTarget`, () => {
-    beforeEach(() => vi.useFakeTimers())
-    afterEach(() => vi.useRealTimers())
-
-    // Open dropdown and enter the panel, returning elements for assertions
-    const open_and_enter_panel = async () => {
-      const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown_ms: 50 })
-      mouse_enter(dropdown)
-      await tick()
-      mouse_enter(dropdown_menu)
-      await tick()
-      return { dropdown, dropdown_menu }
-    }
-
-    test.each([`div:first-child`, `[data-dropdown-toggle]`])(
-      `panel stays open when mouse moves to %s within dropdown`,
-      async (selector) => {
-        const { dropdown, dropdown_menu } = await open_and_enter_panel()
-        const related = dropdown.querySelector<HTMLElement>(selector)
-        dropdown_menu.dispatchEvent(
-          new MouseEvent(`mouseleave`, { relatedTarget: related }),
-        )
-        await vi.advanceTimersByTimeAsync(200)
-        expect(is_visible(dropdown_menu)).toBe(true)
-      },
-    )
-
-    test.each([
-      [`external element`, document.createElement(`div`)],
-      [`null (mouse left window)`, null],
-    ])(`panel closes when mouse leaves to %s`, async (_desc, related_target) => {
-      const { dropdown_menu } = await open_and_enter_panel()
-      dropdown_menu.dispatchEvent(
-        new MouseEvent(`mouseleave`, { relatedTarget: related_target }),
-      )
-      await vi.advanceTimersByTimeAsync(100)
-      expect(is_visible(dropdown_menu)).toBe(false)
-    })
-
-    test(`panel closes when mouse moves to a different dropdown`, async () => {
-      mount_nav({ routes: two_dropdown_routes, dropdown_cooldown_ms: 50 })
-      const [{ dropdown: dropdown1, menu: menu1 }, { dropdown: dropdown2 }] =
-        query_all_dropdowns()
-      const other_trigger = dropdown2.querySelector<HTMLElement>(`div:first-child`)
-
-      mouse_enter(dropdown1)
-      await tick()
-      mouse_enter(menu1)
-      await tick()
-      menu1.dispatchEvent(new MouseEvent(`mouseleave`, { relatedTarget: other_trigger }))
-      await vi.advanceTimersByTimeAsync(100)
-      expect(is_visible(menu1)).toBe(false)
     })
   })
 
@@ -1200,63 +1067,6 @@ describe(`Nav`, () => {
       expect(doc_query(`.custom-tooltip`).getAttribute(`data-placement`)).toBe(`right`)
       // per-route arrow option wins over the shared setting
       expect(document.querySelector(`.custom-tooltip-arrow`)).toBeNull()
-    })
-  })
-
-  describe(`touch device guards`, () => {
-    afterEach(() => vi.unstubAllGlobals())
-
-    test(`mouse hover does not open dropdowns on mobile touch devices`, async () => {
-      vi.stubGlobal(`ontouchstart`, () => {}) // makes `ontouchstart` in globalThis true
-      set_window_width(500)
-      const { dropdown, dropdown_menu, toggle } = mount_dropdown()
-      await tick()
-
-      mouse_enter(dropdown)
-      await tick()
-      expect(is_visible(dropdown_menu)).toBe(false)
-
-      // explicit toggle click still opens the dropdown on touch devices
-      await click(toggle)
-      expect(is_visible(dropdown_menu)).toBe(true)
-    })
-
-    // A touchscreen laptop reports touch support at desktop width, where the pointer is
-    // still a mouse: hover opens the dropdown, so hover has to be able to close it again.
-    // Suppressing the hide on touch support alone stranded it open until a click outside.
-    test(`a hover-opened dropdown still closes on a touch-capable desktop`, async () => {
-      vi.useFakeTimers()
-      vi.stubGlobal(`ontouchstart`, () => {})
-      const { dropdown, dropdown_menu } = mount_dropdown({ dropdown_cooldown_ms: 0 })
-      await tick()
-
-      mouse_enter(dropdown)
-      await tick()
-      expect(is_visible(dropdown_menu)).toBe(true)
-
-      mouse_leave(dropdown)
-      await vi.advanceTimersByTimeAsync(500)
-      expect(is_visible(dropdown_menu)).toBe(false)
-      vi.useRealTimers()
-    })
-
-    // What the touch guard was really protecting: a tap pins the dropdown, and the
-    // synthetic mouseleave that follows it must not undo the tap.
-    test(`a tap-pinned dropdown survives the mouseleave that follows the tap`, async () => {
-      vi.useFakeTimers()
-      vi.stubGlobal(`ontouchstart`, () => {})
-      const { dropdown, dropdown_menu, toggle } = mount_dropdown({
-        dropdown_cooldown_ms: 0,
-      })
-      await tick()
-
-      await click(toggle)
-      expect(is_visible(dropdown_menu)).toBe(true)
-
-      mouse_leave(dropdown)
-      await vi.advanceTimersByTimeAsync(500)
-      expect(is_visible(dropdown_menu)).toBe(true)
-      vi.useRealTimers()
     })
   })
 })

--- a/tests/vitest/NumberRangeInput.svelte.test.ts
+++ b/tests/vitest/NumberRangeInput.svelte.test.ts
@@ -41,8 +41,8 @@ describe(`NumberRangeInput`, () => {
     expect(number.valueAsNumber).toBe(0.3)
   })
 
-  // The wrapping <label> only names its first control, so the range always carries an explicit
-  // name. Without children that label is empty, leaving the number input unnamed as well.
+  // a wrapping <label> names only its first control, so the range needs an explicit name;
+  // without children the label is empty and the number input goes unnamed too
   test.each([
     [`children name the number input`, { children: label_snippet }, null, `Atom radius`],
     [`a bare title names both inputs`, {}, `Atom radius`, `Atom radius`],

--- a/tests/vitest/Popover.svelte.test.ts
+++ b/tests/vitest/Popover.svelte.test.ts
@@ -7,8 +7,8 @@ import TestPopover from './TestPopover.svelte'
 
 describe(`Popover`, () => {
   type PopoverProps = Omit<ComponentProps<typeof Popover>, `children`>
-  // click_outside and focus_trap register document listeners that outlive
-  // document.body.innerHTML = '', so unmount for real between cases
+  // click_outside and focus_trap leave document listeners that outlive innerHTML = '',
+  // so unmount for real between cases
   const mounted: Record<string, unknown>[] = []
   afterEach(async () => {
     await Promise.all(mounted.splice(0).map((app) => unmount(app)))
@@ -77,8 +77,8 @@ describe(`Popover`, () => {
     },
   )
 
-  // The wrapper around the trigger snippet is `display: contents` and measures 0x0,
-  // so anchoring to it would pin every popover to the viewport corner
+  // the trigger wrapper is `display: contents` and measures 0x0, so anchoring to it
+  // would pin every popover to the viewport corner
   test(`positions against the trigger, not the wrapper around it`, async () => {
     mount_popover({ offset: 8 })
     const rect = { top: 20, bottom: 50, left: 100, right: 200, width: 100, height: 30 }
@@ -260,9 +260,8 @@ describe(`Popover`, () => {
     expect(surface()).not.toBeNull()
   })
 
-  // Removing a focused surface delivers no focusout, and focus_trap then hands focus
-  // back to the trigger. Without dropping the stale focus state on close, that focusin
-  // reopens what was just dismissed.
+  // removing a focused surface delivers no focusout, so focus_trap's handback to the
+  // trigger reopens what was dismissed unless close drops the stale focus state
   test(`hover dismissal with focus inside stays closed`, async () => {
     vi.useFakeTimers()
     const props = mount_popover({ trigger_mode: `hover`, close_delay_ms: 10 })
@@ -277,8 +276,8 @@ describe(`Popover`, () => {
     expect(surface()).toBeNull()
   })
 
-  // Same stale state seen from the other side: with nothing to restore focus to, a later
-  // hover cycle must still close on mouseleave instead of waiting on a focus that left.
+  // same stale state from the other side: with nothing to restore focus to, a later hover
+  // cycle must still close on mouseleave rather than wait on a focus that left
   test(`hover-out still closes after a dismissal that stranded focus`, async () => {
     vi.useFakeTimers()
     const props = mount_popover({
@@ -333,8 +332,8 @@ describe(`Popover`, () => {
     await close_and_expect_focus(next_opener)
   })
 
-  // A torn-down component cannot render a surface either way, so asserting on the DOM
-  // alone cannot tell a canceled timer from one that still fires. Watch the timer id.
+  // a torn-down component renders no surface either way, so only the timer id tells a
+  // canceled timer from one that still fires
   test(`unmount cancels a pending delayed open`, async () => {
     vi.useFakeTimers()
     mount_popover({ trigger_mode: `hover`, open_delay_ms: 50 })

--- a/tests/vitest/SettingsSearch.svelte.test.ts
+++ b/tests/vitest/SettingsSearch.svelte.test.ts
@@ -132,8 +132,8 @@ describe(`SettingsSearch`, () => {
     expect(filtered_out(appearance)).toBe(false)
     expect(filtered_out(setting_row(`atom_radius`))).toBe(true)
 
-    // Camera starts collapsed; search opens it, and typing on must not drop that state — not
-    // even for an instant, which is what re-running the whole attachment per keystroke did.
+    // search opens the collapsed Camera section; typing on must not drop that state, not
+    // an instant, which is what re-running the whole attachment per keystroke did
     await set_query(input, `damping`)
     expect(camera.open).toBe(true)
     const open_writes: boolean[] = []
@@ -173,8 +173,8 @@ describe(`SettingsSearch`, () => {
     expect(filtered_out(setting_row(`zoom_speed`))).toBe(false)
   })
 
-  // Rows nest when a keyed wrapper holds keyed rows. A hit on either end keeps the whole
-  // group on screen, so a wrapper matched by its own label never hides its children.
+  // rows nest when a keyed wrapper holds keyed rows: a hit on either end keeps the group,
+  // so a wrapper matched by its own label never hides its children
   test(`keeps nested rows visible when either end of the nesting matches`, async () => {
     const { input } = await mounted_search()
 
@@ -187,9 +187,8 @@ describe(`SettingsSearch`, () => {
     expect(filtered_out(setting_row(`rotation_x`))).toBe(true)
   })
 
-  // Emptying the query must never collapse the field under the cursor, however it was opened
-  // and however it is cleared. Deriving the open state from `query` alone breaks the first
-  // case; unmounting the clear button without rehoming focus breaks the second.
+  // emptying the query must never collapse the field under the cursor: deriving open
+  // state from `query` alone breaks the first case, dropping focus on clear the second
   test.each([
     {
       name: `opened by the trigger and cleared by typing`,
@@ -250,7 +249,7 @@ describe(`SettingsSearch`, () => {
     expect(input.value).toBe(``)
     // the button unmounts on clear, so focus has to land back in the field
     expect(document.activeElement).toBe(input)
-    // The mounted, visible live-region node stays observable while its text clears.
+    // the live region stays mounted and visible while its text clears
     expect(document.querySelector(`[role="status"]`)).toBe(status)
     expect(status.hidden).toBe(false)
     expect(status.textContent).toBe(``)

--- a/tests/vitest/SettingsSearchHarness.svelte
+++ b/tests/vitest/SettingsSearchHarness.svelte
@@ -2,8 +2,8 @@
   import { SettingsGroup, SettingsSearch, SettingsSection } from '$lib'
   import { untrack } from 'svelte'
 
-  // Seeds the field the way a restored session or a deep link would, without the user
-  // ever touching the trigger. Owned here so the component's writes land somewhere live.
+  // seeds the field like a restored session or deep link would, and owns `query` so the
+  // component's writes land somewhere live
   let {
     trigger = `inline`,
     initial_query = ``,

--- a/tests/vitest/SettingsSection.svelte.test.ts
+++ b/tests/vitest/SettingsSection.svelte.test.ts
@@ -297,8 +297,8 @@ describe(`SettingsSection`, () => {
     expect(document.querySelectorAll(`.settings-row-description`)).toHaveLength(0)
   })
 
-  // `explain` and `reset_section` overridden, `explain_toggle` and `reset` omitted, so
-  // both halves of the merge are exercised. The interpolating default lowercases the title.
+  // two keys overridden, two omitted, so both halves of the merge run; the interpolating
+  // default lowercases the title
   test(`labels reword the heading actions, key by key`, async () => {
     mount_section({
       title: `Atoms`,
@@ -356,9 +356,8 @@ describe(`SettingsSection`, () => {
     )
   })
 
-  // The row's own description was snapshotted once at mount and written back on every
-  // refresh, so a caller updating a reactive `data-description` had their new text
-  // reverted, and a caller adding the attribute later had it deleted outright.
+  // the description used to be snapshotted at mount and written back on every refresh, so
+  // caller's later `data-description` was reverted (or deleted, if added after mount)
   test(`follows a caller's later data-description instead of restoring the mount-time one`, async () => {
     mount_section({
       title: `Atoms`,
@@ -444,8 +443,8 @@ describe(`SettingsSection`, () => {
       expect(settings_row()?.querySelectorAll(`.setting-reset-button`)).toHaveLength(1)
     }
 
-    // An unrelated row's enhancements survive as the same nodes: a value edit re-enhances
-    // in place rather than tearing every description and reset button off and back on.
+    // same nodes, not replacements: a value edit re-enhances in place instead of tearing
+    // every description and reset button off and back on
     const palette_description = doc_query(
       `[data-key="palette"] .settings-row-description`,
     )

--- a/tests/vitest/SubpageGrid.test.ts
+++ b/tests/vitest/SubpageGrid.test.ts
@@ -54,8 +54,7 @@ test(`overview pages link to base-prefixed sibling routes`, () => {
   const hrefs = [...document.querySelectorAll(`nav.grid a`)].map((link) =>
     link.getAttribute(`href`),
   )
-  // every link goes through resolve() so it picks up the base path, and the grid is
-  // non-empty. Listing exact routes here would break every time a demo moves.
+  // listing exact routes would break every time a demo moves, so only pin the base prefix
   expect(hrefs.length).toBeGreaterThan(5)
   expect(hrefs.every((href) => href?.startsWith(`/docs/`))).toBe(true)
   expect(hrefs).toContain(`/docs/form`)

--- a/tests/vitest/ThemeToggle.test.ts
+++ b/tests/vitest/ThemeToggle.test.ts
@@ -187,8 +187,8 @@ test(`tooltip=false preserves the native title`, async () => {
   expect(button.getAttribute(`title`)).toBe(`Switch to dark theme`)
 })
 
-// The mode name varies with state, so a caller pinning a static title/aria-label through
-// `rest` loses that variation. `labels` translates the frame and the three mode names.
+// a static title pinned through `rest` loses the per-mode wording, so `labels` translates
+// both the frame and the three mode names
 test(`labels reword the title, mode names included`, async () => {
   localStorage.setItem(`theme`, `system`) // cycles system -> dark -> light
   const button = await mount_theme_toggle({

--- a/tests/vitest/attachments/click-outside.test.ts
+++ b/tests/vitest/attachments/click-outside.test.ts
@@ -9,10 +9,9 @@ describe(`click_outside`, () => {
     kind = `pointerdown`,
     init: PointerEventInit = {},
   ) => {
-    // a real PointerEvent so the scrollbar guard (MouseEvent-only) actually runs here, and
-    // primary by default because the constructor's own default reads as a second finger.
-    // A click gets detail: 1, which is how the dismissal tells a pointer click from a
-    // keyboard or programmatic one — a bare Event would be judged as the latter.
+    // PointerEvent so the MouseEvent-only scrollbar guard runs; isPrimary because the
+    // constructor defaults to a second finger. detail: 1 marks a click as pointer-driven,
+    // which is how dismissal tells it from a keyboard or programmatic one.
     const event = kind.startsWith(`pointer`)
       ? new PointerEvent(kind, { bubbles: true, isPrimary: true, ...init })
       : new MouseEvent(kind, { bubbles: true, detail: 1, ...init })
@@ -34,12 +33,10 @@ describe(`click_outside`, () => {
     return event
   }
 
-  // document.body.innerHTML = '' leaves click_outside's document capture listeners
-  // and Escape layers behind, which would decide later tests' assertions
+  // innerHTML = '' would leave document capture listeners and Escape layers behind
   const cleanups: (() => void)[] = []
   afterEach(() => cleanups.splice(0).forEach((cleanup) => cleanup()))
 
-  // attaches click_outside to a fresh element wired to a spy callback
   const attach_outside = (config: Parameters<typeof click_outside>[0] = {}) => {
     const element = create_element()
     const callback = vi.fn()
@@ -120,9 +117,8 @@ describe(`click_outside`, () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  // Same selector, another instance's trigger: it must not shield this surface. The
-  // function form is resolved per press, for a `bind:this` still null at setup — a
-  // plain `scope` prop would have been captured null forever.
+  // same selector, another instance's trigger: it must not shield this surface. The
+  // function form resolves per press, for a `bind:this` still null at setup.
   it.each([`element`, `function`] as const)(
     `scope as %s confines inside selectors to one subtree`,
     (kind) => {
@@ -204,7 +200,7 @@ describe(`click_outside`, () => {
   it(`ignores a press on the page scrollbar`, () => {
     const { callback } = attach_outside()
 
-    // no layout in the test DOM, so give the root a client box the gutter sits outside of
+    // no layout in the test DOM, so give the root a client box the gutter sits outside
     const root = document.documentElement
     cleanups.push(
       stub_prop(root, `clientWidth`, 800),
@@ -223,14 +219,13 @@ describe(`click_outside`, () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  // The rect is the border box but clientWidth/Height are the padding box, so the gutter
-  // starts a border in from where the rect alone suggests. Getting that wrong swallows
-  // presses on the last border-width of content in any bordered scroller.
+  // the rect is the border box but clientWidth/Height the padding box, so the gutter starts
+  // a border in; getting it wrong swallows presses on the last border-width of content
   it(`locates a scroller's gutter past its border, not at its rect edge`, () => {
     const { callback } = attach_outside()
     const scroller = create_element()
-    // Border box wide enough to hold border + scrollport + a 15px gutter on each axis, so
-    // every press below lands inside it the way a real hit test would deliver them.
+    // border box wide enough for border + scrollport + a 15px gutter on each axis, so
+    // every press below lands inside it as a real hit test would deliver it
     mock_rect(scroller, { left: 100, top: 50, width: 225, height: 125 })
     cleanups.push(
       stub_prop(scroller, `clientLeft`, 10), // a 10px border, then...
@@ -247,7 +242,7 @@ describe(`click_outside`, () => {
     press(150, 165) // horizontal gutter
     expect(callback).not.toHaveBeenCalled()
 
-    // Inside both gutters but outside the border-box-only reading of them
+    // inside both gutters but outside the border-box-only reading of them
     press(305, 155)
     expect(callback).toHaveBeenCalledTimes(1)
   })
@@ -264,8 +259,8 @@ describe(`click_outside`, () => {
   })
 
   it(`tolerates an empty inside selector instead of throwing on every press`, () => {
-    // a trailing empty entry makes the joined selector invalid, which would throw
-    // out of the capture listener for every press anywhere on the page
+    // a trailing empty entry makes the joined selector invalid, which would throw out of
+    // the capture listener on every press anywhere on the page
     const { callback, cleanup } = attach_outside({ inside: [`.modal`, ``] })
 
     expect(() => dispatch_press(create_element())).not.toThrow()
@@ -288,8 +283,8 @@ describe(`click_outside`, () => {
     cleanup?.()
   })
 
-  // A surface living inside a shadow tree: document.activeElement reports the host,
-  // which the surface does not contain, so only descending the chain finds the focus
+  // for a surface in a shadow tree, document.activeElement reports the host, which the
+  // surface does not contain, so only descending the chain finds the focus
   it(`escape sees focus on a node that shares the surface's shadow tree`, () => {
     const host = create_element()
     const [surface, inner] = [
@@ -312,9 +307,9 @@ describe(`click_outside`, () => {
     })
   })
 
-  // Dragging or resizing the surface can release past its edge, and the browser then
-  // reports the click on a common ancestor — outside. Only a gesture that both starts
-  // and ends outside is a dismissal, else a resize would close what it was resizing.
+  // a drag or resize can release past the surface's edge, where the browser reports the
+  // click on a common ancestor. Only a gesture starting and ending outside is a dismissal,
+  // else a resize would close what it was resizing.
   it(`dismiss_on: 'release' waits for clicks and ignores gestures started inside`, () => {
     const { element, callback } = attach_outside({ dismiss_on: `release` })
     const outside = create_element()
@@ -333,8 +328,7 @@ describe(`click_outside`, () => {
     dispatch_press(create_element(), [], `click`)
     expect(callback).toHaveBeenCalledTimes(1)
 
-    // the OS claiming a gesture ends it without a click, so that verdict must not linger
-    // for the next click either
+    // an OS-claimed gesture ends without a click, so that verdict must not linger either
     dispatch_press(element)
     dispatch_press(element, [], `pointercancel`)
     dispatch_press(create_element(), [], `click`)
@@ -346,9 +340,8 @@ describe(`click_outside`, () => {
     expect(callback).toHaveBeenCalledTimes(3)
   })
 
-  // A press inside can end without any click at all — released off-screen, or the OS taking
-  // over for a native drag. The verdict must not then be applied to a click that carries no
-  // pointer of its own: keyboard Enter and .click() both report detail 0.
+  // a press inside can end with no click at all (released off-screen, OS-owned drag), so
+  // its verdict must not hit a pointerless click: Enter and .click() report detail 0
   it(`dismiss_on: 'release' still dismisses on a keyboard-driven click`, () => {
     const { element, callback } = attach_outside({ dismiss_on: `release` })
     const outside = create_element()
@@ -359,10 +352,9 @@ describe(`click_outside`, () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  // Capture phase is what makes dismissal unsuppressable, and its price is running before
-  // the pressed control's own handler — so a control that toggles the surface from its click
-  // handler belongs in `inside`; `release` cannot reorder that one for it (a control bound to
-  // the state is the case `release` does fix, see DraggablePane's checkbox tests)
+  // capture makes dismissal unsuppressable at the price of running before the pressed
+  // control's handler, so a control toggling the surface from its click handler belongs in
+  // `inside`; `release` only fixes controls bound to the state (see DraggablePane tests)
   it(`dismisses from the capture phase, ahead of the pressed control's handler`, () => {
     const order: string[] = []
     const { callback } = attach_outside({ dismiss_on: `release` })

--- a/tests/vitest/attachments/contrast.test.ts
+++ b/tests/vitest/attachments/contrast.test.ts
@@ -6,8 +6,7 @@ import { create_element } from '../index'
 describe(`contrast_color`, () => {
   afterEach(() => vi.restoreAllMocks())
 
-  // brackets a color's luminance from both sides: a threshold just below it has to read
-  // as `over` and one just above as `under`, which pins the value without exposing it
+  // pins a luminance without exposing it: thresholds just below/above read `over`/`under`
   const luminance_brackets = (bg_color: string, expected: number, tolerance: number) => {
     const probe = (luminance_threshold: number) =>
       pick_contrast_color({ bg_color, luminance_threshold, choices: [`over`, `under`] })
@@ -23,8 +22,7 @@ describe(`contrast_color`, () => {
     [`six-digit hex`, `#ffffff`, `black`],
     [`three-digit hex`, `#111`, `white`],
     [`eight-digit hex`, `#ffffffcc`, `black`],
-    // computed styles keep a color in the space it was authored in, so these arrive
-    // at get_bg_color verbatim rather than pre-converted to rgb()
+    // computed styles keep the authored color space, so these reach get_bg_color verbatim
     [`white oklch`, `oklch(1 0 0)`, `black`],
     [`black oklab`, `oklab(0 0 0)`, `white`],
     [`red oklch`, `oklch(0.627955 0.257683 29.2338)`, `white`],
@@ -40,9 +38,7 @@ describe(`contrast_color`, () => {
     expect(pick_contrast_color({ bg_color })).toBe(expected)
   })
 
-  // the conversions are only worth anything if they land on the same luminance the
-  // equivalent sRGB spelling does, so each pair has to agree either side of a threshold
-  // set at the reference color's own luminance
+  // each must land on the same luminance as its equivalent sRGB spelling
   it.each([
     [`oklab(0.627955 0.224863 0.125846)`, 0.299],
     [`oklch(62.7955% 0.257683 29.2338deg)`, 0.299],
@@ -54,8 +50,7 @@ describe(`contrast_color`, () => {
     [`color(srgb-linear 1 1 1)`, 1],
     [`color(xyz-d50 0.9643 1 0.8251)`, 1],
     [`hwb(0.5turn 0% 0%)`, 0.701], // cyan
-    // same cyan a third way: 200grad is 180deg, and `grad` must not read as the `rad`
-    // it ends with, which would leave a trailing `g` and parse to NaN
+    // same cyan: 200grad is 180deg; `grad` must not parse as the `rad` it ends with (NaN)
     [`hwb(200grad 0% 0%)`, 0.701],
     [`oklch(0.627955 0.257683 0.51022606rad)`, 0.299], // red, the 29.2338deg above in radians
     // percentages are as legal in rgb() as anywhere else, in channels and alpha alike
@@ -68,13 +63,11 @@ describe(`contrast_color`, () => {
     expect(luminance_brackets(bg_color, expected, 1e-4)).toEqual(bracketed)
   })
 
-  // The cases above are all primaries or pure white, which every space maps to the same
-  // corner of sRGB — they pass whatever the conversion matrices hold. These are mid-gamut,
-  // where the coefficients actually decide the answer, and the expected channels are what
-  // Chrome 144 paints for the same string (canvas fillStyle, then getImageData).
-  // Chrome quantizes to 8-bit, so its answer is only good to half a channel: 0.5/255 is
-  // 1.96e-3 of luminance, and the tolerance is that bound. Every wrong-matrix result
-  // checked (skipping the D50 adaptation above all) misses by far more than this.
+  // the cases above are primaries or white, which every space maps to the same sRGB
+  // corner, so any matrix passes them. These are mid-gamut, where the matrices decide.
+  // Expected channels are what Chrome 144 paints (canvas fillStyle + getImageData), good
+  // to half a channel (0.5/255 = 1.96e-3 luminance) - hence the tolerance. Wrong-matrix
+  // results (skipping the D50 adaptation above all) miss by far more.
   it.each([
     [`oklch(0.7 0.15 30)`, [237, 118, 101]],
     [`oklab(0.35 0.08 -0.12)`, [75, 28, 118]],
@@ -94,9 +87,8 @@ describe(`contrast_color`, () => {
     expect(luminance_brackets(bg_color, luminance, 2e-3)).toEqual(bracketed)
   })
 
-  // Perceived brightness weights green ×0.587, red ×0.299 and blue ×0.114, so the
-  // same channel value reads very differently. A plain channel average would land
-  // all three of these on 0.333 and give one answer for the lot.
+  // perceived brightness weights green ×0.587, red ×0.299, blue ×0.114; a plain channel
+  // average would land all three on 0.333 and answer the same for the lot
   it.each([
     [`green`, `rgb(0, 255, 0)`, `black`],
     [`red`, `rgb(255, 0, 0)`, `white`],
@@ -115,8 +107,7 @@ describe(`contrast_color`, () => {
     expect(pick_contrast_color(options)).toBe(expected)
   })
 
-  // named colors and color-mix() stay out: a computed value can carry neither, since
-  // color-mix() resolves to a color in its interpolation space before it is read back
+  // named colors and color-mix() never reach a computed value (color-mix resolves first)
   it.each([
     `red`,
     `color-mix(in oklab, red, blue)`,
@@ -132,8 +123,7 @@ describe(`contrast_color`, () => {
     expect(() => pick_contrast_color({ bg_color })).toThrow(/cannot read color/u)
   })
 
-  // a chain with nothing painted in it reports no background at all, and a page with
-  // nothing behind the node is assumed white
+  // an all-transparent chain reports no background; a node with nothing behind it is white
   const tint = `rgba(0, 0, 0, 0.05)`
   it.each([
     [`the first painted ancestor`, `rgb(10, 10, 10)`, ``, `rgb(10, 10, 10)`, `white`],
@@ -154,8 +144,7 @@ describe(`contrast_color`, () => {
     cleanup?.()
   })
 
-  // the ancestor walk stops at the first painted background, and a wide-gamut one is
-  // painted: reading only rgb()/rgba() used to skip straight past it
+  // the walk stops at the first painted bg - rgb()-only reading skipped wide-gamut ones
   it.each([
     [`oklch(0.3 0.1 200)`, `white`, true],
     [`oklch(0.3 0.1 200 / 0)`, `black`, false],

--- a/tests/vitest/attachments/dismiss-on-outside-press.test.ts
+++ b/tests/vitest/attachments/dismiss-on-outside-press.test.ts
@@ -16,9 +16,8 @@ describe(`dismiss_on_outside_press`, () => {
     return { callback, cleanup }
   }
 
-  // One listener over several disjoint menus in a panel, which is exactly what the
-  // attachment cannot express: a wrapper around them all would count every press
-  // between them as inside.
+  // one listener over several disjoint menus in a panel: a wrapper around them all would
+  // count every press between them as inside
   it(`without a node, inside alone decides membership`, () => {
     const panel = create_element()
     const [menu_a, menu_b] = [create_element(), create_element()]
@@ -36,8 +35,7 @@ describe(`dismiss_on_outside_press`, () => {
     press(menu_b)
     expect(callback).not.toHaveBeenCalled()
 
-    // between the two menus but still inside the panel: an attached surface would
-    // have to count this as inside, a node-less listener must not
+    // between the menus but inside the panel: an attached surface would count this inside
     press(panel_filler)
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback.mock.calls[0][0]).toMatchObject({ via: `pointer` })

--- a/tests/vitest/attachments/draggable.test.ts
+++ b/tests/vitest/attachments/draggable.test.ts
@@ -183,8 +183,8 @@ describe(`draggable`, () => {
     expect([element.style.left, element.style.top]).toEqual([``, ``])
   })
 
-  // Either ends the drag: nothing further arrives for a pointer that was canceled or whose
-  // capture went away. `lostpointercapture` is dispatched on the capture target, not window.
+  // either ends the drag: nothing more arrives for a canceled pointer or one whose capture
+  // went away; `lostpointercapture` fires on the capture target, not window
   it.each([
     [
       `pointercancel`,
@@ -249,13 +249,11 @@ describe(`draggable`, () => {
 
     attach_draggable(element, { handle_selector: `.drag-handle` })
 
-    // press on element (not handle) should not start dragging
     element.dispatchEvent(pointer_event(`pointerdown`, 0, 0))
     globalThis.dispatchEvent(pointer_event(`pointermove`, 50, 50))
     expect(element.style.left).toBe(``)
     expect(element.style.top).toBe(``)
 
-    // press on handle should start dragging
     handle.dispatchEvent(pointer_event(`pointerdown`, 0, 0))
     globalThis.dispatchEvent(pointer_event(`pointermove`, 30, 40))
     expect(element.style.left).toBe(`30px`)

--- a/tests/vitest/attachments/focus-trap.test.ts
+++ b/tests/vitest/attachments/focus-trap.test.ts
@@ -84,9 +84,8 @@ describe(`focus_trap`, () => {
     expect(document.activeElement).toBe(buttons[0])
   })
 
-  // an <a href> inside an <svg> is focusable and matches tabbable_selector, but it is an
-  // SVGElement, so looking the active element up with a HTMLElement-typed indexOf misses
-  // it and Tab jumps back to the edge instead of stepping to the neighbor
+  // an <a href> in an <svg> is tabbable, but an HTMLElement-typed indexOf misses the
+  // SVGElement, so Tab jumped back to the edge instead of stepping to the neighbor
   it(`steps past an SVG focusable instead of jumping to the edge`, () => {
     const { surface, buttons } = make_surface()
     const svg = document.createElementNS(`http://www.w3.org/2000/svg`, `svg`)
@@ -153,9 +152,8 @@ describe(`focus_trap`, () => {
     expect(document.activeElement).toBe(outer.buttons[1])
   })
 
-  // The trap listens on the document, so a surface that was never given focus must
-  // not confiscate Tab from the rest of the page. Nav pins a submenu while focus
-  // stays on the toggle outside it, and Tab there has to keep walking the page.
+  // the trap listens on the document, so a surface never given focus must not confiscate
+  // Tab: Nav pins a submenu while focus stays on the toggle outside it
   it(`leaves Tab alone while focus sits outside the trap`, () => {
     const { surface, buttons } = make_surface()
     const outside = create_element(`button`)
@@ -236,8 +234,8 @@ describe(`focus_trap`, () => {
       press_tab(true)
       expect(document.activeElement).toBe(last)
 
-      // `root` narrows what Tab cycles, not what counts as inside: clicking the backdrop
-      // focuses it, and if that read as outside the trap it would disarm Tab entirely
+      // `root` narrows what Tab cycles, not what counts as inside: a focused backdrop
+      // reading as outside would disarm Tab entirely
       backdrop.focus()
       expect(press_tab().defaultPrevented).toBe(true)
       expect(document.activeElement).toBe(first)
@@ -272,8 +270,7 @@ describe(`focus_trap`, () => {
     const event = press_escape()
     expect(on_inner).toHaveBeenCalledTimes(1)
     expect(on_outer).not.toHaveBeenCalled()
-    // canceled on purpose: a native <dialog> around the surface then stays open
-    // until a second Escape lands with this layer gone
+    // canceled on purpose so a native <dialog> around the surface needs a second Escape
     expect(event.defaultPrevented).toBe(true)
 
     cleanup_inner?.()
@@ -282,7 +279,6 @@ describe(`focus_trap`, () => {
     expect(on_inner).toHaveBeenCalledTimes(1)
   })
 
-  // Recapture restores the last inside focus, not the trap's entry point.
   it(`recapture pulls focus back to the last element that held it inside`, async () => {
     const { surface, buttons } = make_surface()
     attach_trap(surface, { recapture: true })
@@ -292,8 +288,8 @@ describe(`focus_trap`, () => {
     expect(await focus_out_to(create_element(`button`))).toBe(buttons[2])
   })
 
-  // A recapture re-resolves `root`, so a trap can inject its fallback tabindex into
-  // more than one element over its life and owes all of them a cleanup.
+  // a recapture re-resolves `root`, so one trap can inject its fallback tabindex into
+  // several elements over its life and owes each a cleanup
   it(`takes the injected tabindex off every root it fell back to`, async () => {
     const surface = create_element()
     // no tabbables in either panel, so the root itself is the fallback focus target
@@ -319,8 +315,7 @@ describe(`focus_trap`, () => {
     expect(panels.map((panel) => panel.hasAttribute(`tabindex`))).toEqual([false, false])
   })
 
-  // the counterpart of the holds_focus guard on Tab: a trap that was never given
-  // focus must not summon it on every focus move elsewhere on the page
+  // counterpart of the Tab holds_focus guard: a trap never given focus must not summon it
   it(`recapture stays out of focus moves that never touched the trap`, async () => {
     const { surface } = make_surface()
     const elsewhere = create_element(`button`)
@@ -345,9 +340,8 @@ describe(`focus_trap`, () => {
     expect(await focus_out_to(outside)).toBe(outside) // a torn-down trap stops recapturing
   })
 
-  // Hygiene rather than behavior — the guard above already silences a late microtask —
-  // but without this every surface that opens leaks a pair of document listeners for
-  // the rest of the page's life.
+  // hygiene, not behavior (the guard above silences late microtasks), but without it every
+  // opened surface leaks a pair of document listeners for the page's life
   it(`recapture takes its document listeners off again on teardown`, () => {
     const removals = vi.spyOn(document, `removeEventListener`)
     focus_trap({ recapture: true, restore: false })(make_surface().surface)?.()

--- a/tests/vitest/attachments/highlight-matches.test.ts
+++ b/tests/vitest/attachments/highlight-matches.test.ts
@@ -41,12 +41,10 @@ describe(`highlight_matches`, () => {
     // Early returns
     [`whitespace-only query`, ` \t\n `, `a b`, false, undefined, undefined],
 
-    // Substring highlighting (fuzzy=false)
     [`case insensitive`, `test`, `<p>Test with TEST and TeSt</p>`, false, 3, undefined],
     [`no cross-node match`, `bc`, `<ul><li>ab</li><li>cd</li></ul>`, false, 0, undefined],
     [`no matches`, `xyz`, `<p>Content without search term</p>`, false, 0, undefined],
 
-    // Fuzzy highlighting (fuzzy=true)
     [`fuzzy no matches`, `xyz`, `<p>Content without search term</p>`, true, 0, undefined],
     [
       `skip with node_filter`,
@@ -87,8 +85,7 @@ describe(`highlight_matches`, () => {
 
   it.each([
     [`CSS is missing`, () => vi.stubGlobal(`CSS`, undefined)],
-    // a registry without the constructor is what a partial polyfill or a stub in a
-    // consumer's test leaves behind; constructing a Highlight there throws
+    // a partial polyfill or consumer stub can leave a registry whose Highlight throws
     [`Highlight is missing`, () => vi.stubGlobal(`Highlight`, undefined)],
   ])(`runs range effects when %s`, (_desc, prepare) => {
     prepare()
@@ -142,10 +139,8 @@ describe(`highlight_matches`, () => {
     ])
   })
 
-  // 'İ' (U+0130) lowercases to 2 UTF-16 units, shifting offsets computed on the
-  // lowercased text. Ranges must map back to the ORIGINAL character positions
-  // (and never exceed the node length). 'İİİab': lowered is 'i̇i̇i̇ab' so naive
-  // offsets for 'a'/'b' would be 6/7 — the correct original offsets are 3/4.
+  // 'İ' (U+0130) lowercases to 2 UTF-16 units, so ranges must map back to the ORIGINAL
+  // offsets: in 'İİİab' the naive 'a'/'b' offsets are 6/7, the original ones 3/4
   it.each([
     [`substring`, false],
     [`fuzzy`, true],
@@ -335,8 +330,8 @@ describe(`highlight_matches`, () => {
     cleanup?.()
   })
 
-  // Flush MO (microtask) before advancing timers, or the burst never arms the debounce.
-  // afterEach restores real timers — create_burst_debounce keys max_wait off Date.now().
+  // flush the MutationObserver microtask before advancing timers, or the burst never arms
+  // the debounce; afterEach restores real timers since max_wait keys off Date.now()
   it(`debounced observation coalesces a burst into one re-run`, async () => {
     vi.useFakeTimers()
     mock_element.textContent = `nothing here`
@@ -398,8 +393,7 @@ describe(`highlight_matches`, () => {
     expect(vi.getTimerCount()).toBe(1)
 
     cleanup?.()
-    // disarmed, not merely ignored: a live timer holds the closure (and, in node,
-    // the event loop) until it fires
+    // disarmed, not merely ignored: a live timer pins the closure and node's event loop
     expect(vi.getTimerCount()).toBe(0)
     await vi.advanceTimersByTimeAsync(100)
 

--- a/tests/vitest/attachments/resizable.test.ts
+++ b/tests/vitest/attachments/resizable.test.ts
@@ -43,8 +43,7 @@ describe(`resizable`, () => {
     expect(on_resize).not.toHaveBeenCalled()
   })
 
-  // `touch-action` has no per-region form, so each strip is a real element carrying its own
-  // — and its cursor, which needs no hover handler now
+  // `touch-action` has no per-region form, so each strip is a real element with its own
   it.each([
     [`right`, `ew-resize`, `width`, [`top`, `bottom`], `vertical`, `200`],
     [`bottom`, `ns-resize`, `height`, [`left`, `right`], `horizontal`, `150`],
@@ -88,8 +87,7 @@ describe(`resizable`, () => {
     },
   )
 
-  // Handles are focusable and arrow-key operable, so their names are announced. The edge
-  // itself is interpolated, which means a translation has to reach the noun too.
+  // handle labels are announced and interpolate the edge, so translations must reach it
   it(`labels rename every resize handle, edge included`, () => {
     const element = create_box()
     attach_resizable(element, {
@@ -117,8 +115,8 @@ describe(`resizable`, () => {
     ]).toEqual([`30`, `30`])
   })
 
-  // Absolute children anchor to the padding box, so a strip flush with its edge sits inside
-  // the border, leaving the visible edge — grabbable back when this hit-tested — dead.
+  // absolute children anchor to the padding box, so a strip flush with its edge sits inside
+  // the border, leaving the visible (grabbable) edge dead
   it(`offsets each strip outward by the border it covers`, () => {
     const element = create_box()
     element.style.borderStyle = `solid`
@@ -159,8 +157,7 @@ describe(`resizable`, () => {
     })
   })
 
-  // A height-only drag that also pinned the width would freeze a responsive element at
-  // whatever it happened to measure the first time anyone grabbed it
+  // pinning the untouched axis too would freeze a responsive element at its first measure
   it(`writes only the axis its grab controls`, () => {
     const element = create_box()
     Object.assign(element.style, { width: ``, height: `` })
@@ -173,8 +170,7 @@ describe(`resizable`, () => {
     globalThis.dispatchEvent(pointer_event(`pointerup`, 100, 245))
   })
 
-  // aria values describe the node a strip resizes, so an outer instance rewriting every
-  // separator it can find would make a nested pane's handles report the wrong size
+  // an outer instance rewriting every separator would make a nested pane report wrong sizes
   it(`leaves a nested resizable's separator values alone`, () => {
     const outer = create_box()
     const inner = create_element(`div`, { width: `80px`, height: `60px` })
@@ -194,8 +190,7 @@ describe(`resizable`, () => {
     globalThis.dispatchEvent(pointer_event(`pointerup`, 295, 75))
   })
 
-  // detaching a strip does not unbind its listeners, so a consumer holding one could still
-  // press it and resize a node this attachment no longer manages
+  // detaching a strip does not unbind its listeners, so a retained one could still resize
   it(`stops responding to a strip retained across cleanup`, () => {
     const element = create_box()
     const on_resize = vi.fn()
@@ -246,8 +241,7 @@ describe(`resizable`, () => {
     expect(element.querySelectorAll(`[data-resize-corner]`)).toHaveLength(0)
   })
 
-  // The whole point of a corner: dragging it moves both axes, where the edge strips it
-  // overlaps would each move only their own.
+  // the point of a corner: both axes at once, where the strips it overlaps move only one
   it.each([
     [`bottom-right`, 300, 250, 300, 250],
     [`top-left`, -50, -30, 250, 180],
@@ -359,8 +353,7 @@ describe(`resizable`, () => {
     expect(element.style.width).toBe(`320px`)
   })
 
-  // left/top are also written by `draggable` on the same node, so a reset that blanks them
-  // unconditionally would snap a dragged element back to wherever its stylesheet puts it
+  // `draggable` writes left/top on the same node, so a blanket reset would snap it back
   it(`double-click leaves a left/top this instance never wrote`, () => {
     const element = create_box()
     attach_resizable(element, { edges: [`left`, `top`] })
@@ -405,8 +398,7 @@ describe(`resizable`, () => {
     globalThis.dispatchEvent(pointer_event(`pointerup`, 500, 75))
   })
 
-  // a second finger drives and ends nothing; the resize belongs to the first, until the OS
-  // takes it away — cancel or lost capture both end it
+  // a second finger drives nothing; only the first pointer or the OS can end the resize
   it.each([
     [
       `pointercancel`,
@@ -440,8 +432,8 @@ describe(`resizable`, () => {
     expect(element.hasPointerCapture(1)).toBe(false)
   })
 
-  // every way a gesture can fail to be a resize. A non-primary press matters most: the
-  // context menu it opens can swallow the release, leaving the element stuck to the cursor
+  // the non-primary press matters most: the context menu it opens can swallow the release,
+  // leaving the element stuck to the cursor
   it.each([
     [
       `a press on the content, clear of every strip`,
@@ -487,7 +479,6 @@ describe(`resizable`, () => {
       height: 150,
     })
 
-    // End resize
     globalThis.dispatchEvent(pointer_event(`pointerup`, 0, 0))
     expect(document.body.style.userSelect).toBe(``)
     expect(on_resize_end).toHaveBeenCalledExactlyOnceWith(

--- a/tests/vitest/attachments/sortable.test.ts
+++ b/tests/vitest/attachments/sortable.test.ts
@@ -218,7 +218,7 @@ describe(`sortable`, () => {
     expect(header.querySelector(`span.icon`)).toBe(icon)
     expect(header.querySelector(`span.sort-arrow:not(.icon)`)?.textContent).toContain(`↑`)
 
-    // repeated clicks replace only the attachment's arrow, preserving the consumer's
+    // repeated clicks replace only the attachment's arrow, not the consumer's icon
     click_header(header)
     expect(header.querySelectorAll(`span.sort-arrow`)).toHaveLength(2)
     expect(header.querySelector(`span.sort-arrow:not(.icon)`)?.textContent).toContain(`↓`)

--- a/tests/vitest/attachments/tooltip.test.ts
+++ b/tests/vitest/attachments/tooltip.test.ts
@@ -347,8 +347,8 @@ describe(`tooltip manager`, () => {
     expect(tooltip_el.hidden).toBe(true)
     expect(document.activeElement).toBe(element)
 
-    // Handing focus back re-enters through focusout/focusin, which must not resurrect
-    // the dismissed tooltip — leaving the trigger afterwards is not a second close.
+    // handing focus back re-enters via focusout/focusin, which must not resurrect the
+    // dismissed tooltip — leaving the trigger afterwards is not a second close
     focus_out(element)
     vi.advanceTimersByTime(0)
     expect(tooltip_el.hidden).toBe(true)
@@ -356,8 +356,8 @@ describe(`tooltip manager`, () => {
       [false, open_detail(element, `escape`)],
     ])
 
-    // The reopen the handoff caused subscribed an Escape layer of its own. Left on the
-    // stack it answers for the surface underneath, which never hears Escape again.
+    // that reopen subscribed an Escape layer of its own; left on the stack it answers
+    // for the surface underneath, which then never hears Escape
     document.dispatchEvent(escape_key())
     expect(surrounding_layer).toHaveBeenCalledOnce()
   })
@@ -721,8 +721,8 @@ describe(`tooltip manager`, () => {
     const { element } = show_tooltip({}, `Temporary`)
     pointer_out(element)
 
-    // A surviving scroll subscription still schedules a frame, even though the guard
-    // inside would make that frame a no-op, so the frame is what proves the release.
+    // a surviving subscription still schedules a frame even though its guard no-ops it,
+    // so the frame is what proves the release
     const frame = vi.spyOn(window, `requestAnimationFrame`)
     window.dispatchEvent(new Event(`scroll`))
     expect(frame).not.toHaveBeenCalled()
@@ -814,8 +814,7 @@ describe(`tooltip manager`, () => {
     expect(hide_popover).toHaveBeenCalledOnce()
     expect([tooltip_el.hidden, tooltip_el.style.display]).toEqual([true, `none`])
 
-    // Exiting the dismissed trigger closes the retained state without rehiding a
-    // popover Escape already closed. The same surface remains reusable afterwards.
+    // exiting the dismissed trigger must not rehide a popover Escape already closed
     pointer_out(element)
     expect(hide_popover).toHaveBeenCalledOnce()
     pointer_over(element)

--- a/tests/vitest/changelog.test.ts
+++ b/tests/vitest/changelog.test.ts
@@ -1,4 +1,3 @@
-// Tests for the changelog page server load markdown transforms
 import { load } from '$root/src/routes/changelog/+page.server'
 import { expect, test } from 'vite-plus/test'
 
@@ -6,14 +5,12 @@ test(`changelog transform preserves code spans and wraps entity tags`, async () 
   const { changelog } = await load()
   const { code: html } = changelog
 
-  // existing code spans containing &gt; survive intact (a previous transform
-  // injected backticks before every entity, splitting code spans mid-way)
+  // regression: an earlier transform injected backticks before every entity, splitting
+  // existing code spans mid-way
   expect(html).toContain(`<code>ul.selected &gt; li</code>`)
-  // bare entity tags like &lt;input&gt; get wrapped in full code spans
   expect(html).toContain(`<code>&lt;input&gt;</code>`)
-  // heading levels are preserved: # Changelog stays h1, ## version headings stay h2
+  // # Changelog stays h1, ## version headings stay h2
   expect(html).toMatch(/<h1[ >]/u)
   expect(html).toContain(`<h2 id="v11-8-0">`)
-  // no stray backticks leak into the rendered output
   expect(html).not.toContain(`\``)
 })

--- a/tests/vitest/file-drop.test.ts
+++ b/tests/vitest/file-drop.test.ts
@@ -5,14 +5,11 @@ import {
 } from '$lib/file-drop'
 import { expect, test, vi } from 'vite-plus/test'
 
-// happy-dom has DataTransfer but no webkitGetAsEntry and no FileSystemEntry types at
-// runtime, so drops are built from hand-rolled entries here. They implement the two
-// callback APIs the real thing exposes - entry.file(cb, err) and reader.readEntries(cb,
-// err) - including readEntries' batching, since draining it is the part most likely to
-// be got wrong.
+// happy-dom has DataTransfer but no webkitGetAsEntry, so drops use hand-rolled entries
+// implementing the callback APIs the real thing exposes - entry.file(cb, err) and
+// reader.readEntries(cb, err), batching included since draining it is the tricky part.
 
-// `file` hands back a File named after the entry; the error and timing tests pass their
-// own to drive the callback themselves.
+// `file` defaults to a File named after the entry; error and timing tests pass their own.
 const file_entry = (
   name: string,
   file: FileSystemFileEntry[`file`] = (on_file) => on_file(new File([name], name)),
@@ -25,8 +22,8 @@ const file_entry = (
     file,
   }) as unknown as FileSystemFileEntry
 
-// `batch_size` mirrors the browser's cap: readEntries returns at most 100 per call and
-// signals the end with an empty batch, so a single call is not enough.
+// `batch_size` mirrors the browser: readEntries returns at most 100 per call and ends
+// with an empty batch, so one call is not enough.
 const dir_entry = (
   name: string,
   children: FileSystemEntry[],
@@ -37,7 +34,7 @@ const dir_entry = (
     isDirectory: true,
     name,
     fullPath: `/${name}`,
-    // per-reader cursor, like the browser's: a second reader restarts the listing
+    // per-reader cursor like the browser's: a second reader restarts the listing
     createReader: () => {
       let read_idx = 0
       return {
@@ -111,8 +108,8 @@ test(`plain files come back in drop order`, async () => {
   expect(names(await files_from_data_transfer(dropped))).toEqual([`a.txt`, `b.txt`])
 })
 
-// The reason this helper exists: DataTransfer.files reports a dropped directory as one
-// zero-byte File named after the directory, so its contents would be lost.
+// why the helper exists: DataTransfer.files reports a dropped directory as one zero-byte
+// File named after it, losing the contents
 test(`directories are expanded depth-first, keeping their listed order`, async () => {
   const lib_dir = dir_entry(`lib`, [file_entry(`deep.ts`)])
   const src_dir = dir_entry(`src`, [file_entry(`index.ts`), lib_dir])
@@ -147,8 +144,7 @@ test(`a directory larger than one readEntries batch is drained fully`, async () 
   expect(await files_from_data_transfer(drop([big_dir]))).toHaveLength(250)
 })
 
-// Entries are unreadable outside the drop event and absent on synthetic drops, where
-// DataTransfer.files is all there is.
+// entries are absent on synthetic drops and outside the drop event, leaving only files
 test.each([
   [`items yield no entries`, [null, null]],
   [`there are no items at all`, []],
@@ -196,9 +192,8 @@ const nested_dirs = (depth: number): FileSystemEntry => {
   return entry
 }
 
-// A symlink to one of its own ancestors nests without end - the entry API resolves it -
-// so unbounded recursion would hang the tab. The cap has to stop that without tripping
-// on a real tree, so both sides of it are pinned here.
+// a symlink to an ancestor nests without end (the entry API resolves it), so uncapped
+// recursion hangs the tab. Both sides of the cap are pinned so it can't trip a real tree.
 test(`directory nesting is capped`, async () => {
   const deepest_allowed = drop([nested_dirs(32)])
   expect(names(await files_from_data_transfer(deepest_allowed))).toEqual([`bottom.txt`])
@@ -209,10 +204,10 @@ test(`directory nesting is capped`, async () => {
   )
 })
 
-// Two sibling links to a common ancestor branch as fast as they descend, so the depth cap
-// alone never trips - measured at 300k directory reads by depth 17. The entry budget is
-// what stops it, and the read counter here fails loudly if it ever stops doing so: an
-// uncapped run is a non-yielding microtask loop that vitest's timeout cannot interrupt.
+// two sibling links to a common ancestor branch as fast as they descend, so the depth cap
+// alone never trips (300k reads by depth 17) - only the entry budget stops it. The read
+// counter fails loudly if it stops: an uncapped run is a non-yielding microtask loop that
+// vitest's timeout cannot interrupt.
 test(`a branching cycle is stopped by the entry budget`, async () => {
   let reads = 0
   const fanout_dir = (): FileSystemEntry =>

--- a/tests/vitest/fullscreen.test.ts
+++ b/tests/vitest/fullscreen.test.ts
@@ -6,11 +6,9 @@ import { createRawSnippet, mount, tick, unmount } from 'svelte'
 import { fromStore, get, writable } from 'svelte/store'
 import { afterEach, assert, beforeEach, describe, expect, test, vi } from 'vite-plus/test'
 
-// happy-dom implements no part of the Fullscreen API, so the three pieces the module
-// touches are stubbed here: Element.requestFullscreen, Document.exitFullscreen and the
-// document.fullscreenElement getter. The stubs keep a single document-wide element, the
-// way a browser does - they do not know about wrappers, so the per-wrapper keying under
-// test lives entirely in the source, not in the fakes.
+// happy-dom implements no part of the Fullscreen API, so requestFullscreen,
+// exitFullscreen and the fullscreenElement getter are stubbed. The stubs keep one
+// document-wide element like a browser does, so the per-wrapper keying lives in the source.
 let fullscreen_element: Element | null = null
 let request_calls: Element[] = []
 const mounted: Record<string, unknown>[] = []
@@ -231,8 +229,7 @@ describe(`flag <-> browser sync`, () => {
     expect(on_request_error).toHaveBeenCalledExactlyOnceWith(request_error)
     expect(console_error).toHaveBeenCalledOnce()
     expect(document.fullscreenElement).toBeNull()
-    // a flag left true would both misreport the browser and make the next attempt a
-    // no-op, since the effect would see no change to act on
+    // a flag left true would misreport the browser and make the next attempt a no-op
     expect(get(flag)).toBe(false)
 
     button.click()
@@ -345,8 +342,7 @@ describe(`fullscreen background`, () => {
   ])(
     `get_page_background falls back to prefers-color-scheme (dark=%s)`,
     (dark, expected) => {
-      // Once: vi.restoreAllMocks leaves vi.fn() mocks alone, so a lasting return value
-      // would follow setup.ts's matchMedia into every later test
+      // Once: restoreAllMocks spares vi.fn() mocks, so a lasting value would leak onward
       vi.mocked(globalThis.matchMedia).mockReturnValueOnce({
         matches: dark,
       } as MediaQueryList)
@@ -369,8 +365,7 @@ describe(`fullscreen background`, () => {
 
       expect(wrapper.style.getPropertyValue(css_var)).toBe(`rgb(7, 8, 9)`)
 
-      // and dropped on the way out: kept, it would still read the pre-switch color
-      // after a theme change, until the next entry happened to refresh it
+      // dropped on the way out, else it keeps a pre-switch color across a theme change
       button.click()
       await settle()
 
@@ -407,8 +402,7 @@ describe(`button rendering`, () => {
     expect(exiting.button.title).toBe(`Exit fullscreen`)
     expect(icon_path(exiting.button)).toBe(icons.ExitFullscreen.d)
 
-    // `labels={{ enter: condition ? `X` : undefined }}` type-checks, so an explicitly
-    // undefined key has to fall back too — a plain spread would render nothing
+    // an explicitly undefined key must fall back too - a plain spread would render nothing
     const undefined_key = mount_button({
       labels: { enter: undefined },
       wrapper: undefined,
@@ -416,9 +410,8 @@ describe(`button rendering`, () => {
     expect(undefined_key.button.title).toBe(`Enter fullscreen`)
   })
 
-  // a raw snippet's render() runs once, so each flag value gets its own mount rather
-  // than a click; the reactive path is covered by the icon swap in `click enters, click
-  // again exits`
+  // a raw snippet's render() runs once, so each flag value gets its own mount; the
+  // reactive path is covered by the icon swap in `click enters, click again exits`
   test.each([
     [false, `off`],
     [true, `on`],

--- a/tests/vitest/heading-anchors.test.ts
+++ b/tests/vitest/heading-anchors.test.ts
@@ -12,8 +12,7 @@ const preprocess = (content: string, filename?: string) =>
   heading_ids().markup({ content, filename })
 
 describe(`slugify_heading`, () => {
-  // Compatibility is intentionally Unicode-preserving and NFC-normalized: fragment IDs
-  // stay readable, and canonically equivalent spellings still collide as duplicates.
+  // Unicode-preserving and NFC-normalized: IDs stay readable, equivalent spellings collide
   it.each([
     [`  Déjà vu / 東京  `, `déjà-vu-東京`],
     [`foo.bar`, `foo-bar`],
@@ -91,7 +90,7 @@ describe(`heading_ids preprocessor`, () => {
       `<h2>Result {fn({a: {b: {c: 1}}})}</h2>`,
       `<h2 id="result">Result {fn({a: {b: {c: 1}}})}</h2>`,
     ],
-    // unmatched } treated as literal (not dropped) to avoid losing content when depth would go negative
+    // unmatched } kept literal, else content is lost when the depth would go negative
     [`<h2>Price: $100}</h2>`, `<h2 id="price-100">Price: $100}</h2>`],
     // inline headings (mdsvex output)
     [`</p> <h2>Title</h2>`, `</p> <h2 id="title">Title</h2>`],
@@ -122,7 +121,7 @@ describe(`heading_ids preprocessor`, () => {
     `<h2 class="test" id="existing" data-foo="bar">Text</h2>`,
     `<h2>{dynamicOnly}</h2>`, // no static text → no id
     `<h2><span></span></h2>`,
-    // leading } preserved in text, but after stripping {test} only } remains which slugifies to empty
+    // after stripping {test} only the literal } remains, which slugifies to empty
     `<h2>}{test}</h2>`,
   ])(`leaves %s unchanged`, (input: string) => {
     expect(preprocess(input).code).toBe(input)
@@ -175,8 +174,8 @@ describe(`heading_ids preprocessor`, () => {
     const result = preprocess(
       `<h2>Foo</h2>\n<h2>Foo</h2>\n<h3>Foo 1</h3>\n<h2>Foo</h2>\n<h2>Bar</h2>\n<h2>Café</h2>\n<h2>Cafe\u0301</h2>`,
     )
-    // The already-suffixed Foo 1 cannot collide with the duplicate Foo's `foo-1`.
-    // NFC normalization also makes decomposed `Cafe\u0301` a duplicate of `Café`.
+    // the already-suffixed `Foo 1` must not collide with the duplicate Foo's `foo-1`; NFC
+    // also makes decomposed `Cafe\u0301` a duplicate of `Café`
     expect(result.code).toBe(
       `<h2 id="foo">Foo</h2>\n<h2 id="foo-1">Foo</h2>\n<h3 id="foo-1-1">Foo 1</h3>\n` +
         `<h2 id="foo-2">Foo</h2>\n<h2 id="bar">Bar</h2>\n<h2 id="café">Café</h2>\n` +
@@ -197,8 +196,8 @@ describe(`heading_ids preprocessor`, () => {
 })
 
 describe(`heading_anchors attachment`, () => {
-  // production attaches to <main>; the default selector uses :scope so headings are
-  // matched relative to the attached node (h1-h6 as direct or 2nd-level children)
+  // production attaches to <main>; the default :scope selector matches h1-h6 that are
+  // direct or 2nd-level children of the attached node
   const create_container = (html = ``) => {
     document.body.innerHTML = `<main>${html}</main>`
     return doc_query(`main`)
@@ -252,15 +251,14 @@ describe(`heading_anchors attachment`, () => {
       `<div id="same"></div><h2>Same</h2>`,
       [`same-1`],
     ],
-    // querySelector('#2024-roadmap') throws SyntaxError since CSS ID selectors
-    // can't start with an unescaped digit - uniqueness check must use getElementById
+    // a CSS ID selector can't start with a digit, so uniqueness must use getElementById
     [
       `digit-leading text (invalid as CSS ID selector)`,
       `<h2>2024 Roadmap</h2><h3>2024 Roadmap</h3>`,
       [`2024-roadmap`, `2024-roadmap-1`],
     ],
-    // guards get_default_headings ordering: a direct-child heading must be processed
-    // before a grandchild in a later sibling, so the duplicate suffix lands on the grandchild
+    // guards get_default_headings ordering: the direct child must be processed first, so
+    // the duplicate suffix lands on the later sibling's grandchild
     [
       `direct child before a later sibling's grandchild`,
       `<h2>Dup</h2><div><h3>Dup</h3></div>`,
@@ -301,8 +299,7 @@ describe(`heading_anchors attachment`, () => {
     const container = create_container()
     const cleanup = heading_anchors({ selector: `h2` })(container)
 
-    // prove the observer is live first, else the absence of anchors after cleanup
-    // is equally explained by the attachment never having worked
+    // prove the observer is live first, else no anchors after cleanup proves nothing
     const before_cleanup = document.createElement(`h2`)
     before_cleanup.id = `before`
     container.append(before_cleanup)

--- a/tests/vitest/index.test.ts
+++ b/tests/vitest/index.test.ts
@@ -23,9 +23,8 @@ test(`src/lib/index.ts re-exports all Svelte components`, () => {
   expect(components.filter((name) => !(name && name in lib))).toEqual([])
 })
 
-// Svelte types `class` as a ClassValue, so a consumer may hand any component an array or
-// an object. Interpolating that into a string renders `class="masonry [object Object]"`;
-// the array form passes it to Svelte's own clsx pass, which is what resolves the object.
+// Svelte types `class` as ClassValue, so consumers may pass arrays/objects; interpolating
+// one into a string renders `[object Object]` instead of letting Svelte's clsx resolve it
 test(`no component interpolates a class prop into a class string`, () => {
   const sources = import.meta.glob<string>(`$lib/**/*.svelte`, {
     eager: true,

--- a/tests/vitest/index.ts
+++ b/tests/vitest/index.ts
@@ -19,11 +19,10 @@ export function doc_query<T extends Element = HTMLElement>(selector: string): T 
   return node
 }
 
-// Shadows a prototype getter (navigator.userAgent, documentElement.clientWidth) with
-// an own value property. Returns the undo, which callers must register for teardown so
-// a failed assertion cannot leak the stub into later tests.
-// Restores the original descriptor, not just deletes: `globalThis.innerWidth` and friends are
-// own properties of the window, so deleting them leaves every later test reading `undefined`.
+// Shadows a prototype getter with an own value property; returns the undo callers must
+// register for teardown so a failed assertion cannot leak the stub. Restores the original
+// descriptor rather than deleting, since `globalThis.innerWidth` and friends are own
+// properties that later tests would otherwise read as `undefined`.
 export const stub_prop = (target: object, prop: string, value: unknown) => {
   const original = Object.getOwnPropertyDescriptor(target, prop)
   Object.defineProperty(target, prop, { value, configurable: true })
@@ -33,8 +32,8 @@ export const stub_prop = (target: object, prop: string, value: unknown) => {
   }
 }
 
-// happy-dom skips layout, so every geometry an attachment reads has to be mocked:
-// getBoundingClientRect plus the read-only offset* properties (hence defineProperty).
+// happy-dom skips layout, so mock getBoundingClientRect plus the read-only offset*
+// properties (hence defineProperty).
 export const mock_rect = (
   element: HTMLElement,
   rect: { left: number; top: number; width?: number; height?: number },
@@ -132,12 +131,10 @@ export const stub_css_highlights = () => {
   return { registry, clear_spy, set_spy, delete_spy }
 }
 
-// Tracking settlement (rather than awaiting) is the only way to assert a promise is
-// still pending, which is what a queue is for.
+// tracking settlement rather than awaiting is the only way to assert a promise is pending
 export const track = <T>(promise: Promise<T>) => {
   const state: { settled: boolean; value?: T; reason?: unknown } = { settled: false }
-  // a rejection settles the promise too; without this arm it would read as forever
-  // pending and go unhandled, so a broken promise looks like a hung one
+  // rejections settle too; without this arm a broken promise reads as forever pending
   void promise.then(
     (value) => Object.assign(state, { settled: true, value }),
     (reason: unknown) => Object.assign(state, { settled: true, reason }),

--- a/tests/vitest/labels.test.ts
+++ b/tests/vitest/labels.test.ts
@@ -4,9 +4,8 @@ import { mount, tick } from 'svelte'
 import { expect, test } from 'vite-plus/test'
 import { doc_query } from './index'
 
-// Spreading a partial over the defaults keeps an explicitly-undefined key as undefined
-// instead of falling back. `exactOptionalPropertyTypes` is off, so a conditional override
-// — an ordinary Svelte idiom — type-checks and then renders nothing.
+// a plain spread keeps an explicitly-undefined key undefined instead of falling back, and
+// with `exactOptionalPropertyTypes` off a conditional override type-checks yet renders ``
 test.each([
   [`an explicitly undefined key falls back`, { show_less: undefined }, `show less`],
   [`a provided key wins`, { show_less: `weniger` }, `weniger`],

--- a/tests/vitest/live-examples/highlighter.test.ts
+++ b/tests/vitest/live-examples/highlighter.test.ts
@@ -1,4 +1,3 @@
-// Tests for starry-night syntax highlighter
 import { create_highlighter } from '$lib/live-examples/create-highlighter'
 import { default_highlighter } from '$lib/live-examples/default-highlighter'
 import { starry_night, starry_night_highlighter } from '$lib/live-examples/highlighter'
@@ -25,9 +24,8 @@ describe(`starry_night_highlighter`, () => {
     vi.resetModules()
   })
 
-  // Which flags resolve is starry-night's own data, so one row per distinct path here:
-  // the separately shipped svelte grammar, one from the common bundle, and a flag whose
-  // punctuation has to survive into the CSS class
+  // one row per resolution path: the separately shipped svelte grammar, one from the
+  // common bundle, and a flag whose punctuation must survive into the CSS class
   test.each([
     [`svelte`, `<div>test</div>`],
     [`ts`, `const x: number = 1`],
@@ -41,7 +39,7 @@ describe(`starry_night_highlighter`, () => {
         `su`,
       ),
     )
-    // Verify syntax highlighting produces spans, not only a wrapper.
+    // token spans, not just the wrapper
     expect(result).toContain(`<span class="pl-`)
   })
 
@@ -51,7 +49,7 @@ describe(`starry_night_highlighter`, () => {
       (lang) => {
         const result = starry_night_highlighter(`const x = 1`, lang)
         expect(result).toMatch(/^<pre class="highlight highlight-[a-z]+"><code>/u)
-        expect(result).not.toContain(lang) // Should use lowercase version
+        expect(result).not.toContain(lang)
       },
     )
   })
@@ -66,8 +64,7 @@ describe(`starry_night_highlighter`, () => {
     )
   })
 
-  // the fallback path emits nothing but the wrapper, so pin the whole string: a
-  // substring check would pass while the tail of the input went unescaped
+  // pin the whole string: a substring check would pass with an unescaped tail
   test.each([
     [`HTML special characters`, `<div>&</div>`, `&lt;div&gt;&amp;&lt;/div&gt;`],
     [`braces`, `{#if x}{/if}`, `&#123;#if x&#125;&#123;/if&#125;`],
@@ -115,9 +112,8 @@ describe(`create_highlighter`, () => {
     expect(await custom.highlight_block(`#let x = 1`, `TYP`)).toBe(
       `<pre class="highlight highlight-typ"><code>${typst_html}</code></pre>`,
     )
-    // unknown language falls back to escaped plain text, wrapped and unwrapped. Braces
-    // are escaped either way: unwrapped output goes into the same mdsvex markup, where a
-    // literal `{` would be read as the start of a Svelte expression.
+    // unknown language falls back to escaped plain text either way — unwrapped output
+    // goes into the same mdsvex markup, where `{` would start a Svelte expression
     expect(await custom.highlight(`<a>{x}</a>`, `py`)).toBe(
       `&lt;a&gt;&#123;x&#125;&lt;/a&gt;`,
     )
@@ -126,16 +122,14 @@ describe(`create_highlighter`, () => {
     )
   })
 
-  // starry-night's index re-exports the 34-grammar `common` bundle with no subpath to
-  // reach it separately, so one mention here would pin ~1.3 MB into the chunk of every
-  // consumer that brings its own grammars. Defaulting belongs in highlighter.ts.
+  // starry-night's index re-exports the 34-grammar `common` bundle with no separate
+  // subpath, so one mention pins ~1.3 MB into every consumer bringing its own grammars
   test(`never references starry-night's common bundle`, async () => {
     const source = (await import(`$lib/live-examples/create-highlighter.ts?raw`)).default
     // comments stripped: this file explains the rule in prose, which would match too
     const code = source
       .replaceAll(/\/\*[\s\S]*?\*\//gu, ``)
-      // from the marker to the line end only: stripping the whole line would delete
-      // code sharing it with a comment, and let a real reference slip past the guard
+      // marker to line end only: dropping whole lines would hide trailing-comment code
       .replaceAll(/\/\/.*$/gmu, ``)
     expect(code).toContain(`createStarryNight`)
     expect(code).not.toContain(`common`)

--- a/tests/vitest/live-examples/mdsvex-transform.test.ts
+++ b/tests/vitest/live-examples/mdsvex-transform.test.ts
@@ -72,9 +72,8 @@ describe(`code block detection`, () => {
       const value = get_example_value(tree)
       expect(value).toContain(`highlight-${lang}`)
       expect(value).not.toContain(EXAMPLE_COMPONENT_PREFIX)
-      // code-only output is raw HTML with no component scope, so the lang-label
-      // must be positioned out of flow inline or it indents the first code line
-      // (pre is white-space: pre)
+      // code-only output is raw HTML with no component scope, so the lang-label needs an
+      // inline out-of-flow position; pre is white-space: pre, so in-flow indents line 1
       expect(value).toMatch(/<span class="lang-label" style="[^"]*position:absolute/)
       expect(value).toContain(
         `<pre class="highlight highlight-${lang}" style="position:relative">`,
@@ -272,9 +271,8 @@ describe(`script block injection`, () => {
       create_code_node(`svelte`, `<div>Test</div>`, `example`),
     ])
     remark()(tree, create_file())
-    // imports must NOT be injected into the decoy node...
+    // imports go into a fresh script block, never the decoy node
     expect(tree.children[0].value).toBe(decoy)
-    // ...but into a freshly created script block
     const script = tree.children.find((node) => node.value?.startsWith(`<script>`))
     expect(script?.value).toContain(`import Example_0`)
   })

--- a/tests/vitest/live-examples/vite-plugin.test.ts
+++ b/tests/vitest/live-examples/vite-plugin.test.ts
@@ -279,8 +279,8 @@ describe(`pending_hmr_file lifecycle`, () => {
     // re-transform with identical examples — fix clears pending_hmr_file
     transform(plugin, ctx, make_code(`<div>V1</div>`), id)
 
-    // later: examples change WITHOUT a preceding handleHotUpdate.
-    // Without the fix, stale pending_hmr_file causes spurious full-reload.
+    // examples change without a preceding handleHotUpdate: a stale pending_hmr_file
+    // used to trigger a spurious full-reload here
     transform(plugin, ctx, make_code(`<div>V2</div>`), id)
     vi.advanceTimersByTime(500)
 

--- a/tests/vitest/masonry.test.ts
+++ b/tests/vitest/masonry.test.ts
@@ -4,12 +4,10 @@ import { type ComponentProps, mount, tick } from 'svelte'
 import { beforeEach, describe, expect, test, vi } from 'vite-plus/test'
 import MasonryAppendHarness from './MasonryAppendHarness.svelte'
 
-// Every test mounts into the same body, so keep that boilerplate in one place
 const mount_masonry = (props: ComponentProps<typeof Masonry>) =>
   mount(Masonry, { target: document.body, props })
 
-// Most harness tests only care about the exported append/remove/set_cols methods,
-// so `events` defaults to a throwaway array
+// most harness tests only use append/remove/set_cols, so `events` defaults to a throwaway
 const mount_harness = (
   props: ComponentProps<typeof MasonryAppendHarness> = { events: [] },
 ) => mount(MasonryAppendHarness, { target: document.body, props })
@@ -18,7 +16,6 @@ const n_items = 30
 const make_items = (count: number) => Array.from({ length: count }, (_, idx) => idx)
 const indices = make_items(n_items)
 
-// Rendered DOM shape lives here so tests don't hardcode selectors
 const masonry_el = () => document.querySelector<HTMLElement>(`div.masonry`)
 const col_els = () => document.querySelectorAll<HTMLElement>(`div.masonry > div.col`)
 // item wrappers (`> div`) vs any child (`> *`) - the latter also counts default spans
@@ -35,7 +32,6 @@ const as_columns = () =>
   get_col_dist()
     .map((col) => col.join(`,`))
     .join(` | `)
-// Track ResizeObserver registrations
 const resize_observers = new Map<Element, ResizeObserverCallback>()
 // number for a uniform height, or a function to give each item its own measured height
 let mock_height: number | ((el: Element) => number) = 100
@@ -295,8 +291,7 @@ describe(`Masonry append render stability`, () => {
 })
 
 describe(`Masonry order modes`, () => {
-  // Distinct heights so every mode yields a different distribution, pinning each
-  // algorithm's exact output rather than just item counts per column.
+  // distinct heights make every mode yield a different distribution, pinning exact output
   const dist_heights = [300, 80, 120, 400, 60, 220, 90]
   const dist_height = (item: number) => dist_heights[item]
 
@@ -321,10 +316,8 @@ describe(`Masonry order modes`, () => {
     expect(as_columns()).toBe(expected)
   })
 
-  // Appending alone can't tell the two balancing modes apart: greedy shortest-column
-  // placement is prefix-deterministic, so re-running it over a longer list reproduces
-  // the same columns. Removing from the middle re-packs everything after it, which is
-  // exactly what balanced-stable must not do (issue #53).
+  // Appending can't tell the balancing modes apart (greedy placement is prefix-deterministic);
+  // only a mid-list removal re-packs, which balanced-stable must not do (issue #53).
   test.each([
     [`balanced`, `2,4 | 3`], // re-packed from scratch
     [`balanced-stable`, `3 | 2,4`], // survivors keep their columns
@@ -469,8 +462,7 @@ describe(`Masonry default rendering`, () => {
     mount_masonry({ items, masonryWidth: 500, minColWidth: 200 })
     const spans = document.querySelectorAll(`div.masonry > div.col > div > span`) // default rendering
     expect(spans).toHaveLength(items.length)
-    // Default balanced-stable placement alternates equal-height items across 2 columns,
-    // while DOM order is grouped by column.
+    // balanced-stable alternates equal-height items across 2 columns; DOM order is by column
     expect(Array.from(spans).map((span) => span.textContent)).toEqual([
       `apple`,
       `cherry`,
@@ -545,8 +537,8 @@ describe(`Masonry virtualization`, () => {
     expect(count_5).toBeGreaterThan(count_1)
   })
 
-  // overscan=0 removes the slack that hid an exclusive end one row short, so the item
-  // straddling the viewport's bottom edge went unrendered and left a blank strip.
+  // overscan=0 removed the slack hiding an exclusive end one row short: the bottom-edge
+  // item went unrendered, leaving a blank strip
   test(`overscan=0 still renders the item at the viewport's bottom edge`, () => {
     mount_virtualized(50, {
       getEstimatedHeight: () => 100,
@@ -570,8 +562,8 @@ describe(`Masonry virtualization`, () => {
   })
 
   test(`scrolling moves the window, and a consumer's onscroll still fires`, async () => {
-    // `{...rest}` is spread after the component's own onscroll, so unchained a consumer
-    // handler replaces it outright and the window silently stops tracking the scroll
+    // `{...rest}` spreads after the component's own onscroll, so unless chained a consumer
+    // handler replaces it and the window silently stops tracking
     const consumer_scroll = vi.fn()
     mount_virtualized(200, {
       calcCols: () => 1,
@@ -596,7 +588,6 @@ describe(`Masonry virtualization`, () => {
   })
 
   test(`defers virtualization until masonryHeight is measured for string heights`, async () => {
-    // Mock clientHeight=0 to simulate unmeasured state
     const original = Object.getOwnPropertyDescriptor(
       HTMLElement.prototype,
       `clientHeight`,
@@ -614,7 +605,7 @@ describe(`Masonry virtualization`, () => {
         calcCols: () => 2,
       })
 
-      // With clientHeight=0 (unmeasured), all items render (virtualization deferred)
+      // clientHeight=0 means unmeasured, so virtualization is deferred
       expect(item_els()).toHaveLength(100)
     } finally {
       if (original) {
@@ -634,8 +625,8 @@ describe(`Masonry virtualization`, () => {
 })
 
 describe(`Masonry item cleanup`, () => {
-  // Regression: a removed id must be purged from stable_assignments, or re-adding it
-  // pins it back to its old column instead of the shortest one.
+  // Regression: a removed id must be purged from stable_assignments, else re-adding it
+  // pins it back to its old column.
   test(`re-adding a removed id places it fresh, not in its old column`, async () => {
     // item 3 is tall, so the column holding it stays clearly the longest
     mock_height = (el) => (el.textContent === `3` ? 500 : 100)
@@ -686,7 +677,7 @@ describe(`Masonry virtual scroll stability`, () => {
       getEstimatedHeight: () => 100,
     })
     const columns = col_els()
-    // Verify round-robin: item N should be in column N % 3
+    // round-robin: item N belongs in column N % 3
     for (let col_idx = 0; col_idx < columns.length; col_idx++) {
       const spans = columns[col_idx].querySelectorAll(`span`)
       const item_ids = Array.from(spans)
@@ -736,9 +727,8 @@ describe(`Masonry virtual scroll stability`, () => {
     expect(rendered).toBeGreaterThan(0)
   })
 
-  // A 0 estimate is meaningless, same as in get_height, so it has to fall through to the
-  // 150 default. With `??` the estimate stays 0, prefix sums are gaps alone and the window
-  // swells: 58 items render instead of 14.
+  // A 0 estimate must fall through to the 150 default; with `??` it stays 0, prefix sums
+  // become gaps alone and the window swells to 58 items instead of 14.
   test(`a zero getEstimatedHeight falls back to the default rather than collapsing`, () => {
     mount_virtualized(500, { getEstimatedHeight: () => 0, height: 500 })
 

--- a/tests/vitest/masonry.test.ts
+++ b/tests/vitest/masonry.test.ts
@@ -562,8 +562,8 @@ describe(`Masonry virtualization`, () => {
   })
 
   test(`scrolling moves the window, and a consumer's onscroll still fires`, async () => {
-    // `{...rest}` spreads after the component's own onscroll, so unless chained a consumer
-    // handler replaces it and the window silently stops tracking
+    // the explicit onscroll follows `{...rest}`, so unless chained it replaces the consumer's
+    // handler and their callback silently stops firing
     const consumer_scroll = vi.fn()
     mount_virtualized(200, {
       calcCols: () => 1,

--- a/tests/vitest/portal.test.ts
+++ b/tests/vitest/portal.test.ts
@@ -35,8 +35,7 @@ test(`restores from a shadow root after its anchor is removed`, async () => {
   expect(node.isConnected).toBe(false)
 })
 
-// closing must hide the dropdown in the same tick; deferring it to the reposition
-// microtask would leave a stale dropdown painted for a frame
+// deferring the hide to the reposition microtask would paint a stale dropdown for a frame
 test(`hides synchronously when open flips false`, () => {
   const { target, node } = create_fixture()
   const action = portal_action(node, { active: true, open: true, target_node: target })
@@ -45,9 +44,8 @@ test(`hides synchronously when open flips false`, () => {
   action.update({ active: true, open: false, target_node: target })
   expect(node.hidden).toBe(true)
 
-  // deactivating hands visibility back to the consumer's own markup. Latching the
-  // closed state here instead would stick: update() stops touching `hidden` once the
-  // node is home, so reopening with the portal still off could never show it again.
+  // deactivating hands visibility back to the consumer's markup. Latching the closed
+  // state would stick: update() stops touching `hidden` once the node is home.
   action.update({ active: false, open: false, target_node: target })
   expect(node.hidden).toBe(false)
 
@@ -62,7 +60,7 @@ test(`losing the target hides while portalled but not once deactivated`, () => {
   const action = portal_action(node, { active: true, open: true, target_node: target })
   expect(node.hidden).toBe(false)
 
-  // portalled with nowhere to anchor: no sane position to paint at
+  // portalled with nowhere to anchor: no position to paint at
   action.update({ active: true, open: true, target_node: null })
   expect(node.hidden).toBe(true)
 
@@ -97,8 +95,7 @@ test(`destroy detaches viewport listeners and cancels queued positioning`, async
   const action = portal_action(node, { active: true, open: true, target_node: target })
   action.destroy()
   await tick()
-  // the exact pairs matter: scroll must be removed with capture=true or the
-  // capturing listener added on activate stays bound forever
+  // scroll must be removed with capture=true or the capturing listener stays bound
   expect(
     remove_spy.mock.calls.slice(baseline).map(([type, , options]) => [type, options]),
   ).toEqual([

--- a/tests/vitest/print.test.ts
+++ b/tests/vitest/print.test.ts
@@ -1,10 +1,9 @@
 import { format_print_filename, print_element } from '$lib/print'
 import { afterEach, beforeEach, expect, test, vi } from 'vite-plus/test'
 
-// happy-dom has no window.print and never fires afterprint, so print is a spy and the
-// event is dispatched by hand. Nothing else is stubbed except the measured height: the
-// DOM does no layout, so every element reports height 0 and the mm arithmetic would be
-// vacuous without a real number to convert.
+// happy-dom has no window.print and never fires afterprint, so print is spied and the
+// event dispatched by hand. Heights are stubbed too: the DOM does no layout, so every
+// element reports 0 and the mm arithmetic would be vacuous.
 const print_spy = vi.fn()
 let original_title = ``
 
@@ -14,7 +13,7 @@ beforeEach(() => {
   original_title = document.title
 })
 afterEach(() => {
-  after_print() // the print dialog always closes eventually; let each test clean up
+  after_print() // the dialog always closes eventually
   vi.useRealTimers() // the watchdog cases opt into fake ones
   vi.unstubAllGlobals()
   document.title = original_title
@@ -23,7 +22,7 @@ afterEach(() => {
 const make_target = (height_px: number): HTMLElement => {
   const node = document.createElement(`section`)
   document.body.append(node)
-  // height is the only field read, so the cast stands in for the rest of DOMRect
+  // only height is read, so the cast stands in for the rest of DOMRect
   vi.spyOn(node, `getBoundingClientRect`).mockReturnValue({
     height: height_px,
   } as DOMRect)
@@ -52,14 +51,13 @@ test(`filename swaps document.title for the print and restores it after`, () => 
   expect(document.title).toBe(`Some Page`)
 })
 
-// afterprint arrives a turn late, so a second print can start while the first still has
-// the title swapped. Taken as the original, that filename would outlive both prints.
+// afterprint lands a turn late; the second print must not capture the swapped title.
 test(`overlapping prints restore the title the first one found`, () => {
   document.title = `Some Page`
   print_element(make_target(500), { filename: `first-print` })
   print_element(make_target(500), { filename: `second-print` })
 
-  expect(document.title).toBe(`first-print`) // the second call does not get to re-swap
+  expect(document.title).toBe(`first-print`) // the second call does not re-swap
   after_print()
   expect(document.title).toBe(`Some Page`)
 })
@@ -85,20 +83,20 @@ test.each([
   [960, {}, `210mm 254mm`], // 10in at 96 CSS px per inch
   [960, { page_width_mm: 148 }, `148mm 254mm`], // A5 instead of the A4 default
   [960, { px_per_inch: 192 }, `210mm 127mm`], // a context reporting scaled pixels
-  [100, {}, `210mm 27mm`], // 26.46mm rounded up, never down onto a second sheet
+  [100, {}, `210mm 27mm`], // 26.46mm rounded up, never onto a second sheet
 ])(`single_page sizes the page to the element (%i px)`, (height, options, expected) => {
   const node = make_target(height)
   print_element(node, { single_page: true, ...options })
 
   expect(page_rule()).toBe(`@page { size: ${expected}; margin: 0 }`)
   expect(node.hasAttribute(`data-print-target`)).toBe(true)
-  // the rules have to reach the element itself and the ancestors that would clip it
+  // rules must reach the element and the ancestors that would clip it
   const css = print_styles()[0].textContent ?? ``
   expect(css).toContain(`[data-print-target] { width: ${expected.split(` `)[0]}`)
   expect(css).toContain(`html, body, [data-print-target] { height: auto !important`)
 })
 
-// The injected rule outliving the print would resize every later @page on the document.
+// an injected rule outliving the print would resize every later @page on the document
 test(`afterprint removes the injected @page rule and the target marker`, () => {
   const node = make_target(960)
   document.title = `Docs`
@@ -112,7 +110,7 @@ test(`afterprint removes the injected @page rule and the target marker`, () => {
   expect(document.title).toBe(`Docs`)
 })
 
-// A print() that throws never fires afterprint, so nothing else would undo the swap
+// a print() that throws never fires afterprint, so nothing else would undo the swap
 test(`a print that throws still restores the title, marker and style`, () => {
   const node = make_target(960)
   document.title = `Docs`
@@ -143,9 +141,8 @@ test(`a second cleanup leaves a title the app set in the meantime alone`, () => 
   expect(document.title).toBe(`App Renamed`)
 })
 
-// Headless and embedded webviews return from print() without ever dispatching
-// afterprint. Left alone the swapped title and the injected rules stand for good, and
-// the in-flight flag disables every later filename swap for the page's lifetime.
+// headless and embedded webviews return from print() without ever firing afterprint,
+// leaving the title swapped, the rules injected and later filename swaps disabled
 test(`a print that never fires afterprint is undone by the watchdog`, () => {
   vi.useFakeTimers()
   const node = make_target(960)
@@ -158,16 +155,14 @@ test(`a print that never fires afterprint is undone by the watchdog`, () => {
   expect(document.title).toBe(`Docs`)
   expect(node.hasAttribute(`data-print-target`)).toBe(false)
   expect(print_styles()).toHaveLength(0)
-  // the swap flag went back too, so a later print still gets its filename
+  // the swap flag reset too, so a later print still gets its filename
   print_element(node, { filename: `later-print` })
   expect(document.title).toBe(`later-print`)
 })
 
-// Both prints target the same node, and the marker is shared state on it, so the first
-// print's cleanup must leave the second alone whichever way it arrives: disarmed by
-// afterprint, or fired by a watchdog that is still armed because its print never ended.
-// Without token ownership the armed one strips the live marker mid-dialog and leaves its
-// width rules matching nothing.
+// both prints share the marker on one node, so the first print's cleanup must leave the
+// second alone whether it was disarmed by afterprint or is still armed. Without token
+// ownership the armed one strips the live marker mid-dialog.
 test.each([
   [`disarmed by afterprint`, true],
   [`still armed, its own print never having ended`, false],
@@ -177,8 +172,7 @@ test.each([
   print_element(node, { single_page: true })
   if (first_print_ends) {
     after_print()
-    // pins the disarm itself: without it the assertions below still fail, but on a
-    // stripped marker rather than on the stale timer that stripped it
+    // pins the disarm: without it, failures blame the marker, not the stale timer
     expect(vi.getTimerCount()).toBe(0)
   }
 

--- a/tests/vitest/source-links.test.ts
+++ b/tests/vitest/source-links.test.ts
@@ -137,14 +137,12 @@ describe(`create_source_links`, () => {
     detach()
   })
 
-  // The anchor adopts the code span's text nodes so Svelte keeps patching them, which means
-  // a reactive `<code>{name}</code>` rewrites the text *inside* our link. Skipping every
-  // span that already holds an anchor left that link pointing at the old name forever.
+  // the anchor adopts the span's text nodes, so a reactive `<code>{name}</code>` rewrites
+  // text inside our link; skipping spans that already hold one froze the old name
   it(`re-resolves a link whose code span text changed, and unwraps it when it stops matching`, async () => {
     const root = document.createElement(`main`)
     const code = document.createElement(`code`)
-    // held across rescans: the anchor adopts this very node, which is how Svelte goes on
-    // patching a reactive `<code>{name}</code>` from inside our link
+    // held across rescans: the anchor adopts this very node
     const text = document.createTextNode(`Footer`)
     code.append(text)
     root.append(code)

--- a/tests/vitest/text-search.test.ts
+++ b/tests/vitest/text-search.test.ts
@@ -18,9 +18,8 @@ const render = (html: string): HTMLElement => {
 const ranges_of = (...args: Parameters<typeof search_text>): Range[] =>
   search_text(...args).map((match) => match.range)
 
-// Endpoints rather than range.toString(): a range spanning node boundaries can
-// stringify correctly while starting in the wrong node at a coincidentally equal
-// offset, so the containers are what pin down the offset mapping.
+// Endpoints, not range.toString(): a cross-node range can stringify correctly while
+// starting in the wrong node at a coincidentally equal offset.
 const range_bounds = (range: Range): [string, number, string, number] => [
   range.startContainer.textContent ?? ``,
   range.startOffset,
@@ -89,9 +88,8 @@ describe(`search_text`, () => {
   })
 
   it.each([
-    // offsets are computed on normalized text but must land on the original
-    // characters: canonical decomposition and lowercasing can expand one source
-    // character while 😀 already spans two UTF-16 units
+    // offsets computed on normalized text must land on the original characters:
+    // decomposition/lowercasing expand a char, and 😀 spans two UTF-16 units
     [`length-changing lowercase`, `<p>İİİab</p>`, `ab`, [`İİİab`, 3, `İİİab`, 5]],
     [`length-changing match`, `<p>İ</p>`, `i\u0307`, [`İ`, 0, `İ`, 1]],
     [`astral characters`, `<p>😀ab</p>`, `ab`, [`😀ab`, 2, `😀ab`, 4]],
@@ -179,9 +177,8 @@ describe(`search_text`, () => {
     ])
   })
 
-  // Pins the binary search against the linear scan it replaced: a match on every
-  // boundary of the offset table is where an off-by-one would show up.
-  // The quadratic scan it also fixes is a cost, not a behavior, so nothing asserts it.
+  // Pins the binary search that replaced a linear scan: a match on every offset-table
+  // boundary is where an off-by-one would show up.
   it(`maps every match onto its node in a segment split across many nodes`, () => {
     const texts = Array.from({ length: 30 }, (_unused, idx) => `a${idx}b`)
     const root = render(`<p>${texts.map((text) => `<b>${text}</b>`).join(``)}</p>`)
@@ -211,8 +208,7 @@ describe(`search_text`, () => {
   it(`honors a custom segment selector`, () => {
     const root = render(`<div class="cell">ab<b>c</b></div><div class="cell">d</div>`)
 
-    // extending the default selector is the intended way to teach the search about
-    // markup it does not know: each .cell becomes its own segment
+    // extending the default selector makes each .cell its own segment
     const segment_selector = `${DEFAULT_SEGMENT_SELECTOR}, .cell`
     expect(search_text(root, `abc`, { segment_selector })).toHaveLength(1)
     expect(search_text(root, `abcd`, { segment_selector })).toEqual([])
@@ -316,8 +312,8 @@ describe(`highlight_ranges`, () => {
     highlight_ranges(search(`<p>beta</p>`, `beta`))
     expect(registry.get(`text-search-match`)).toBe(foreign)
 
-    // a CSS.highlights.clear() elsewhere vacates it with no successor. Yielding to
-    // nobody would strand the highlight for the rest of the page's life.
+    // an external CSS.highlights.clear() leaves no successor; yielding to nobody
+    // would strand the highlight for the page's life
     registry.clear()
     highlight_ranges(search(`<p>gamma</p>`, `gamma`))
     expect(installed_ranges()).toHaveLength(3)
@@ -362,8 +358,8 @@ describe(`highlight_ranges`, () => {
     expect(set_spy).not.toHaveBeenCalled()
   })
 
-  // highlight_matches keeps separate owner bookkeeping in attachments/highlight-matches.ts.
-  // Sharing a CSS class must stay safe until both implementations are merged.
+  // highlight_matches keeps its own owner bookkeeping, so sharing a CSS class must
+  // stay safe until both implementations are merged
   it(`unions ranges with the highlight_matches attachment on a shared css class`, () => {
     const root = render(`<p>Hello <b>wo</b>rld</p>`)
     const attachment_cleanup = highlight_matches({
@@ -387,14 +383,14 @@ describe(`highlight_ranges`, () => {
   })
 })
 
-// observe_text_mutations is a MutationObserver wired straight to create_burst_debounce,
-// so the two share a clock and are exercised together
+// observe_text_mutations wires a MutationObserver into create_burst_debounce, so the
+// two share a clock and are exercised together
 describe(`observe_text_mutations and create_burst_debounce`, () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
-  // happy-dom delivers mutation records in a microtask, which fake timers leave
-  // alone, so awaiting the async advance runs both the observer and the debounce
+  // happy-dom delivers mutation records in a microtask that fake timers ignore, so the
+  // async advance is needed to run both observer and debounce
   const mutate = async (node: Element, advance_ms: number) => {
     node.append(document.createElement(`span`))
     await vi.advanceTimersByTimeAsync(advance_ms)
@@ -421,8 +417,7 @@ describe(`observe_text_mutations and create_burst_debounce`, () => {
       max_wait_ms: 120,
     })
 
-    // each mutation would reset a plain debounce, so without the ceiling these
-    // 6 x 20 ms steps would never let the callback run
+    // without the max_wait ceiling these 6 x 20 ms steps would keep resetting the debounce
     for (let idx = 0; idx < 6; idx++) await mutate(root, 20)
     expect(on_mutation).toHaveBeenCalledTimes(1)
     stop()
@@ -459,8 +454,8 @@ describe(`observe_text_mutations and create_burst_debounce`, () => {
     vi.advanceTimersByTime(200)
     expect(callback).not.toHaveBeenCalled()
 
-    // carrying the canceled burst's start forward would leave the ceiling already
-    // spent, collapsing the debounce to zero and firing on the first trigger
+    // carrying the canceled burst's start forward would leave the ceiling spent,
+    // collapsing the debounce to zero
     trigger()
     vi.advanceTimersByTime(49)
     expect(callback).not.toHaveBeenCalled()

--- a/tests/vitest/toast.svelte.test.ts
+++ b/tests/vitest/toast.svelte.test.ts
@@ -57,8 +57,7 @@ describe(`toast queue reducer`, () => {
   })
 
   test(`a demoted toast keeps its unspent visibility budget`, () => {
-    // `a` is seen for 200 ms of its 1000 ms budget before `b` interrupts it, so it must
-    // come back with 800 ms left rather than a fresh 1000 or the 800 it never spends
+    // `a` is seen 200 ms of its 1000 ms budget before `b` interrupts, so it returns with 800
     const first = add(create_toast_queue(), `a`, { visible_duration_ms: 1000 }).queue
     expect(first.active_toast?.expires_at_ms).toBe(1000)
 
@@ -83,9 +82,8 @@ describe(`toast queue reducer`, () => {
   })
 
   test.each([
-    // A bare deadline is a wall-clock contract and keeps running off screen. Pair it with
-    // a visibility budget and the budget wins: the deadline is banked rather than left
-    // running on a toast nobody has seen yet.
+    // a bare deadline is wall-clock and runs off screen; pair it with a visibility budget
+    // and the budget wins, banking the deadline instead
     [`an absolute deadline keeps running while the toast waits`, {}, 1000, true],
     [
       `a visibility budget banks the deadline instead`,
@@ -166,9 +164,8 @@ describe(`toast queue reducer`, () => {
       expect(messages(louder.queue.pending)).toEqual([`on screen`])
     })
 
-    // What a repeat does to the toast it matches turns on the two priorities. Each case
-    // starts from the same `warning` toast carrying an action and a 900 ms budget, and
-    // the repeat is the same text with only its priority and `supplies` changed.
+    // what a repeat does to its match turns on the two priorities; every case starts from
+    // this `warning` toast and varies only the repeat's priority and `supplies`
     const original = {
       priority: `warning`,
       dedupe_key: `job`,
@@ -535,9 +532,8 @@ describe(`<Toast />`, () => {
     await tick()
 
     expect(doc_query(`.toast`).dataset.priority).toBe(`watch`)
-    // `watch` is the ladder's second-highest rung, so it is sticky — and urgency has to
-    // agree with that: announcing it politely would let a notice that never leaves the
-    // screen go unread. Both rules read the top two off the store's own ladder.
+    // `watch` is second-highest here, so sticky; urgency must agree, or a notice that
+    // never leaves the screen goes unread
     expect(assertive().textContent).toContain(`watching src/`)
     expect(polite().textContent).not.toContain(`watching src/`)
   })
@@ -777,9 +773,8 @@ describe(`<Toast />`, () => {
     expect(document.activeElement).toBe(target ?? before)
   })
 
-  // every route out of the toast unmounts the button holding focus, so each one has to
-  // hand the user's place back rather than dropping it on <body> — unless the user got
-  // there first, when reclaiming the origin would yank them out of where they went
+  // every exit unmounts the button holding focus, so each must restore the origin rather
+  // than drop focus on <body> — unless the user already moved, when restoring would yank
   test.each<[string, (store: ToastStore) => void, boolean?]>([
     [`the action button`, () => doc_query<HTMLButtonElement>(`.toast-action`).click()],
     [`the dismiss button`, () => doc_query<HTMLButtonElement>(`.toast-dismiss`).click()],
@@ -809,9 +804,8 @@ describe(`<Toast />`, () => {
     expect(document.activeElement).toBe(moved_on ? elsewhere : opener)
   })
 
-  // Escape is scoped to the stack, so a press anywhere else on the page is none of the
-  // toast's business, and gated on `dismissible` — with no close button rendered it
-  // would otherwise be the one way left to shut a toast declared undismissable.
+  // Escape is scoped to the stack and gated on `dismissible`, else it would be the one
+  // way left to shut a toast declared undismissable
   test.each([
     [true, undefined],
     [false, `a`],

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -17,7 +17,6 @@ type TocProps = ComponentProps<typeof Toc>
 
 const mounted_components: Record<string, unknown>[] = []
 
-// mounts into document.body and registers for teardown in afterEach
 const mount_toc = (props: TocProps = {}) => {
   mounted_components.push(mount(Toc, { target: document.body, props }))
 }
@@ -29,8 +28,8 @@ const set_body = (html: string) => {
 const setup_empty_page = () =>
   set_body(`<h1>H1</h1><h2 class="toc-exclude">H2</h2><h5>H5</h5>`)
 
-// `Heading 1`..`Heading n` as h2s with matching `heading-n` ids, the shape most
-// interaction tests want. happy-dom gives every heading top=0, so the last one starts active.
+// `Heading 1`..`Heading n` as h2s with `heading-n` ids. happy-dom gives every heading
+// top=0, so the last one starts active.
 const set_headings = (count: number) =>
   set_body(
     Array.from(
@@ -44,8 +43,7 @@ const set_window_width = (width: number) => {
   globalThis.dispatchEvent(new Event(`resize`))
 }
 
-// Element.prototype is the only place to intercept this: happy-dom has no layout, so the
-// component's own scrollIntoView call is all there is to observe.
+// happy-dom has no layout, so the component's own scrollIntoView call is all we can observe
 const spy_scroll_into_view = () =>
   vi.spyOn(Element.prototype, `scrollIntoView`).mockImplementation(() => {})
 
@@ -70,9 +68,8 @@ const setup_nested_headings = () =>
       <h3 id="sub-2-1">Sub 2.1</h3>
     `)
 
-// only top/bottom/left/right matter to the component, so derive the rest from those.
-// bottom/right collapse onto top/left rather than 0, since a negative width or height
-// makes DOMRect normalize by swapping the edges back.
+// only top/bottom/left/right matter; bottom/right collapse onto top/left rather than 0,
+// since a negative width or height makes DOMRect swap the edges back
 const dom_rect = ({
   top = 0,
   left = 0,
@@ -109,8 +106,7 @@ const find_matching_css_selector = (style_text: string, declaration_pattern: Reg
   for (const { groups } of style_text
     .replaceAll(/\/\*[^]*?\*\//gu, ``)
     .matchAll(/(?<selector>[^{}]+)\{(?<block>[^{}]+)\}/g)) {
-    // every component's CSS lands in the same head here, so a generic declaration like
-    // `box-sizing: border-box` would otherwise match a neighbor's rule first
+    // every component's CSS shares one head, so a generic declaration could match a neighbor
     if (!groups?.selector.includes(`toc`)) continue
     if (declaration_pattern.test(groups.block)) return groups.selector.trim()
   }
@@ -125,10 +121,8 @@ beforeAll(() => {
   })
 })
 
-// Svelte merges `style:` directives and a spread `style` into one cssText write, and
-// happy-dom drops any declaration whose value holds a var() with a fallback, which is how
-// Toc expresses indent and font size. The element never shows those styles, so record the
-// strings Svelte writes and assert on those instead.
+// happy-dom drops declarations whose value holds a var() with a fallback, which is how Toc
+// expresses indent and font size, so record the cssText Svelte writes and assert on that
 const style_prototype = Object.getPrototypeOf(document.createElement(`div`).style)
 const css_text_property = Object.getOwnPropertyDescriptor(style_prototype, `cssText`)
 if (!css_text_property?.set) throw new Error(`cssText is not a setter on this DOM`)
@@ -269,8 +263,7 @@ describe(`Toc`, () => {
     // the <a href> is a valid percent-encoded URL string
     expect(doc_query(`aside.toc li > a`).getAttribute(`href`)).toBe(`#sec%3A1`)
 
-    // but the history fragment must match the DOM id exactly (no encoding) so it resolves
-    // directly via getElementById rather than the browser's percent-decode fallback
+    // the history fragment must match the DOM id exactly so getElementById resolves it
     doc_query(`aside.toc li > a`).dispatchEvent(
       new MouseEvent(`click`, { bubbles: true }),
     )
@@ -416,8 +409,7 @@ describe(`Toc`, () => {
       const event = new MouseEvent(`click`, { bubbles: true, cancelable: true })
       doc_query(selector).dispatchEvent(event)
 
-      // a nested interactive element keeps native behavior (no preventDefault, no scroll);
-      // plain content falls through to the li handler which scrolls and updates the fragment
+      // nested interactive elements keep native behavior; plain content falls to the li
       expect(event.defaultPrevented).toBe(scrolls)
       expect(scroll_into_view_mock).toHaveBeenCalledTimes(scrolls ? 1 : 0)
       expect(replace_state_mock.mock.calls).toEqual(scrolls ? [[{}, ``, `#first`]] : [])
@@ -486,9 +478,8 @@ describe(`Toc`, () => {
     }
   })
 
-  // Each case needs its own invalid selector: happy-dom throws the first time it parses
-  // one, then caches the failure and lets later querySelector calls for the same string
-  // return null, which would hide the invalidity from Toc's validation
+  // each case needs its own invalid selector: happy-dom throws only on the first parse, then
+  // caches the failure and returns null, hiding the invalidity from Toc's validation
   test.each([
     [`headingSelector`, `[`, { headingSelector: `[` }],
     [`excludeSelector`, `((`, { excludeSelector: `((` }],
@@ -531,8 +522,8 @@ describe(`Toc`, () => {
     const msg = `Toc found no headings for headingSelector=':is(h2, h3, h4)' after applying excludeSelector='.toc-exclude'. Hiding table of contents.`
     expect(warn_mock).toHaveBeenCalledExactlyOnceWith(msg)
 
-    // rendering the ToC itself and any later unrelated childList mutation both notify the
-    // MutationObserver. the empty heading set is unchanged, so neither may rebuild and re-warn
+    // both the ToC render and this unrelated mutation notify the observer, but the empty
+    // heading set is unchanged, so neither may rebuild and re-warn
     document.body.append(document.createElement(`p`))
     await tick()
     document.body.append(document.createElement(`p`))
@@ -561,9 +552,8 @@ describe(`Toc`, () => {
     const toc_list = doc_query(`aside.toc > nav > ol`)
     expect(toc_list.children).toHaveLength(3)
 
-    // Indent is applied via CSS calc with --toc-indent-per-level variable. happy-dom's
-    // parser rejects calc() wrapping var(), so the value never lands on the element and
-    // the styles Toc sets have to be read off setProperty instead.
+    // happy-dom's parser rejects calc() wrapping var(), so the indent never lands on the
+    // element and has to be read off what Toc wrote
     expect(written_style_values(`margin-left`)).toEqual([
       expect.stringContaining(`calc(0 *`),
       expect.stringContaining(`calc(1 *`),
@@ -664,8 +654,7 @@ describe(`Toc`, () => {
 
     mount_toc({ desktop: false })
     expect(document.querySelector(`aside.toc > nav`)).toBeNull()
-    // both glyphs stay mounted so CSS can transition between them; swapping one <svg> for
-    // the other would render the same states with no animation
+    // both glyphs stay mounted so CSS can transition between them
     const shown_icons = () =>
       [...document.querySelectorAll(`aside.toc > button > svg`)].map((svg) =>
         svg.classList.contains(`shown`),
@@ -780,8 +769,7 @@ describe(`Toc`, () => {
       const scroll_into_view_mock = spy_scroll_into_view()
       const replace_state_mock = vi.spyOn(history, `replaceState`)
 
-      // breakpoint above the happy-dom window width forces mobile mode, where open=true is
-      // enough for keys to be handled (no hover check)
+      // a breakpoint above the window width forces mobile mode, where open=true suffices
       mount_toc({ open: true, breakpoint: 2000, scrollBehavior })
       await tick()
 
@@ -873,14 +861,12 @@ describe(`Toc`, () => {
 
     // arrange rects so any rebuild's set_active_heading() would switch active to Alpha
     mock_active_heading(`a`)
-    // Toc observes document.body with childList+subtree, and every childList record used to
-    // short-circuit to a full-document heading re-query. On a page with a Toc in the layout
-    // that meant any unrelated insertion — a toast, a virtualized editor row — paid for it.
-    // `doc_query` uses the singular `querySelector`, so the assertions below cannot trip it.
+    // every childList record used to trigger a full-document heading re-query, so any
+    // unrelated insertion paid for it. `doc_query` is singular, so it cannot trip this spy.
     const query_spy = vi.spyOn(document, `querySelectorAll`)
 
-    // a subtree with no heading in it, the shape virtualized rows and toasts have. The skip
-    // must avoid rebuilding (and re-running set_active_heading), so active stays put too
+    // a heading-less subtree (a toast, a virtualized row) must skip the rebuild,
+    // so set_active_heading never runs and active stays put
     const noise = document.createElement(`div`)
     noise.innerHTML = `<span>row</span><span>row</span>`
     document.body.append(noise)
@@ -1002,9 +988,8 @@ describe(`Toc`, () => {
     const active_text = () => doc_query(`aside.toc ol li.active`).textContent.trim()
     const scroll_mock = vi.fn<Element[`scrollIntoView`]>()
 
-    // happy-dom reports top=0 for every unmocked heading, so plain scroll detection lands
-    // on the last one. `Heading 3` therefore means scroll_target was released, `Heading 1`
-    // that it still pins the clicked heading.
+    // unmocked headings all report top=0, so plain detection lands on the last: `Heading 3`
+    // means scroll_target was released, `Heading 1` that it still pins the clicked heading
     beforeEach(() => {
       set_headings(3)
       scroll_mock.mockClear()
@@ -1099,8 +1084,7 @@ describe(`hideOnIntersect`, () => {
   const clear_of_toc = { top: 0, bottom: 50, left: 0, right: 1200 }
   const over_toc = { top: 150, bottom: 250, left: 0, right: 1200 }
 
-  // parks the ToC in the top-right corner so only a banner's vertical extent decides
-  // overlap, then leaves b1 clear of it and b2 wherever the case wants it
+  // parks the ToC top-right so only a banner's vertical extent decides overlap
   const setup_banners = async (
     target: (b1: HTMLElement, b2: HTMLElement) => TocProps[`hideOnIntersect`],
     {
@@ -1175,8 +1159,7 @@ describe(`hideOnIntersect`, () => {
     const { aside, b2 } = await setup_banners(() => `.banner`)
     await scroll()
     expect(is_intersecting(aside)).toBe(true)
-    // opacity: 0 alone would leave the links tabbable while aria-hidden hides them from
-    // assistive tech, so the subtree has to be inert for as long as it is invisible
+    // opacity: 0 alone leaves the links tabbable, so the subtree must be inert while hidden
     expect(aside.hasAttribute(`inert`)).toBe(true)
 
     mock_bounding_rect(b2, { top: 500, bottom: 600, left: 0, right: 1200 })
@@ -1187,10 +1170,8 @@ describe(`hideOnIntersect`, () => {
 })
 
 describe(`Element Prop Bags`, () => {
-  // shared marker so one assertion covers style pass-through for every element. the class
-  // values deliberately vary (string / array / object) to cover Svelte's class forms.
-  // a longhand: the `style:` directives on these elements make happy-dom re-serialize
-  // the whole declaration, which would expand a shorthand like `outline` into parts
+  // one shared marker covers style pass-through everywhere; class values vary (string/array/
+  // object) to cover Svelte's forms. A longhand, since happy-dom would split a shorthand.
   const marker_style = `opacity: 0.5;`
 
   const prop_bag_cases = [
@@ -1304,8 +1285,7 @@ describe(`Element Prop Bags`, () => {
         )
         await tick()
       }
-      // happy-dom honors `disabled` for dispatched clicks, so a disabled control
-      // never sees the event that jsdom would have delivered
+      // happy-dom honors `disabled` for dispatched clicks, unlike jsdom
       const is_disabled = `disabled` in bag && bag.disabled === true
       expect(user_click).toHaveBeenCalledTimes(has_user_click && !is_disabled ? 1 : 0)
       expect(on_open_change).toHaveBeenCalledTimes(expected_open_change_count)
@@ -1325,8 +1305,7 @@ describe(`Element Prop Bags`, () => {
       `style`,
     )
     expect(style_attribute).toContain(`padding-left: 10px;`)
-    // the generated declarations survive the merge but not happy-dom's parser, so they
-    // are asserted on what Svelte wrote rather than on the element
+    // happy-dom's parser drops these, so assert on what Svelte wrote, not on the element
     expect(written_style_values(`margin-left`)).toContain(
       `margin-left: calc(1 * var(--toc-indent-per-level, 1em))`,
     )
@@ -1336,9 +1315,8 @@ describe(`Element Prop Bags`, () => {
     expect(written_css_texts.join(``)).not.toContain(`\n`)
   })
 
-  // equal specificity, so source order decides. With hover first, an unset --toc-active-bg
-  // made `background` invalid on the active row and swallowed its hover fill — the row most
-  // likely to be pointed at was the one row that did not light up.
+  // equal specificity, so source order decides: with hover first, an unset --toc-active-bg
+  // made `background` invalid on the active row and swallowed its hover fill
   test(`the hover rule is declared after the active rule`, async () => {
     set_body(`<h2>Heading 1</h2>`)
     mount_toc()
@@ -1379,9 +1357,8 @@ describe(`Element Prop Bags`, () => {
       selector_pattern: /aside\.toc.*> nav.*> ol/,
     },
     {
-      // the toggle's box is structural for the same reason: under `:where()` a host
-      // `button { padding }` reset outweighed it and resized the hit target, leaving the
-      // toggle a different size from Nav's burger on the same page
+      // under `:where()` a host `button { padding }` reset outweighed this and resized the
+      // hit target, leaving the toggle a different size from Nav's burger
       rule_name: `open button box rule`,
       declaration_pattern: /padding: var\(--toc-mobile-btn-padding, [\d.]+rem\);/,
       expects_where: false,
@@ -1414,7 +1391,6 @@ describe(`collapseSubheadings`, () => {
     expect(get_collapsed_states()).toEqual(Array.from({ length: 8 }, () => false))
   })
 
-  // Parameterized test for collapse behavior with different modes and active headings
   test.each([
     // [description, mode, active_id, expected_collapsed_states]
     [

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -439,6 +439,33 @@ describe(`Toc`, () => {
     },
   )
 
+  // the window handler preventDefaults arrows to drive its own list, and a custom tocItem's
+  // fields sit inside nav, so the focus guard let them through and stole the caret
+  test(`tocItem text fields keep their own arrow keys`, async () => {
+    set_body(`<h2 id="first">First</h2><h2 id="second">Second</h2>`)
+    mock_active_heading(`first`)
+
+    mount_toc({
+      tocItem: createRawSnippet<[HTMLHeadingElement]>((heading) => ({
+        render: () => `<input class="filter" value="${heading().id}">`,
+      })),
+    })
+    await tick()
+
+    const field = doc_query<HTMLInputElement>(`aside.toc li > input.filter`)
+    field.focus()
+    const event = new KeyboardEvent(`keydown`, {
+      key: `ArrowDown`,
+      bubbles: true,
+      cancelable: true,
+    })
+    field.dispatchEvent(event)
+    await tick()
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(document.activeElement).toBe(field) // the ToC did not move focus off the field
+  })
+
   test(`modified clicks on ToC links keep native browser behavior`, async () => {
     set_body(`<h2 id="intro">Intro</h2>`)
     const replace_state_mock = vi.spyOn(history, `replaceState`)

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -104,9 +104,11 @@ const get_collapsed_states = () =>
   )
 
 const find_matching_css_selector = (style_text: string, declaration_pattern: RegExp) => {
-  for (const { groups } of style_text.matchAll(
-    /(?<selector>[^{}]+)\{(?<block>[^{}]+)\}/g,
-  )) {
+  // the selector group is "everything since the previous rule", so a comment above a rule
+  // lands inside it and a `:where(` check would read the comment instead of the selector
+  for (const { groups } of style_text
+    .replaceAll(/\/\*[^]*?\*\//gu, ``)
+    .matchAll(/(?<selector>[^{}]+)\{(?<block>[^{}]+)\}/g)) {
     // every component's CSS lands in the same head here, so a generic declaration like
     // `box-sizing: border-box` would otherwise match a neighbor's rule first
     if (!groups?.selector.includes(`toc`)) continue
@@ -656,17 +658,25 @@ describe(`Toc`, () => {
     )
   })
 
-  test(`mobile button opens the ToC`, async () => {
+  test(`mobile button opens the ToC and cross-fades its icon`, async () => {
     globalThis.innerWidth = 600
     set_headings(2)
 
     mount_toc({ desktop: false })
     expect(document.querySelector(`aside.toc > nav`)).toBeNull()
+    // both glyphs stay mounted so CSS can transition between them; swapping one <svg> for
+    // the other would render the same states with no animation
+    const shown_icons = () =>
+      [...document.querySelectorAll(`aside.toc > button > svg`)].map((svg) =>
+        svg.classList.contains(`shown`),
+      )
+    expect(shown_icons()).toEqual([true, false]) // [closed, open]
 
     doc_query(`aside.toc button`).click()
     await tick()
 
     expect(document.querySelector(`aside.toc > nav`)).not.toBeNull()
+    expect(shown_icons()).toEqual([false, true])
   })
 
   test(`active heading is scrolled into view and highlighted when opening ToC on mobile`, async () => {
@@ -1326,6 +1336,20 @@ describe(`Element Prop Bags`, () => {
     expect(written_css_texts.join(``)).not.toContain(`\n`)
   })
 
+  // equal specificity, so source order decides. With hover first, an unset --toc-active-bg
+  // made `background` invalid on the active row and swallowed its hover fill — the row most
+  // likely to be pointed at was the one row that did not light up.
+  test(`the hover rule is declared after the active rule`, async () => {
+    set_body(`<h2>Heading 1</h2>`)
+    mount_toc()
+    await tick()
+
+    const css = document.head.textContent
+    expect(css.indexOf(`--toc-li-hover-bg`)).toBeGreaterThan(
+      css.indexOf(`--toc-active-bg`),
+    )
+  })
+
   test.each([
     {
       rule_name: `aside base rule`,
@@ -1353,6 +1377,15 @@ describe(`Element Prop Bags`, () => {
       declaration_pattern: /list-style: var\(--toc-ol-list-style, none\);/,
       expects_where: false,
       selector_pattern: /aside\.toc.*> nav.*> ol/,
+    },
+    {
+      // the toggle's box is structural for the same reason: under `:where()` a host
+      // `button { padding }` reset outweighed it and resized the hit target, leaving the
+      // toggle a different size from Nav's burger on the same page
+      rule_name: `open button box rule`,
+      declaration_pattern: /padding: var\(--toc-mobile-btn-padding, [\d.]+rem\);/,
+      expects_where: false,
+      selector_pattern: /aside\.toc.*> button/,
     },
   ])(
     `uses expected selector specificity for $rule_name`,

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -28,8 +28,8 @@ import {
 import { afterEach, assert, beforeEach, describe, expect, test, vi } from 'vite-plus/test'
 import { doc_query, stub_prop } from './index'
 
-// RFC 4122 v4 is xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx (y = 8/9/a/b); the timestamp+counter
-// fallback used when crypto is unavailable only guarantees the generic UUID shape
+// RFC 4122 v4 pins the version/variant nibbles; the timestamp+counter fallback used when
+// crypto is unavailable only guarantees the generic UUID shape
 const uuid_v4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu
 const uuid_any = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu
 test.each([
@@ -98,10 +98,8 @@ describe(`get_style`, () => {
     selected: `color: blue`,
     option: `color: green`,
   }
-  // object styles get the same trailing-semicolon normalization as string styles;
-  // partial style objects (e.g. only `selected`) are fine, but any key other than
-  // `option`/`selected` is rejected, even when a valid key is also present.
-  // A null/undefined key selects no sub-style but still validates the style object.
+  // object styles normalize trailing semicolons like string styles, and may be partial;
+  // a null/undefined key selects no sub-style but still validates the style object
   test.each([
     [option_style, `selected`, `color: blue;`],
     [option_style, `option`, `color: green;`],
@@ -149,9 +147,8 @@ describe(`keyboard shortcut parsing`, () => {
     [`cmd+k`, { key: `k`, ctrl: false, shift: false, alt: false, meta: true }],
     [`Meta+Alt+X`, { key: `x`, ctrl: false, shift: false, alt: true, meta: true }],
     [`ctrl+shift+k`, { key: `k`, ctrl: true, shift: true, alt: false, meta: false }],
-    // spelled-out keys resolve to the `event.key` they stand for, so a combo that
-    // survives a split on `+` still matches. `space` never matched before: parts are
-    // trimmed, leaving ` ` unspellable any other way.
+    // spelled-out keys resolve to the `event.key` they stand for, so a combo survives the
+    // split on `+`. `space` never matched before: parts are trimmed, so ` ` was unspellable.
     [`ctrl+plus`, { key: `+`, ctrl: true, shift: false, alt: false, meta: false }],
     [`ctrl+space`, { key: ` `, ctrl: true, shift: false, alt: false, meta: false }],
     [`shift+comma`, { key: `,`, ctrl: false, shift: true, alt: false, meta: false }],
@@ -329,8 +326,7 @@ describe(`shortcut rebinding`, () => {
 })
 
 describe(`fuzzy_match`, () => {
-  // Index edges live in fuzzy_match_indices; pin the null guard and a thin boolean smoke
-  // so the wrapper cannot drift without a failing expected value.
+  // index edges live in fuzzy_match_indices; here just the null guard and a boolean smoke
   test.each([
     [null, `test`],
     [undefined, `test`],
@@ -603,8 +599,8 @@ describe(`compute_position`, () => {
     ).toEqual({ top: 10, left: -50, placement: `bottom` })
   })
 
-  // The portalled dropdown used to carry its own above/below rule. Its replacement
-  // has to agree everywhere, including with the anchor scrolled out of view.
+  // compute_position replaced the dropdown's own above/below rule, so it must agree
+  // everywhere, including with the anchor scrolled out of view
   test(`reproduces the dropdown's above/below rule across a grid`, () => {
     const view_height = 800
     viewport(1000, view_height)
@@ -662,7 +658,7 @@ describe(`chain_handlers`, () => {
     expect(seen).toEqual([event, event])
   })
 
-  // documents a real hazard: an internal handler that throws swallows the consumer's
+  // hazard: an internal handler that throws swallows the consumer's
   test(`a throwing handler stops the chain`, () => {
     const later = vi.fn()
     const boom = () => {


### PR DESCRIPTION
Mobile polish across `Nav` and `Toc`, plus two page-level layout fixes that only showed up on a phone.

## Nav: submenus open on click, never on hover

Hover-opening popped a panel over the page on every pass of the pointer across the nav, and a touch device has no hover at all, so the two input modes behaved differently for no gain. A click, tap, `Enter`, `Space` or `ArrowDown` opens a submenu; the caret again, `Escape` or a click outside closes it.

**Breaking:** the `dropdown_cooldown_ms` prop is removed. It only timed the hover-out delay, so nothing is left for it to time.

This also retires the machinery hover required: the hide timer, the touch-device sniff, the focusin-opens/focusout-closes handlers, and the invisible `.dropdown::after` band that bridged the pointer gap to the popover. Thirteen tests encoded hover behavior and are replaced by one pinning the new contract from both sides — hovering a shut dropdown leaves it shut, and moving off an open one leaves it open, which is what used to let a tap's synthetic `mouseleave` undo the tap.

## Nav: the mobile expanded section

- **Animates open** on a `0fr -> 1fr` grid row rather than appearing in one frame, since `display: none` cannot transition. `visibility` rides along so the still-mounted links stop collecting Tab focus behind a closed section, and the opening gap is transitioned padding because `min-height: 0` zeroes a grid item's content box but not its padding.
- **Compact rows.** Child rows inherited a 1.6 line-height that made them *taller* than the parent they hang under (33.7px vs 26.6px). At 1.3 and 2pt block padding they measure 24.0px.
- **One guide line** down the wrapper instead of a border per link, so it has no notch at the section's opening padding. Each link's own border sits exactly on the rule, letting the current row recolor a segment rather than draw a second line beside it.
- **A caret you can hit.** It is the only opener now, so it takes the row's full height and runs out over the row's padding to the painted edge: 24×24px → 42.6×26.1px.
- **An opaque burger.** Transparent, it left its bars sitting on whatever page text scrolled beneath. It now wears the same chip as Toc's toggle, and both are anchored by their box edge so the chip rather than the glyph sits 1rem from the corner.

## Toc: a toggle that is not a second burger

Two identical burgers pinned to one phone screen say nothing about which opens what, so the closed state is an indented three-row list. Its viewBox is cropped to the path bounds to render at the button's full width like Nav's bars; the X keeps a roomier box so it lands on Nav's 17.9px span instead of being the larger of two close buttons on a page showing both. Both glyphs stay mounted in one grid cell and cross-fade with a quarter turn, matching the 0.2s linear the burger uses to fold into its X.

The mobile panel drops the desktop `3em` inset — it made room for the sticky column's gutter, and in a floating panel it was a blank band down the left of every entry.

ToC rows also adopt Nav's hover fill, radius and fade as fallbacks behind the public `--toc-li-*` tokens, which still win. Doing so surfaced a bug: `li:hover` and `li.active` have equal specificity, `.active` came second, and its `background: var(--toc-active-bg)` with the var unset is invalid at computed-value time — so it wiped the hover fill from the one row most likely to be pointed at. The rules are reordered and a test pins the order.

## Page layout

- Grid items floor at min-content, so one wide code block or table stretched `main` past the viewport and scrolled the whole page sideways on a phone. `min-width: 0` lets code scroll inside its own `pre code`.
- `aside.toc.mobile` no longer collapses to `0x0`: the aside is `position: fixed` and already out of flow, and the collapse also flattened the panel it now lays out.
- The Nav demo in `Examples.md` gets `breakpoint={0}` so it stays inline on phones rather than pinning a second fixed burger over the site's own, in the same corner.
